### PR TITLE
Static analysis: cache-path invariants + stale docs fix

### DIFF
--- a/.claude/rules/ahk-patterns.md
+++ b/.claude/rules/ahk-patterns.md
@@ -5,8 +5,8 @@
 - Use direct function refs, not `Func("Name")` (v1 pattern)
 - String comparisons: use `StrCompare()` not `<`/`>` operators
 - `#Include` is compile-time only - cannot be conditional at runtime
-- Store expects Map records from producers: use `rec["key"]` not `rec.key`
-- `_WS_GetOpt()` helper handles both Map and plain Object options
+- Producers submit Map records; store converts to Objects internally via `WL_UpsertWindow()`. Use `rec["key"]` in producer code, `rec.key` in store/GUI code
+- `_WS_GetOpt()` helper handles both Map and plain Object options (polymorphic)
 
 ## No Inline Globals in Switch Cases
 


### PR DESCRIPTION
## Summary
- Add `cache_path_invariants` sub-check to `check_batch_patterns.ps1` — validates `WL_GetDisplayList()` dirty-flag management across all 4 cache paths
- Fix stale `ahk-patterns.md` rule about Map vs Object record access patterns post-refactor

## What the new check catches
- Dirty flag never cleared → cache never hits, performance regression
- Dirty flag cleared in wrong path → stale display data
- `gWS_DirtyHwnds` never reset → accumulates stale entries
- Cache hit path (Path 1) incorrectly modifying dirty state

## Audit context
Deep review of all 43 static analysis sub-checks against post-refactor production code. Found the existing suite is comprehensive — scan_pairing already enforces try/finally per-function, Critical section checks cover all return paths, callback null guards are enforced, etc. This cache-path invariant was the one actionable gap for preventing a whole class of cache-coherency bugs.

## Test plan
- [x] Full test suite passes: 61/61 static analysis checks, 770/770 tests
- [x] New check validates current `WL_GetDisplayList()` with zero false positives
- [x] Check runs in existing `check_batch_patterns.ps1` batch — shares file cache, minimal overhead

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)