### PR TITLE
Post-refactor code quality round 4: log paths, GDI+ sync, WM_COPYDATA DRY

### DIFF
--- a/src/core/icon_pump.ahk
+++ b/src/core/icon_pump.ahk
@@ -473,8 +473,8 @@ _IP_Tick() {
     _errCount := 0
     _backoffUntil := 0
     } catch as e {
-        global LOG_PATH_STORE
-        HandleTimerError(e, &_errCount, &_backoffUntil, LOG_PATH_STORE, "IP_Tick")
+        global LOG_PATH_ICONPUMP
+        HandleTimerError(e, &_errCount, &_backoffUntil, LOG_PATH_ICONPUMP, "IP_Tick")
     }
 }
 

--- a/src/core/proc_pump.ahk
+++ b/src/core/proc_pump.ahk
@@ -187,8 +187,8 @@ _PP_Tick() {
     _errCount := 0
     _backoffUntil := 0
     } catch as e {
-        global LOG_PATH_STORE
-        HandleTimerError(e, &_errCount, &_backoffUntil, LOG_PATH_STORE, "PP_Tick")
+        global LOG_PATH_PROCPUMP
+        HandleTimerError(e, &_errCount, &_backoffUntil, LOG_PATH_PROCPUMP, "PP_Tick")
     }
 }
 

--- a/src/editors/config_editor_native.ahk
+++ b/src/editors/config_editor_native.ahk
@@ -1070,9 +1070,12 @@ _CEN_GetControlValue(ctrlInfo, type) {
         return ctrlInfo.ctrl.Text
     } else if (type = "int") {
         try {
-            txt := ctrlInfo.ctrl.Value
-            if (SubStr(txt, 1, 2) = "0x")
-                return Integer(txt)
+            txt := String(ctrlInfo.ctrl.Value)
+            ; Hex fields: ensure "0x" prefix so bare hex like "FF" parses correctly
+            if (ctrlInfo.HasOwnProp("fmt") && ctrlInfo.fmt = "hex") {
+                if (SubStr(txt, 1, 2) != "0x")
+                    txt := "0x" txt
+            }
             return Integer(txt)
         } catch {
             return 0

--- a/src/gui/gui_interceptor.ahk
+++ b/src/gui/gui_interceptor.ahk
@@ -28,6 +28,10 @@ global gINT_AltUpDuringPending := false  ; Track if Alt released before Tab_Deci
 ; Bypass mode state - when true, Tab hotkey is disabled for fullscreen games
 global gINT_BypassMode := false
 
+; Settle delay before Tab decision — allows Alt_Up hotkey to fire first.
+; 1ms was insufficient; 5ms is empirically safe across tested hardware.
+global INT_TAB_DECIDE_SETTLE_MS := 5
+
 ; ========================= HOTKEY SETUP =========================
 
 INT_SetupHotkeys() {
@@ -205,8 +209,8 @@ _INT_Tab_Decide() {
     if (cfg.DiagEventLog)
         GUI_LogEvent("INT: Tab_Decide (altIsDown=" gINT_AltIsDown " altUpFlag=" gINT_AltUpDuringPending ")")
     ; Delay to let Alt_Up hotkey run first if it's pending
-    ; 1ms wasn't enough - Alt_Up hotkey may not have fired yet
-    SetTimer(_INT_Tab_Decide_Inner, -5)
+    global INT_TAB_DECIDE_SETTLE_MS
+    SetTimer(_INT_Tab_Decide_Inner, -INT_TAB_DECIDE_SETTLE_MS)
 }
 
 _INT_Tab_Decide_Inner() {

--- a/src/shared/config_loader.ahk
+++ b/src/shared/config_loader.ahk
@@ -848,9 +848,11 @@ global TOOLTIP_DURATION_DEFAULT := 2000
 global IPC_TICK_IDLE := 100              ; Default, overridden from cfg.IPCIdleTickMs
 
 ; WM_COPYDATA command IDs (launcher <-> client control signals)
+; ID 1: removed — was TABBY_CMD_RESTART_STORE (store now in-process)
 global TABBY_CMD_RESTART_ALL := 2     ; Config editor -> launcher: restart all subprocesses
 global TABBY_CMD_TOGGLE_VIEWER := 3   ; Launcher -> GUI: toggle debug viewer window
 global TABBY_CMD_RELOAD_BLACKLIST := 4  ; Blacklist editor -> launcher -> GUI: reload blacklist
+; ID 5: removed — was TABBY_CMD_QUERY_STATS (replaced by dedicated WM message)
 global TABBY_CMD_STATS_RESPONSE := 6   ; GUI -> launcher: stats snapshot JSON payload
 global TABBY_CMD_EDITOR_CLOSED := 7   ; Editor -> launcher: editor process closing (dashboard refresh)
 global TABBY_CMD_PUMP_FAILED := 8     ; GUI -> launcher: pump crashed or hung, please restart

--- a/src/shared/ipc_wmcopydata.ahk
+++ b/src/shared/ipc_wmcopydata.ahk
@@ -1,10 +1,14 @@
 #Requires AutoHotkey v2.0
 
+; WM_COPYDATA constants
+global IPC_SMTO_ABORTIFHUNG := 0x0002
+global IPC_WM_SEND_TIMEOUT_MS := 3000
+
 ; Send a WM_COPYDATA command to a target window (launcher/gui).
 ; Uses DllCall to bypass DetectHiddenWindows.
 ; Returns true if message was sent, false if target window is invalid.
 IPC_SendWmCopyData(targetHwnd, cmdCode) {
-    global WM_COPYDATA
+    global WM_COPYDATA, IPC_SMTO_ABORTIFHUNG, IPC_WM_SEND_TIMEOUT_MS
     if (!targetHwnd || !DllCall("user32\IsWindow", "ptr", targetHwnd, "int"))
         return false
     cds := Buffer(A_PtrSize * 3, 0)
@@ -16,9 +20,28 @@ IPC_SendWmCopyData(targetHwnd, cmdCode) {
         , "uint", WM_COPYDATA
         , "ptr", A_ScriptHwnd
         , "ptr", cds.Ptr
-        , "uint", 0x0002   ; SMTO_ABORTIFHUNG
-        , "uint", 3000
+        , "uint", IPC_SMTO_ABORTIFHUNG
+        , "uint", IPC_WM_SEND_TIMEOUT_MS
         , "ptr*", &_ := 0
         , "ptr")
     return true
+}
+
+; Send a WM_COPYDATA command with a payload buffer to a target window.
+; Uses SendMessage (not DllCall) so caller must manage DetectHiddenWindows.
+; Returns true if message was sent successfully.
+IPC_SendWmCopyDataWithPayload(targetHwnd, cmdCode, payloadBuf, payloadSize) {
+    global WM_COPYDATA
+    if (!targetHwnd)
+        return false
+    cds := Buffer(A_PtrSize * 3, 0)
+    NumPut("uptr", cmdCode, cds, 0)
+    NumPut("uptr", payloadSize, cds, A_PtrSize)
+    NumPut("uptr", payloadBuf.Ptr, cds, A_PtrSize * 2)
+    try {
+        SendMessage(WM_COPYDATA, A_ScriptHwnd, cds.Ptr, , "ahk_id " targetHwnd)
+        return true
+    } catch {
+        return false
+    }
 }

--- a/tests/check_batch_patterns.ps1
+++ b/tests/check_batch_patterns.ps1
@@ -1353,7 +1353,7 @@ foreach ($path in $fileCacheText.Keys) {
     foreach ($m in $relayMatches) {
         [void]$cmdSent.Add($m.Groups[1].Value)
     }
-    $helperMatches = [regex]::Matches($text, 'IPC_SendWmCopyData\([^,]*,\s*(TABBY_CMD_\w+)')
+    $helperMatches = [regex]::Matches($text, 'IPC_SendWmCopyData\w*\([^,]*,\s*(TABBY_CMD_\w+)')
     foreach ($m in $helperMatches) {
         [void]$cmdSent.Add($m.Groups[1].Value)
     }


### PR DESCRIPTION
## Summary
- **Fix wrong log paths**: IconPump and ProcPump `HandleTimerError` was logging to `LOG_PATH_STORE` instead of their own dedicated log files, mixing pump errors into the store error log
- **Fix hex parsing in config editor**: Bare hex input like "FF" (without "0x" prefix) now parses correctly instead of silently resetting to minimum value
- **GDI+ resource cleanup**: Cleanup now driven by shared `GDIP_RES_TYPES` registry — adding a new brush/font/format only requires updating one place instead of two
- **WM_COPYDATA DRY**: Extract `IPC_SendWmCopyDataWithPayload()` helper to consolidate COPYDATASTRUCT buffer construction. Name `SMTO_ABORTIFHUNG` constant.
- **Named constants**: `INT_TAB_DECIDE_SETTLE_MS` (5ms), `STAGGER_*_MS` (17/37/53ms startup delays)
- **Hover state dedup**: Extract `_GUI_ApplyHoverState()` shared by `GUI_RecalcHover` and `GUI_OnMouseMove`
- **Documentation**: TABBY_CMD ID gaps (1, 5) now documented with removal context

## Test plan
- [x] Full test suite: 772/772 passed (61 static analysis, 505 unit, 43 live, 224 GUI)
- [ ] Manual: verify hex color fields in config editor accept bare hex input
- [ ] Manual: verify pump errors appear in correct log files (`tabby_iconpump.log`, `tabby_procpump.log`)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)