### PR TITLE
Post-refactor code quality round 3: hex format bug, DRY editors, named constants

### DIFF
--- a/src/core/proc_pump.ahk
+++ b/src/core/proc_pump.ahk
@@ -67,7 +67,7 @@ ProcPump_Start() {
         global _PP_IdleThreshold, _PP_FailedPidCacheTTL
         ProcBatchPerTick := cfg.ProcPumpBatchSize
         ProcTimerIntervalMs := cfg.ProcPumpIntervalMs
-        _PP_IdleThreshold := cfg.HasOwnProp("ProcPumpIdleThreshold") ? cfg.ProcPumpIdleThreshold : 5
+        _PP_IdleThreshold := cfg.ProcPumpIdleThreshold
         _PP_FailedPidCacheTTL := cfg.ProcPumpFailedPidRetryMs
     }
 

--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -71,7 +71,7 @@ WinEventHook_Start() {
         global _WEH_IdleThreshold
         WinEventHook_DebounceMs := cfg.WinEventHookDebounceMs
         WinEventHook_BatchMs := cfg.WinEventHookBatchMs
-        _WEH_IdleThreshold := cfg.HasOwnProp("WinEventHookIdleThreshold") ? cfg.WinEventHookIdleThreshold : 10
+        _WEH_IdleThreshold := cfg.WinEventHookIdleThreshold
     }
 
     ; Reset log for new session (before early-exit guard)

--- a/src/editors/blacklist_editor.ahk
+++ b/src/editors/blacklist_editor.ahk
@@ -12,6 +12,14 @@
 ; signal is sent via launcher to apply changes immediately.
 ; ============================================================
 
+; Layout constants (pixels)
+global BE_TAB_PAD := 20          ; Tab control horizontal padding
+global BE_TAB_BOTTOM := 110      ; Space below tab control for buttons
+global BE_EDIT_BOTTOM := 200     ; Space below edit controls
+global BE_EDIT_HPAD := 50        ; Edit control horizontal padding
+global BE_BTN_Y_OFFSET := 45    ; Button Y offset from bottom
+global BE_BTN_W := 100           ; Button width
+
 global gBE_Gui := 0
 global gBE_TitleEdit := 0
 global gBE_ClassEdit := 0
@@ -330,6 +338,7 @@ _BE_IsGuiValid() {
 }
 
 _BE_OnSize(guiObj, minMax, width, height) {
+    global BE_TAB_PAD, BE_TAB_BOTTOM, BE_EDIT_BOTTOM, BE_EDIT_HPAD, BE_BTN_Y_OFFSET, BE_BTN_W
     ; Guard against destroyed GUI
     if (!_BE_IsGuiValid())
         return
@@ -339,12 +348,12 @@ _BE_OnSize(guiObj, minMax, width, height) {
 
     ; Resize tab control
     try {
-        guiObj["Tabs"].Move(, , width - 20, height - 110)
+        guiObj["Tabs"].Move(, , width - BE_TAB_PAD, height - BE_TAB_BOTTOM)
     }
 
     ; Resize edit controls within tabs
-    editHeight := height - 200
-    editWidth := width - 50
+    editHeight := height - BE_EDIT_BOTTOM
+    editWidth := width - BE_EDIT_HPAD
     try {
         guiObj["TitleEdit"].Move(, , editWidth, editHeight)
         guiObj["ClassEdit"].Move(, , editWidth, editHeight)
@@ -353,9 +362,9 @@ _BE_OnSize(guiObj, minMax, width, height) {
 
     ; Move buttons
     try {
-        guiObj["BtnCancel"].Move(width - 100, height - 45)
-        guiObj["BtnSave"].Move(width - 200, height - 45)
-        guiObj["BtnTest"].Move(10, height - 45)
+        guiObj["BtnCancel"].Move(width - BE_BTN_W, height - BE_BTN_Y_OFFSET)
+        guiObj["BtnSave"].Move(width - BE_BTN_W * 2, height - BE_BTN_Y_OFFSET)
+        guiObj["BtnTest"].Move(10, height - BE_BTN_Y_OFFSET)
     }
 }
 

--- a/src/editors/config_editor.ahk
+++ b/src/editors/config_editor.ahk
@@ -45,6 +45,10 @@ ConfigEditor_Run(launcherHwnd := 0, forceNative := false) {
         } catch as e {
             ; WebView2 detection succeeded but init failed - fall back to native
             ; This can happen if WebView2 is registered but DLL is missing/corrupt
+            if (cfg.DiagWebViewLog) {
+                global LOG_PATH_WEBVIEW
+                try LogAppend(LOG_PATH_WEBVIEW, "WebView2 init failed, falling back to native: " e.Message)
+            }
         }
     }
 

--- a/src/gui/gui_constants.ahk
+++ b/src/gui/gui_constants.ahk
@@ -12,8 +12,10 @@ global GWL_EXSTYLE := -20
 global WS_EX_LAYERED := 0x80000
 
 ; Window messages
+global WM_CLOSE := 0x0010
 global WM_MOUSEMOVE := 0x0200
 global WM_LBUTTONDOWN := 0x0201
+global WM_MOUSEWHEEL := 0x020A
 global WM_MOUSELEAVE := 0x02A3
 global WM_DPICHANGED := 0x02E0
 
@@ -28,6 +30,7 @@ global SWP_NOSIZE := 0x0001
 global SWP_NOMOVE := 0x0002
 global SWP_NOZORDER := 0x0004
 global SWP_NOACTIVATE := 0x0010
+global SWP_FRAMECHANGED := 0x0020
 global SWP_SHOWWINDOW := 0x0040
 global SWP_NOOWNERZORDER := 0x0200
 

--- a/src/gui/gui_input.ahk
+++ b/src/gui/gui_input.ahk
@@ -215,7 +215,8 @@ _GUI_PerformAction(action, idx1 := 0) {
     if (action = "close") {
         hwnd := cur.hwnd
         if (hwnd && WinExist("ahk_id " hwnd)) {
-            try PostMessage(0x0010, 0, 0, , "ahk_id " hwnd)
+            global WM_CLOSE
+            try PostMessage(WM_CLOSE, 0, 0, , "ahk_id " hwnd)
         }
         _GUI_RemoveItemAt(idx1)
         return

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -516,7 +516,7 @@ if (!IsSet(g_AltTabbyMode) || g_AltTabbyMode = "gui") {
     ; normal processing."  Returning 0 here previously ate WM_LBUTTONDOWN for
     ; every window in MainProcess, breaking buttons/edits in themed dialogs.
     OnMessage(WM_LBUTTONDOWN, (wParam, lParam, msg, hwnd) => (hwnd = gGUI_OverlayH ? (GUI_OnClick(lParam & 0xFFFF, (lParam >> 16) & 0xFFFF), 0) : ""))
-    OnMessage(0x020A, (wParam, lParam, msg, hwnd) => (hwnd = gGUI_OverlayH ? (GUI_OnWheel(wParam, lParam), 0) : ""))  ; lint-ignore: onmessage-collision
+    OnMessage(WM_MOUSEWHEEL, (wParam, lParam, msg, hwnd) => (hwnd = gGUI_OverlayH ? (GUI_OnWheel(wParam, lParam), 0) : ""))  ; lint-ignore: onmessage-collision
     OnMessage(WM_MOUSEMOVE, (wParam, lParam, msg, hwnd) => (hwnd = gGUI_OverlayH ? GUI_OnMouseMove(wParam, lParam, msg, hwnd) : ""))
     OnMessage(WM_MOUSELEAVE, (wParam, lParam, msg, hwnd) => (hwnd = gGUI_OverlayH ? GUI_OnMouseLeave() : ""))
 

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -240,7 +240,6 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
 
         if (gGUI_State = "ACTIVE") {
             gGUI_TabCount += 1
-            global gStats_TabSteps
             gStats_TabSteps += 1
             delta := shiftHeld ? -1 : 1
             _GUI_MoveSelectionFrozen(delta)

--- a/src/gui/gui_win.ahk
+++ b/src/gui/gui_win.ahk
@@ -227,13 +227,13 @@ Win_SetCornerPreference(hWnd, pref := 2) {
 
 ; Remove WS_EX_LAYERED style
 Win_ForceNoLayered(hWnd) {
-    global GWL_EXSTYLE, WS_EX_LAYERED
+    global GWL_EXSTYLE, WS_EX_LAYERED, SWP_NOSIZE, SWP_NOMOVE, SWP_NOZORDER, SWP_FRAMECHANGED
     try {
         ex := DllCall("user32\GetWindowLongPtrW", "ptr", hWnd, "int", GWL_EXSTYLE, "ptr")
         if (ex & WS_EX_LAYERED) {
             ex := ex & ~WS_EX_LAYERED
             DllCall("user32\SetWindowLongPtrW", "ptr", hWnd, "int", GWL_EXSTYLE, "ptr", ex, "ptr")
-            DllCall("user32\SetWindowPos", "ptr", hWnd, "ptr", 0, "int", 0, "int", 0, "int", 0, "int", 0, "uint", 0x0001 | 0x0002 | 0x0004 | 0x0020)
+            DllCall("user32\SetWindowPos", "ptr", hWnd, "ptr", 0, "int", 0, "int", 0, "int", 0, "int", 0, "uint", SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED)
         }
     }
 }

--- a/src/shared/blacklist.ahk
+++ b/src/shared/blacklist.ahk
@@ -104,9 +104,6 @@ _Blacklist_Reload() {
         if (line = "" || SubStr(line, 1, 1) = ";")
             continue
 
-        ; Trim again for section headers like "[ Title ]"
-        line := Trim(line)
-
         ; Check for section header
         if (SubStr(line, 1, 1) = "[" && SubStr(line, -1) = "]") {
             currentSection := SubStr(line, 2, -1)

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -645,7 +645,7 @@ Shortcut_GetEffectiveExePath() {
     global cfg
     if (IsSet(cfg) && cfg.HasOwnProp("SetupExePath") && cfg.SetupExePath != "" && FileExist(cfg.SetupExePath))
         return cfg.SetupExePath
-    return A_IsCompiled ? A_ScriptFullPath : A_ScriptFullPath
+    return A_ScriptFullPath
 }
 
 ; ============================================================

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -569,8 +569,9 @@ WL_ValidateExistence() {
             continue
 
         ; Check DWM cloaking
+        global DWMWA_CLOAKED
         static cloakedBuf := Buffer(4, 0)  ; static: reused per-iteration, repopulated by DllCall
-        hr := DllCall("dwmapi\DwmGetWindowAttribute", "ptr", hwnd, "uint", 14, "ptr", cloakedBuf.Ptr, "uint", 4, "int")
+        hr := DllCall("dwmapi\DwmGetWindowAttribute", "ptr", hwnd, "uint", DWMWA_CLOAKED, "ptr", cloakedBuf.Ptr, "uint", 4, "int")
         isCloaked := (hr = 0) && (NumGet(cloakedBuf, 0, "UInt") != 0)
 
         ; If cloaked, it's likely on another workspace - keep it
@@ -1233,9 +1234,6 @@ WL_CleanupAllIcons() {
     }
     Critical "Off"
 }
-
-; Bound diagnostic maps to prevent unbounded memory growth
-; Unconditional: maps may retain entries from when logging was previously enabled
 
 ; ============================================================
 ; DisplayList — Transform store records into sorted item arrays

--- a/tests/test_unit_core_config.ahk
+++ b/tests/test_unit_core_config.ahk
@@ -641,12 +641,13 @@ RunUnitTests_CoreConfig() {
     ; Test: _CL_FormatValue(false, "bool") → "false"
     AssertEq(_CL_FormatValue(false, "bool"), "false", "_CL_FormatValue(false, bool) = 'false'")
 
-    ; Test: _CL_FormatValue(42, "int") → "42" (small int, no hex)
-    AssertEq(_CL_FormatValue(5, "int"), "5", "_CL_FormatValue(5, int) = '5' (small int, decimal)")
+    ; Test: _CL_FormatValue(int) → decimal by default (no hex unless fmt="hex")
+    AssertEq(_CL_FormatValue(5, "int"), "5", "_CL_FormatValue(5, int) = '5' (decimal)")
+    AssertEq(_CL_FormatValue(255, "int"), "255", "_CL_FormatValue(255, int) = '255' (decimal, no auto-hex)")
 
-    ; Test: _CL_FormatValue(large int) → hex format
-    hexResult := _CL_FormatValue(255, "int")
-    AssertEq(hexResult, "0xFF", "_CL_FormatValue(255, int) = '0xFF' (large int, hex)")
+    ; Test: _CL_FormatValue(int, fmt="hex") → hex format
+    AssertEq(_CL_FormatValue(255, "int", "hex"), "0xFF", "_CL_FormatValue(255, int, hex) = '0xFF'")
+    AssertEq(_CL_FormatValue(16, "int", "hex"), "0x10", "_CL_FormatValue(16, int, hex) = '0x10'")
 
     ; Test: _CL_FormatValue(0.5, "float") → string "0.5" (uses {:.6g} format)
     floatResult := _CL_FormatValue(0.5, "float")


### PR DESCRIPTION
## Summary

- **Fix `_CL_FormatValue` hex heuristic bug**: Any int >= 16 was formatted as hex (e.g. `MaxItems=32` became `0x20` in config.ini). Now only formats hex when registry entry has `fmt:"hex"`. Threaded `fmt` param through `CL_SaveChanges` → `CL_WriteIniPreserveFormat`.
- **DRY config editors**: Replaced inline WM_COPYDATA restart signal in both native and WebView2 editors with shared `IPC_SendWmCopyData()`. Extracted `_CEN_GetChangedValues()` helper eliminating duplicate registry loop. Replaced hand-rolled JSON in registry editor with `JSON.Dump()`.
- **Named constants**: Added `WM_CLOSE`, `WM_MOUSEWHEEL`, `SWP_FRAMECHANGED` to gui_constants.ahk. Replaced magic numbers for `DWMWA_CLOAK` (13), `DWMWA_CLOAKED` (14), and SWP flags with named constants. Added blacklist editor layout constants.
- **Enrichment pump**: Fixed double `ProcessUtils_GetPath` syscall by adding `&outPath` parameter to `_Pump_ResolveProcessName`.
- **Cleanup**: Removed redundant `HasOwnProp` config guards (all keys have registry defaults), dead ternary in `setup_utils`, stale IPC comments in icon_pump, redundant globals and Trim() calls.
- **Theme consistency**: Applied `Theme_ApplyToGui()` to registry editor (was hardcoded `"202020"`).
- **Diagnostics**: Added WebView2 fallback logging to config_editor dispatcher.

## Test plan

- [x] Full test suite passes (764/764 — static analysis, unit, GUI, live)
- [x] Updated `_CL_FormatValue` tests to cover new `fmt` parameter and verify large ints stay decimal by default
- [ ] Manual: verify config editor save/restart cycle works (native + WebView2)
- [ ] Manual: verify registry editor renders correctly in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)