### PR TITLE
Parallel live test isolation across worktrees

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -25,7 +25,7 @@ Or run AHK directly (double-slash for Git Bash):
 AutoHotkey64.exe //ErrorStdOut tests\run_tests.ahk --live
 ```
 
-Logs: `%TEMP%\alt_tabby_tests.log` (unit tests). `--live` runs suites in parallel with separate logs: `alt_tabby_tests_core.log`, `alt_tabby_tests_features.log`, `alt_tabby_tests_execution.log`
+Logs: `%TEMP%\alt_tabby_tests_<worktree>.log` (unit tests). `--live` adds suite suffixes: `_core`, `_features`, `_execution`, etc.
 
 **Pre-gate:** Static analysis (`tests/static_analysis.ps1`) runs before all tests. If any function uses a file-scope global without a `global` declaration, the suite is blocked. Fix by adding `global <name>` inside the flagged function. New checks are auto-discovered as `tests/check_*.ps1`.
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -14,3 +14,4 @@ Omit investigation notes, rejected candidates, and false positives. PR reference
 ## Worktree Agents
 
 All file edits and new files must stay within your worktree. Never modify files in the main checkout or other worktrees.
+Live tests (`--live`) are worktree-safe: scoped process kills, isolated pipes/mutexes, worktree-prefixed logs.

--- a/tests/gui_tests.ahk
+++ b/tests/gui_tests.ahk
@@ -15,7 +15,7 @@ A_IconHidden := true  ; No tray icon during tests
 ; RUN ALL TESTS
 ; ============================================================
 
-try FileDelete(A_Temp "\gui_tests.log")
+try FileDelete(GUI_TestLogPath)
 
 GUI_Log("=== Alt-Tabby GUI Tests ===")
 GUI_Log("Running split test modules...")

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -5,6 +5,11 @@
 #Warn VarUnset, Off
 A_IconHidden := true  ; No tray icon during tests
 
+; Worktree-scoped log path (prevents cross-worktree log clobbering)
+SplitPath(A_ScriptDir, , &_guiWorktreeParent)
+SplitPath(_guiWorktreeParent, &_guiWorktreeId)
+global GUI_TestLogPath := A_Temp "\gui_tests_" _guiWorktreeId ".log"
+
 ; ============================================================
 ; 1. GLOBALS (must match gui_main.ahk)
 ; ============================================================
@@ -448,5 +453,6 @@ GUI_AssertTrue(condition, testName) {
 }
 
 GUI_Log(msg) {
-    FileAppend(msg "`n", A_Temp "\gui_tests.log", "UTF-8")
+    global GUI_TestLogPath
+    FileAppend(msg "`n", GUI_TestLogPath, "UTF-8")
 }

--- a/tests/run_tests.ahk
+++ b/tests/run_tests.ahk
@@ -20,8 +20,15 @@ _TestOnError(err, mode) {
 ;   - test_unit.ahk:  Unit tests (WindowList, Config, Entry Points)
 ;   - test_live.ahk:  Live integration tests (require --live flag)
 
+; --- Worktree ID for log file scoping (prevents cross-worktree log clobbering) ---
+; A_ScriptDir is tests/, parent is worktree root. SplitPath on A_ScriptDir gives OutDir
+; (the parent path), then SplitPath on that gives OutFileName (worktree folder name).
+SplitPath(A_ScriptDir, , &_worktreeParent)
+SplitPath(_worktreeParent, &_worktreeId)
+global WorktreeId := _worktreeId
+
 ; --- Global test state ---
-global TestLogPath := A_Temp "\alt_tabby_tests.log"
+global TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId ".log"
 global TestErrors := 0
 global TestPassed := 0
 
@@ -124,31 +131,31 @@ for _, arg in A_Args {
 ; Single-suite modes use a dedicated log file to avoid file locking
 ; conflicts when multiple instances run in parallel
 if (DoLiveCore)
-    TestLogPath := A_Temp "\alt_tabby_tests_core.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_core.log"
 else if (DoLiveNetwork)
-    TestLogPath := A_Temp "\alt_tabby_tests_network.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_network.log"
 else if (DoLiveFeatures)
-    TestLogPath := A_Temp "\alt_tabby_tests_features.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_features.log"
 else if (DoLiveExecution)
-    TestLogPath := A_Temp "\alt_tabby_tests_execution.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_execution.log"
 else if (DoLiveLifecycle)
-    TestLogPath := A_Temp "\alt_tabby_tests_lifecycle.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_lifecycle.log"
 else if (DoUnitCoreStore)
-    TestLogPath := A_Temp "\alt_tabby_tests_unit_core_store.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_unit_core_store.log"
 else if (DoUnitCoreParsing)
-    TestLogPath := A_Temp "\alt_tabby_tests_unit_core_parsing.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_unit_core_parsing.log"
 else if (DoUnitCoreConfig)
-    TestLogPath := A_Temp "\alt_tabby_tests_unit_core_config.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_unit_core_config.log"
 else if (DoUnitStorage)
-    TestLogPath := A_Temp "\alt_tabby_tests_unit_storage.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_unit_storage.log"
 else if (DoUnitSetup)
-    TestLogPath := A_Temp "\alt_tabby_tests_unit_setup.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_unit_setup.log"
 else if (DoUnitCleanup)
-    TestLogPath := A_Temp "\alt_tabby_tests_unit_cleanup.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_unit_cleanup.log"
 else if (DoUnitAdvanced)
-    TestLogPath := A_Temp "\alt_tabby_tests_unit_advanced.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_unit_advanced.log"
 else if (DoUnitStats)
-    TestLogPath := A_Temp "\alt_tabby_tests_unit_stats.log"
+    TestLogPath := A_Temp "\alt_tabby_tests_" WorktreeId "_unit_stats.log"
 
 ; --- Error handler BEFORE any I/O to catch early startup errors ---
 OnError(_Test_OnError)

--- a/tests/test_live_execution.ahk
+++ b/tests/test_live_execution.ahk
@@ -1,10 +1,18 @@
 ; Live Tests - Execution Modes
 ; Compilation Verification, Compiled Exe Modes
 ; Included by test_live.ahk
+;
+; ISOLATION: Copies AltTabby.exe to a temp dir as AltTabby_exectest.exe with
+; its own config.ini (FirstRunCompleted=true, unique PumpPipeName). This gives
+; it a unique mutex (different InstallationId from different dir) so it runs
+; without conflicting with other parallel test suites or user's running instance.
 #Include test_utils.ahk
+
+global EXECTEST_EXE_NAME := "AltTabby_exectest.exe"
 
 RunLiveTests_Execution() {
     global TestPassed, TestErrors, cfg
+    global EXECTEST_EXE_NAME
 
     compiledExePath := A_ScriptDir "\..\release\AltTabby.exe"
 
@@ -14,8 +22,6 @@ RunLiveTests_Execution() {
     Log("`n--- Compilation Verification Test ---")
 
     ; Check that AltTabby.exe exists in release folder
-    compiledExePath := A_ScriptDir "\..\release\AltTabby.exe"
-
     if (FileExist(compiledExePath)) {
         Log("PASS: AltTabby.exe exists in release folder")
         TestPassed++
@@ -47,166 +53,164 @@ RunLiveTests_Execution() {
     }
 
     ; ============================================================
-    ; Compiled Exe Mode Tests
+    ; Compiled Exe Mode Tests (isolated environment)
     ; ============================================================
     Log("`n--- Compiled Exe Mode Tests ---")
 
-    ; Note: test.ps1 kills all AltTabby.exe processes at startup.
-    ; We do NOT call _Test_KillAllAltTabby() here because this suite runs
-    ; in parallel with others that may have their own AltTabby.exe processes.
-    ; For standalone runs: if another instance is running, the launcher's
-    ; --testing-mode will exit silently (acceptable — just a SKIP).
+    if (!FileExist(compiledExePath)) {
+        Log("SKIP: Compiled exe tests skipped - AltTabby.exe not found")
+        return
+    }
 
-    if (FileExist(compiledExePath)) {
-        ; Test launcher mode (spawns gui subprocess)
-        ; Use --testing-mode to prevent wizard and install mismatch dialogs from blocking
-        Log("  Testing launcher mode (spawns gui)...")
+    ; --- Setup isolated test environment ---
+    testDir := A_Temp "\alttabby_exectest_" A_TickCount
+    testExe := testDir "\" EXECTEST_EXE_NAME
+
+    _ExecTest_Cleanup(testDir)
+    DirCreate(testDir)
+    FileCopy(compiledExePath, testExe, true)
+
+    ; Write config with wizard skip and unique pipe name
+    pipeName := "tabby_pump_exec_" A_TickCount
+    configContent := "[Setup]`nFirstRunCompleted=true`n[IPC]`nPumpPipeName=" pipeName "`n"
+    FileAppend(configContent, testDir "\config.ini", "UTF-8")
+
+    Log("  Isolated env: " testDir)
+    Log("  Exe: " EXECTEST_EXE_NAME ", pipe: " pipeName)
+
+    ; --- Test launcher mode (spawns gui subprocess) ---
+    Log("  Testing launcher mode (spawns gui)...")
+    launcherPid := 0
+
+    if (!_Test_RunSilent('"' testExe '" --testing-mode', &launcherPid)) {
+        Log("FAIL: Could not launch " EXECTEST_EXE_NAME " (launcher mode)")
+        TestErrors++
         launcherPid := 0
+    }
 
-        if (!_Test_RunSilent('"' compiledExePath '" --testing-mode', &launcherPid)) {
-            Log("FAIL: Could not launch AltTabby.exe (launcher mode)")
-            TestErrors++
-            launcherPid := 0
+    if (launcherPid) {
+        ; Poll for subprocess spawning — count only OUR isolated exe name
+        processCount := 0
+        spawnStart := A_TickCount
+        while ((A_TickCount - spawnStart) < 5000) {
+            processCount := _Test_CountProcesses(EXECTEST_EXE_NAME)
+            if (processCount >= 2)
+                break
+            Sleep(100)
         }
 
-        if (launcherPid) {
-            ; Poll for subprocess spawning instead of fixed sleep
-            ; Launcher spawns gui, so expect 2+ AltTabby.exe processes (pump is optional)
-            processCount := 0
-            spawnStart := A_TickCount
-            while ((A_TickCount - spawnStart) < 5000) {
-                processCount := _Test_CountProcesses("AltTabby.exe")
-                if (processCount >= 2)
-                    break
-                Sleep(100)
-            }
-
-            if (processCount >= 2) {
-                Log("PASS: Launcher mode spawned " processCount " processes (launcher + gui" (processCount > 2 ? " + pump" : "") ")")
-                TestPassed++
-            } else {
-                ; Diagnostics: is the launcher still alive or did it exit?
-                launcherAlive := ProcessExist(launcherPid)
-                launcherLog := ""
-                logPath := EnvGet("TEMP") "\tabby_launcher.log"
-                if (FileExist(logPath)) {
-                    try launcherLog := FileRead(logPath)
-                }
-                if (!launcherAlive && processCount < 2) {
-                    ; Launcher exited immediately — most likely mutex conflict with existing
-                    ; instance (--testing-mode silently exits on mutex failure).
-                    ; This is an environment issue, not a code bug.
-                    Log("SKIP: Launcher exited immediately (likely mutex conflict with running instance)")
-                    Log("  Diagnostic: launcher PID " launcherPid " alive=no, processes=" processCount)
-                    if (launcherLog != "")
-                        Log("  Launcher log:`n" launcherLog)
-                } else {
-                    Log("FAIL: Launcher mode only has " processCount " process(es), expected 2+")
-                    Log("  Diagnostic: launcher PID " launcherPid " alive=" (launcherAlive ? "yes" : "no"))
-                    if (launcherLog != "")
-                        Log("  Launcher log:`n" launcherLog)
-                    TestErrors++
-                }
-            }
-
-            ; Kill launcher and its children (targeted by PID, not blanket process name kill)
-            for _, child in _Test_FindChildProcesses(launcherPid, "AltTabby.exe") {
-                try ProcessClose(child.pid)
-            }
-            try ProcessClose(launcherPid)
-            waitStart := A_TickCount
-            while (ProcessExist(launcherPid) && (A_TickCount - waitStart) < 2000)
-                Sleep(20)
-            Sleep(50)  ; Brief grace for handle release
-        }
-
-        ; --- Config/Blacklist Recreation Test ---
-        Log("`n--- Config/Blacklist Recreation Test ---")
-
-        releaseDir := A_ScriptDir "\..\release"
-        configPath := releaseDir "\config.ini"
-        blacklistPath := releaseDir "\blacklist.txt"
-        configBackup := ""
-        blacklistBackup := ""
-
-        ; Back up existing files
-        if (FileExist(configPath)) {
-            configBackup := FileRead(configPath, "UTF-8")
-            FileDelete(configPath)
-        }
-        if (FileExist(blacklistPath)) {
-            blacklistBackup := FileRead(blacklistPath, "UTF-8")
-            FileDelete(blacklistPath)
-        }
-
-        ; Verify files are deleted
-        if (FileExist(configPath) || FileExist(blacklistPath)) {
-            Log("FAIL: Could not delete config files for recreation test")
-            TestErrors++
+        if (processCount >= 2) {
+            Log("PASS: Launcher mode spawned " processCount " processes (launcher + gui" (processCount > 2 ? " + pump" : "") ")")
+            TestPassed++
         } else {
-            Log("  Deleted config.ini and blacklist.txt for recreation test")
-
-            ; Run compiled gui briefly - it should recreate the files during init
-            recreatePid := 0
-
-            _Test_RunSilent('"' compiledExePath '" --gui-only --test', &recreatePid)
-
-            if (recreatePid) {
-                ; Poll for both files to appear (adaptive wait, not fixed sleep)
-                ; Files are created early in _GUI_Main_Init: ConfigLoader_Init → config.ini,
-                ; Blacklist_Init → blacklist.txt. Under parallel test load, compiled exe
-                ; startup can exceed 2s, so poll instead of sleeping a fixed duration.
-                waitStart := A_TickCount
-                configRecreated := false
-                blacklistRecreated := false
-                while ((A_TickCount - waitStart) < 8000) {
-                    if (!configRecreated)
-                        configRecreated := FileExist(configPath)
-                    if (!blacklistRecreated)
-                        blacklistRecreated := FileExist(blacklistPath)
-                    if (configRecreated && blacklistRecreated)
-                        break
-                    Sleep(100)
-                }
-
-                if (configRecreated) {
-                    Log("PASS: config.ini recreated by compiled exe")
-                    TestPassed++
-                } else {
-                    Log("FAIL: config.ini NOT recreated by compiled exe")
-                    TestErrors++
-                }
-
-                if (blacklistRecreated) {
-                    Log("PASS: blacklist.txt recreated by compiled exe")
-                    TestPassed++
-                } else {
-                    Log("FAIL: blacklist.txt NOT recreated by compiled exe")
-                    TestErrors++
-                }
-
-                ; Kill the test process
-                try {
-                    ProcessClose(recreatePid)
-                }
+            ; Diagnostics: is the launcher still alive or did it exit?
+            launcherAlive := ProcessExist(launcherPid)
+            launcherLog := ""
+            logPath := EnvGet("TEMP") "\tabby_launcher.log"
+            if (FileExist(logPath)) {
+                try launcherLog := FileRead(logPath)
+            }
+            if (!launcherAlive && processCount < 2) {
+                Log("SKIP: Launcher exited immediately (likely mutex conflict with running instance)")
+                Log("  Diagnostic: launcher PID " launcherPid " alive=no, processes=" processCount)
+                if (launcherLog != "")
+                    Log("  Launcher log:`n" launcherLog)
             } else {
-                Log("FAIL: Could not launch compiled exe for recreation test")
+                Log("FAIL: Launcher mode only has " processCount " process(es), expected 2+")
+                Log("  Diagnostic: launcher PID " launcherPid " alive=" (launcherAlive ? "yes" : "no"))
+                if (launcherLog != "")
+                    Log("  Launcher log:`n" launcherLog)
                 TestErrors++
             }
         }
 
-        ; Restore original files
-        if (configBackup != "") {
-            try FileDelete(configPath)
-            FileAppend(configBackup, configPath, "UTF-8")
-            Log("  Restored original config.ini")
+        ; Kill launcher and its children (targeted by PID tree)
+        for _, child in _Test_FindChildProcesses(launcherPid, EXECTEST_EXE_NAME) {
+            try ProcessClose(child.pid)
         }
-        if (blacklistBackup != "") {
-            try FileDelete(blacklistPath)
-            FileAppend(blacklistBackup, blacklistPath, "UTF-8")
-            Log("  Restored original blacklist.txt")
-        }
-    } else {
-        Log("SKIP: Compiled exe tests skipped - AltTabby.exe not found")
+        try ProcessClose(launcherPid)
+        waitStart := A_TickCount
+        while (ProcessExist(launcherPid) && (A_TickCount - waitStart) < 2000)
+            Sleep(20)
+        Sleep(50)  ; Brief grace for handle release
     }
+
+    ; --- Config/Blacklist Recreation Test (in isolated dir) ---
+    Log("`n--- Config/Blacklist Recreation Test ---")
+
+    configPath := testDir "\config.ini"
+    blacklistPath := testDir "\blacklist.txt"
+
+    ; Delete both files — they should be recreated by the exe on startup
+    try FileDelete(configPath)
+    try FileDelete(blacklistPath)
+
+    if (FileExist(configPath) || FileExist(blacklistPath)) {
+        Log("FAIL: Could not delete config files for recreation test")
+        TestErrors++
+    } else {
+        Log("  Deleted config.ini and blacklist.txt for recreation test")
+
+        ; Run compiled gui briefly - it should recreate the files during init
+        recreatePid := 0
+        _Test_RunSilent('"' testExe '" --gui-only --test', &recreatePid)
+
+        if (recreatePid) {
+            ; Poll for both files to appear
+            waitStart := A_TickCount
+            configRecreated := false
+            blacklistRecreated := false
+            while ((A_TickCount - waitStart) < 8000) {
+                if (!configRecreated)
+                    configRecreated := FileExist(configPath)
+                if (!blacklistRecreated)
+                    blacklistRecreated := FileExist(blacklistPath)
+                if (configRecreated && blacklistRecreated)
+                    break
+                Sleep(100)
+            }
+
+            if (configRecreated) {
+                Log("PASS: config.ini recreated by compiled exe")
+                TestPassed++
+            } else {
+                Log("FAIL: config.ini NOT recreated by compiled exe")
+                TestErrors++
+            }
+
+            if (blacklistRecreated) {
+                Log("PASS: blacklist.txt recreated by compiled exe")
+                TestPassed++
+            } else {
+                Log("FAIL: blacklist.txt NOT recreated by compiled exe")
+                TestErrors++
+            }
+
+            ; Kill the test process
+            try ProcessClose(recreatePid)
+        } else {
+            Log("FAIL: Could not launch compiled exe for recreation test")
+            TestErrors++
+        }
+    }
+
+    ; --- Cleanup ---
+    _ExecTest_Cleanup(testDir)
+}
+
+; Kill all execution test processes and remove temp directory
+_ExecTest_Cleanup(testDir) {
+    global EXECTEST_EXE_NAME
+
+    ; Kill processes by name (only our isolated copies)
+    _Test_KillProcessesByName(EXECTEST_EXE_NAME)
+
+    ; Remove temp directory
+    if (DirExist(testDir)) {
+        try DirDelete(testDir, true)
+    }
+
+    ; Delete stale pump/launcher logs from previous runs
+    try FileDelete(A_Temp "\tabby_pump.log")
+    try FileDelete(A_Temp "\tabby_launcher.log")
 }

--- a/tests/test_utils.ahk
+++ b/tests/test_utils.ahk
@@ -162,12 +162,32 @@ _RepeatStr(str, count) {
     return result
 }
 
-; Kill all running AltTabby.exe processes
+; Kill all running AltTabby.exe processes (blanket — use scoped variants for parallel safety)
 _Test_KillAllAltTabby() {
     for _, proc in _Test_EnumProcesses("AltTabby.exe") {
         try ProcessClose(proc.pid)
     }
     ; Give processes time to fully exit
+    Sleep(200)
+}
+
+; Kill AltTabby processes whose exe path starts with dirPath (worktree-safe)
+_Test_KillAltTabbyInDir(dirPath) {
+    for _, proc in _Test_EnumProcesses("AltTabby.exe") {
+        try {
+            procPath := ProcessGetPath(proc.pid)
+            if (InStr(procPath, dirPath) = 1)
+                ProcessClose(proc.pid)
+        }
+    }
+    Sleep(200)
+}
+
+; Kill all processes matching a custom exe name (e.g. "AltTabby_exectest.exe")
+_Test_KillProcessesByName(exeName) {
+    for _, proc in _Test_EnumProcesses(exeName) {
+        try ProcessClose(proc.pid)
+    }
     Sleep(200)
 }
 


### PR DESCRIPTION
## Summary
- **Scoped process kills**: `test.ps1` and `compile.ps1` now only kill AltTabby.exe processes from their own worktree's `release/` directory, protecting the user's running instance and other worktrees' test processes
- **Isolated execution test**: Copies exe to temp dir as `AltTabby_exectest.exe` with unique pipe name and config, following the existing lifecycle test isolation pattern
- **Worktree-prefixed logs**: All test log files include the worktree folder name (e.g. `alt_tabby_tests_kind-chaum_core.log`), preventing cross-worktree clobbering

## Test plan
- [x] Full test suite passes (553/553): all unit, live, execution, lifecycle, and GUI suites
- [x] Log files correctly scoped with worktree name in `%TEMP%`
- [ ] Manual: run `--live` from two worktrees simultaneously — both should complete without interference
- [ ] Manual: start Alt-Tabby normally, then run `--live` from a worktree — user's instance should survive

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)