### PR TITLE
Post-refactor code quality: DRY, error handling, dead code

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -197,13 +197,10 @@ _ModeInit() {
 ; Run config editor and exit when launched with --config
 ; Supports --force-native flag to skip WebView2 and use AHK GUI
 if (g_AltTabbyMode = "config") {
-    global ARG_LAUNCHER_HWND, ARG_LAUNCHER_HWND_LEN
-    launcherHwnd := 0
+    launcherHwnd := _ParseLauncherHwnd()
     forceNative := false
     for _, arg in A_Args {
-        if (SubStr(arg, 1, ARG_LAUNCHER_HWND_LEN) = ARG_LAUNCHER_HWND)
-            launcherHwnd := Integer(SubStr(arg, ARG_LAUNCHER_HWND_LEN + 1))
-        else if (arg = "--force-native")
+        if (arg = "--force-native")
             forceNative := true
     }
     ; Theme_Init is called inside ConfigEditor_Run after ConfigLoader_Init
@@ -214,17 +211,23 @@ if (g_AltTabbyMode = "config") {
 
 ; Run blacklist editor and exit when launched with --blacklist
 if (g_AltTabbyMode = "blacklist") {
-    global ARG_LAUNCHER_HWND, ARG_LAUNCHER_HWND_LEN
-    launcherHwnd := 0
-    for _, arg in A_Args {
-        if (SubStr(arg, 1, ARG_LAUNCHER_HWND_LEN) = ARG_LAUNCHER_HWND)
-            launcherHwnd := Integer(SubStr(arg, ARG_LAUNCHER_HWND_LEN + 1))
-    }
+    launcherHwnd := _ParseLauncherHwnd()
     ; Initialize config + theme for blacklist editor process
     _ModeInit()
     BlacklistEditor_Run(launcherHwnd)
     _NotifyEditorClosed(launcherHwnd)
     ExitApp()
+}
+
+; Parse --launcher-hwnd=<N> from command-line args.
+; Shared by config and blacklist editor mode handlers.
+_ParseLauncherHwnd() {
+    global ARG_LAUNCHER_HWND, ARG_LAUNCHER_HWND_LEN
+    for _, arg in A_Args {
+        if (SubStr(arg, 1, ARG_LAUNCHER_HWND_LEN) = ARG_LAUNCHER_HWND)
+            return Integer(SubStr(arg, ARG_LAUNCHER_HWND_LEN + 1))
+    }
+    return 0
 }
 
 ; Notify launcher that an editor process is closing (for dashboard refresh).

--- a/src/core/icon_pump.ahk
+++ b/src/core/icon_pump.ahk
@@ -152,12 +152,6 @@ IconPump_Stop() {
     SetTimer(_IP_Tick, 0)
 }
 
-; Query whether the icon pump timer is running
-IconPump_IsRunning() { ; lint-ignore: dead-function
-    global _IP_TimerOn
-    return _IP_TimerOn
-}
-
 ; Query whether the icon pump has been configured (may be idle-paused but functional)
 IconPump_IsEnabled() {
     global IconTimerIntervalMs

--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -621,9 +621,10 @@ _WEH_StartMruFallback() {
         _WEH_MruFallbackActive := true
         try {
             MRU_Lite_Init()
-        } catch {
+            try LogAppend(LOG_PATH_STORE, "WEH_ProcessBatch: MRU_Lite fallback ACTIVATED during backoff")
+        } catch as e {
+            try LogAppend(LOG_PATH_STORE, "WEH_ProcessBatch: MRU_Lite fallback FAILED: " e.Message)
         }
-        try LogAppend(LOG_PATH_STORE, "WEH_ProcessBatch: MRU_Lite fallback ACTIVATED during backoff")
     }
 }
 

--- a/src/shared/blacklist.ahk
+++ b/src/shared/blacklist.ahk
@@ -279,7 +279,7 @@ Blacklist_IsWindowEligible(hwnd, title := "", class := "") {
     }
 
     ; Delegate to Ex variant (vis/min/clk refs discarded — no extra cost since
-    ; the same DllCalls happen either way via _BL_ProbeVisMinCloak)
+    ; the same DllCalls happen either way via BL_ProbeVisMinCloak)
     vis := false, min := false, clk := false
     return Blacklist_IsWindowEligibleEx(hwnd, title, class, &vis, &min, &clk)
 }
@@ -292,8 +292,8 @@ _BL_IsAltTabEligible(hwnd) {
 }
 
 ; Shared vis/min/cloak probe — single source for the DllCall trio
-; Used by both _BL_IsAltTabEligibleEx and Blacklist_IsWindowEligibleEx (DRY)
-_BL_ProbeVisMinCloak(hwnd, &outVis, &outMin, &outCloak) {
+; Used by _BL_IsAltTabEligibleEx, Blacklist_IsWindowEligibleEx, and WinUtils_ProbeWindow
+BL_ProbeVisMinCloak(hwnd, &outVis, &outMin, &outCloak) {
     global DWMWA_CLOAKED
     static cloakedBuf := Buffer(4, 0)
     outVis := DllCall("user32\IsWindowVisible", "ptr", hwnd, "int") != 0
@@ -309,7 +309,7 @@ _BL_IsAltTabEligibleEx(hwnd, &outVis, &outMin, &outCloak) {
     global GWL_STYLE, GWL_EXSTYLE, GW_OWNER
 
     ; Get visibility state via shared helper
-    _BL_ProbeVisMinCloak(hwnd, &outVis, &outMin, &outCloak)
+    BL_ProbeVisMinCloak(hwnd, &outVis, &outMin, &outCloak)
 
     ; Get regular window style
     style := DllCall("user32\GetWindowLongPtrW", "ptr", hwnd, "int", GWL_STYLE, "ptr")
@@ -363,7 +363,7 @@ Blacklist_IsWindowEligibleEx(hwnd, title, class, &outVis, &outMin, &outCloak) {
             return false
     } else {
         ; Fetch vis/min/cloak directly when eligibility check is skipped
-        _BL_ProbeVisMinCloak(hwnd, &outVis, &outMin, &outCloak)
+        BL_ProbeVisMinCloak(hwnd, &outVis, &outMin, &outCloak)
     }
 
     ; Check blacklist (use cached config value for hot path performance)

--- a/src/shared/config_loader.ahk
+++ b/src/shared/config_loader.ahk
@@ -85,6 +85,7 @@ ConfigLoader_Init(basePath := "", readOnly := false) {
 
     _CL_LoadAllSettings()  ; Load user overrides
     _CL_ValidateSettings() ; Clamp values to safe ranges
+    _CL_ComputeDerivedGlobals() ; Derive runtime constants from validated config
     _CL_ResolveAhkV2Path()     ; Auto-discover AHK v2 if not set
     _CL_ResolveKomorebicPath() ; Auto-discover komorebic if not set
     gConfigLoaded := true
@@ -670,8 +671,12 @@ _CL_ValidateSettings() {
     ; --- Safety poll: 0=disabled, otherwise floor at 30000ms ---
     if (cfg.WinEnumSafetyPollMs > 0 && cfg.WinEnumSafetyPollMs < 30000)
         cfg.WinEnumSafetyPollMs := 30000
+}
 
-    ; --- Derived globals (must come after clamping) ---
+; Compute runtime globals derived from validated config values.
+; Must be called AFTER _CL_ValidateSettings() — depends on clamped values.
+_CL_ComputeDerivedGlobals() {
+    global cfg
     global IPC_TICK_IDLE
     IPC_TICK_IDLE := cfg.IPCIdleTickMs
     global LOG_MAX_BYTES, LOG_KEEP_BYTES

--- a/src/shared/ipc_pipe.ahk
+++ b/src/shared/ipc_pipe.ahk
@@ -320,6 +320,8 @@ _IPC_CreatePipeInstance(pipeName) {
     ; Create security attributes with NULL DACL to allow non-elevated processes
     ; to connect when we're running as administrator
     pSA := IPC_CreateOpenSecurityAttrs()
+    if (!pSA && logEnabled)
+        _IPC_Log("WARN: IPC_CreateOpenSecurityAttrs failed — pipe will use default security (may block non-elevated connections)")
 
     hPipe := DllCall("CreateNamedPipeW"
         , "str", "\\.\pipe\" pipeName

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -64,7 +64,7 @@ global gStats_CrossWorkspace := 0
 global gStats_WorkspaceToggles := 0
 global gStats_LastSent := Map()
 
-; Store globals (from window_list.ahk - not included in GUI test chain)
+; Store globals (mocked for GUI tests — production uses embedded store in gui_main.ahk)
 global gWS_Store := Map()
 global gWS_DirtyHwnds := Map()
 

--- a/tests/test_unit_core_config.ahk
+++ b/tests/test_unit_core_config.ahk
@@ -753,6 +753,7 @@ RunUnitTests_CoreConfig() {
     cfg.DiagLogKeepKB := 500
     cfg.DiagLogMaxKB := 500
     _CL_ValidateSettings()
+    _CL_ComputeDerivedGlobals()
     if (cfg.DiagLogKeepKB = 250) {
         Log("PASS: DiagLogKeepKB=500 with DiagLogMaxKB=500 forced to 250 (half)")
         TestPassed++

--- a/tests/test_unit_core_store.ahk
+++ b/tests/test_unit_core_store.ahk
@@ -29,31 +29,9 @@ RunUnitTests_CoreStore() {
     ; Test 5: WindowList basic operations
     WL_Init()
     WL_BeginScan()
-
-    testRecs := []
-    rec1 := Map()
-    rec1["hwnd"] := 12345
-    rec1["title"] := "Test Window 1"
-    rec1["class"] := "TestClass"
-    rec1["pid"] := 100
-    rec1["isVisible"] := true
-    rec1["isCloaked"] := false
-    rec1["isMinimized"] := false
-    rec1["z"] := 1
-    testRecs.Push(rec1)
-
-    rec2 := Map()
-    rec2["hwnd"] := 67890
-    rec2["title"] := "Test Window 2"
-    rec2["class"] := "TestClass2"
-    rec2["pid"] := 200
-    rec2["isVisible"] := true
-    rec2["isCloaked"] := false
-    rec2["isMinimized"] := false
-    rec2["z"] := 2
-    testRecs.Push(rec2)
-
-    result := WL_UpsertWindow(testRecs, "test")
+    rec1 := _TestRec(Map("hwnd", 12345, "title", "Test Window 1", "z", 1))
+    rec2 := _TestRec(Map("hwnd", 67890, "title", "Test Window 2", "class", "TestClass2", "pid", 200, "z", 2))
+    result := WL_UpsertWindow([rec1, rec2], "test")
     AssertEq(result.added, 2, "WL_UpsertWindow adds records")
 
     ; Test 6: GetDisplayList with plain object opts (THE BUG FIX)
@@ -159,10 +137,8 @@ RunUnitTests_CoreStore() {
 
     ; Scan 1: Add two windows
     WL_BeginScan()
-    rec1 := Map("hwnd", 11111, "title", "Persistent", "class", "Test", "pid", 1,
-                "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
-    rec2 := Map("hwnd", 22222, "title", "Disappearing", "class", "Test", "pid", 2,
-                "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2)
+    rec1 := _TestRec(Map("hwnd", 11111, "title", "Persistent", "class", "Test", "pid", 1, "z", 1))
+    rec2 := _TestRec(Map("hwnd", 22222, "title", "Disappearing", "class", "Test", "pid", 2, "z", 2))
     WL_UpsertWindow([rec1, rec2], "test")
     WL_EndScan(100)  ; 100ms grace
 
@@ -198,12 +174,10 @@ RunUnitTests_CoreStore() {
 
     ; Scan 1: Add two windows - one with workspaceName, one without
     WL_BeginScan()
-    wsRec1 := Map("hwnd", 33333, "title", "Komorebi Managed", "class", "Test", "pid", 10,
-                  "isVisible", true, "isCloaked", true, "isMinimized", false, "z", 1,
-                  "workspaceName", "MyWorkspace")
-    wsRec2 := Map("hwnd", 44444, "title", "Unmanaged Window", "class", "Test", "pid", 11,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2,
-                  "workspaceName", "")
+    wsRec1 := _TestRec(Map("hwnd", 33333, "title", "Komorebi Managed", "class", "Test", "pid", 10,
+                           "isCloaked", true, "z", 1, "workspaceName", "MyWorkspace"))
+    wsRec2 := _TestRec(Map("hwnd", 44444, "title", "Unmanaged Window", "class", "Test", "pid", 11,
+                           "z", 2, "workspaceName", ""))
     WL_UpsertWindow([wsRec1, wsRec2], "test")
     WL_EndScan(100)
 
@@ -232,9 +206,8 @@ RunUnitTests_CoreStore() {
     Log("Testing EndScan does not protect empty workspaceName...")
     WL_Init()
     WL_BeginScan()
-    emptyWsRec := Map("hwnd", 55555, "title", "Empty WS Window", "class", "Test", "pid", 12,
-                      "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1,
-                      "workspaceName", "")
+    emptyWsRec := _TestRec(Map("hwnd", 55555, "title", "Empty WS Window", "class", "Test", "pid", 12,
+                               "z", 1, "workspaceName", ""))
     WL_UpsertWindow([emptyWsRec], "test")
     WL_EndScan(100)
 
@@ -258,12 +231,10 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     sortTestRecs := []
-    sortTestRecs.Push(Map("hwnd", 5001, "title", "SortTest1", "class", "T", "pid", 1,
-                          "isVisible", true, "isCloaked", false, "isMinimized", false,
-                          "z", 1, "lastActivatedTick", 100))
-    sortTestRecs.Push(Map("hwnd", 5002, "title", "SortTest2", "class", "T", "pid", 2,
-                          "isVisible", true, "isCloaked", false, "isMinimized", false,
-                          "z", 2, "lastActivatedTick", 200))
+    sortTestRecs.Push(_TestRec(Map("hwnd", 5001, "title", "SortTest1", "class", "T", "pid", 1,
+                                   "z", 1, "lastActivatedTick", 100)))
+    sortTestRecs.Push(_TestRec(Map("hwnd", 5002, "title", "SortTest2", "class", "T", "pid", 2,
+                                   "z", 2, "lastActivatedTick", 200)))
     WL_UpsertWindow(sortTestRecs, "test")
     WL_EndScan()
 
@@ -366,15 +337,12 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     imRecs := []
-    imRecs.Push(Map("hwnd", 6001, "title", "IM_A", "class", "T", "pid", 1,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 1, "lastActivatedTick", 100))
-    imRecs.Push(Map("hwnd", 6002, "title", "IM_B", "class", "T", "pid", 2,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 2, "lastActivatedTick", 200))
-    imRecs.Push(Map("hwnd", 6003, "title", "IM_C", "class", "T", "pid", 3,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 3, "lastActivatedTick", 300))
+    imRecs.Push(_TestRec(Map("hwnd", 6001, "title", "IM_A", "class", "T", "pid", 1,
+                              "z", 1, "lastActivatedTick", 100)))
+    imRecs.Push(_TestRec(Map("hwnd", 6002, "title", "IM_B", "class", "T", "pid", 2,
+                              "z", 2, "lastActivatedTick", 200)))
+    imRecs.Push(_TestRec(Map("hwnd", 6003, "title", "IM_C", "class", "T", "pid", 3,
+                              "z", 3, "lastActivatedTick", 300)))
     WL_UpsertWindow(imRecs, "test")
     WL_EndScan()
 
@@ -429,12 +397,10 @@ RunUnitTests_CoreStore() {
     ; Add windows so SetCurrentWorkspace has work to do
     WL_BeginScan()
     cbRecs := []
-    cbRecs.Push(Map("hwnd", 6101, "title", "CB1", "class", "T", "pid", 1,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 1, "workspaceName", "Alpha"))
-    cbRecs.Push(Map("hwnd", 6102, "title", "CB2", "class", "T", "pid", 2,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 2, "workspaceName", "Beta"))
+    cbRecs.Push(_TestRec(Map("hwnd", 6101, "title", "CB1", "class", "T", "pid", 1,
+                              "z", 1, "workspaceName", "Alpha")))
+    cbRecs.Push(_TestRec(Map("hwnd", 6102, "title", "CB2", "class", "T", "pid", 2,
+                              "z", 2, "workspaceName", "Beta")))
     WL_UpsertWindow(cbRecs, "test")
     WL_EndScan()
 
@@ -464,15 +430,12 @@ RunUnitTests_CoreStore() {
 
     WL_BeginScan()
     recs := []
-    recs.Push(Map("hwnd", 1001, "title", "Win1", "class", "T", "pid", 1,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false,
-                  "z", 1, "workspaceName", "Main"))
-    recs.Push(Map("hwnd", 1002, "title", "Win2", "class", "T", "pid", 2,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false,
-                  "z", 2, "workspaceName", "Other"))
-    recs.Push(Map("hwnd", 1003, "title", "Win3", "class", "T", "pid", 3,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false,
-                  "z", 3, "workspaceName", ""))  ; Unmanaged
+    recs.Push(_TestRec(Map("hwnd", 1001, "title", "Win1", "class", "T", "pid", 1,
+                            "z", 1, "workspaceName", "Main")))
+    recs.Push(_TestRec(Map("hwnd", 1002, "title", "Win2", "class", "T", "pid", 2,
+                            "z", 2, "workspaceName", "Other")))
+    recs.Push(_TestRec(Map("hwnd", 1003, "title", "Win3", "class", "T", "pid", 3,
+                            "z", 3, "workspaceName", "")))  ; Unmanaged
     WL_UpsertWindow(recs, "test")
     WL_EndScan()
 
@@ -514,15 +477,12 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     batchRecs := []
-    batchRecs.Push(Map("hwnd", 7001, "title", "Batch1", "class", "T", "pid", 1,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false,
-                       "z", 1, "lastActivatedTick", 100))
-    batchRecs.Push(Map("hwnd", 7002, "title", "Batch2", "class", "T", "pid", 2,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false,
-                       "z", 2, "lastActivatedTick", 200))
-    batchRecs.Push(Map("hwnd", 7003, "title", "Batch3", "class", "T", "pid", 3,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false,
-                       "z", 3, "lastActivatedTick", 300))
+    batchRecs.Push(_TestRec(Map("hwnd", 7001, "title", "Batch1", "class", "T", "pid", 1,
+                                 "z", 1, "lastActivatedTick", 100)))
+    batchRecs.Push(_TestRec(Map("hwnd", 7002, "title", "Batch2", "class", "T", "pid", 2,
+                                 "z", 2, "lastActivatedTick", 200)))
+    batchRecs.Push(_TestRec(Map("hwnd", 7003, "title", "Batch3", "class", "T", "pid", 3,
+                                 "z", 3, "lastActivatedTick", 300)))
     WL_UpsertWindow(batchRecs, "test")
     WL_EndScan()
 
@@ -585,15 +545,12 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     mruBatchRecs := []
-    mruBatchRecs.Push(Map("hwnd", 8001, "title", "MRUBatch_A", "class", "T", "pid", 1,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 1, "lastActivatedTick", 100))
-    mruBatchRecs.Push(Map("hwnd", 8002, "title", "MRUBatch_B", "class", "T", "pid", 2,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 2, "lastActivatedTick", 200))
-    mruBatchRecs.Push(Map("hwnd", 8003, "title", "MRUBatch_C", "class", "T", "pid", 3,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 3, "lastActivatedTick", 300))
+    mruBatchRecs.Push(_TestRec(Map("hwnd", 8001, "title", "MRUBatch_A", "class", "T", "pid", 1,
+                                    "z", 1, "lastActivatedTick", 100)))
+    mruBatchRecs.Push(_TestRec(Map("hwnd", 8002, "title", "MRUBatch_B", "class", "T", "pid", 2,
+                                    "z", 2, "lastActivatedTick", 200)))
+    mruBatchRecs.Push(_TestRec(Map("hwnd", 8003, "title", "MRUBatch_C", "class", "T", "pid", 3,
+                                    "z", 3, "lastActivatedTick", 300)))
     WL_UpsertWindow(mruBatchRecs, "test")
     WL_EndScan()
 
@@ -666,9 +623,8 @@ RunUnitTests_CoreStore() {
 
     ; Add our hwnd to the store via upsert
     WL_BeginScan()
-    reappearRec := Map("hwnd", testHwnd, "title", "TestProcess", "class", "TestClass",
-                       "pid", ProcessExist(), "isVisible", true, "isCloaked", false,
-                       "isMinimized", false, "z", 1, "lastActivatedTick", A_TickCount)
+    reappearRec := _TestRec(Map("hwnd", testHwnd, "title", "TestProcess",
+                                "pid", ProcessExist(), "z", 1, "lastActivatedTick", A_TickCount))
     WL_UpsertWindow([reappearRec], "test")
     WL_EndScan()
 
@@ -709,12 +665,10 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     staleRecs := []
-    staleRecs.Push(Map("hwnd", 8001, "title", "StaleTest1", "class", "T", "pid", 1,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false,
-                       "z", 1, "lastActivatedTick", 100))
-    staleRecs.Push(Map("hwnd", 8002, "title", "StaleTest2", "class", "T", "pid", 2,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false,
-                       "z", 2, "lastActivatedTick", 200))
+    staleRecs.Push(_TestRec(Map("hwnd", 8001, "title", "StaleTest1", "class", "T", "pid", 1,
+                                 "z", 1, "lastActivatedTick", 100)))
+    staleRecs.Push(_TestRec(Map("hwnd", 8002, "title", "StaleTest2", "class", "T", "pid", 2,
+                                 "z", 2, "lastActivatedTick", 200)))
     WL_UpsertWindow(staleRecs, "test")
     WL_EndScan()
 
@@ -761,15 +715,12 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     mruRecs := []
-    mruRecs.Push(Map("hwnd", 9001, "title", "MRU_A", "class", "T", "pid", 1,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 1, "lastActivatedTick", 100))
-    mruRecs.Push(Map("hwnd", 9002, "title", "MRU_B", "class", "T", "pid", 2,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 2, "lastActivatedTick", 200))
-    mruRecs.Push(Map("hwnd", 9003, "title", "MRU_C", "class", "T", "pid", 3,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 3, "lastActivatedTick", 300))
+    mruRecs.Push(_TestRec(Map("hwnd", 9001, "title", "MRU_A", "class", "T", "pid", 1,
+                               "z", 1, "lastActivatedTick", 100)))
+    mruRecs.Push(_TestRec(Map("hwnd", 9002, "title", "MRU_B", "class", "T", "pid", 2,
+                               "z", 2, "lastActivatedTick", 200)))
+    mruRecs.Push(_TestRec(Map("hwnd", 9003, "title", "MRU_C", "class", "T", "pid", 3,
+                               "z", 3, "lastActivatedTick", 300)))
     WL_UpsertWindow(mruRecs, "test")
     WL_EndScan()
 
@@ -826,15 +777,12 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     hwndsRecs := []
-    hwndsRecs.Push(Map("hwnd", 9001, "title", "HO_A", "class", "T", "pid", 1,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 1, "lastActivatedTick", 100))
-    hwndsRecs.Push(Map("hwnd", 9002, "title", "HO_B", "class", "T", "pid", 2,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 2, "lastActivatedTick", 200))
-    hwndsRecs.Push(Map("hwnd", 9003, "title", "HO_C", "class", "T", "pid", 3,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 3, "lastActivatedTick", 300))
+    hwndsRecs.Push(_TestRec(Map("hwnd", 9001, "title", "HO_A", "class", "T", "pid", 1,
+                                 "z", 1, "lastActivatedTick", 100)))
+    hwndsRecs.Push(_TestRec(Map("hwnd", 9002, "title", "HO_B", "class", "T", "pid", 2,
+                                 "z", 2, "lastActivatedTick", 200)))
+    hwndsRecs.Push(_TestRec(Map("hwnd", 9003, "title", "HO_C", "class", "T", "pid", 3,
+                                 "z", 3, "lastActivatedTick", 300)))
     WL_UpsertWindow(hwndsRecs, "test")
     WL_EndScan()
 
@@ -872,18 +820,14 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     invRecs := []
-    invRecs.Push(Map("hwnd", 9001, "title", "INV_A", "class", "T", "pid", 1,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 1, "lastActivatedTick", 100))
-    invRecs.Push(Map("hwnd", 9002, "title", "INV_B", "class", "T", "pid", 2,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 2, "lastActivatedTick", 200))
-    invRecs.Push(Map("hwnd", 9003, "title", "INV_C", "class", "T", "pid", 3,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 3, "lastActivatedTick", 300))
-    invRecs.Push(Map("hwnd", 9004, "title", "INV_D", "class", "T", "pid", 4,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 4, "lastActivatedTick", 400))
+    invRecs.Push(_TestRec(Map("hwnd", 9001, "title", "INV_A", "class", "T", "pid", 1,
+                               "z", 1, "lastActivatedTick", 100)))
+    invRecs.Push(_TestRec(Map("hwnd", 9002, "title", "INV_B", "class", "T", "pid", 2,
+                               "z", 2, "lastActivatedTick", 200)))
+    invRecs.Push(_TestRec(Map("hwnd", 9003, "title", "INV_C", "class", "T", "pid", 3,
+                               "z", 3, "lastActivatedTick", 300)))
+    invRecs.Push(_TestRec(Map("hwnd", 9004, "title", "INV_D", "class", "T", "pid", 4,
+                               "z", 4, "lastActivatedTick", 400)))
     WL_UpsertWindow(invRecs, "test")
     WL_EndScan()
 
@@ -919,12 +863,10 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     titleRecs := []
-    titleRecs.Push(Map("hwnd", 9101, "title", "Alpha", "class", "T", "pid", 1,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false,
-                       "z", 1, "lastActivatedTick", 100))
-    titleRecs.Push(Map("hwnd", 9102, "title", "Beta", "class", "T", "pid", 2,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false,
-                       "z", 2, "lastActivatedTick", 200))
+    titleRecs.Push(_TestRec(Map("hwnd", 9101, "title", "Alpha", "class", "T", "pid", 1,
+                                 "z", 1, "lastActivatedTick", 100)))
+    titleRecs.Push(_TestRec(Map("hwnd", 9102, "title", "Beta", "class", "T", "pid", 2,
+                                 "z", 2, "lastActivatedTick", 200)))
     WL_UpsertWindow(titleRecs, "test")
     WL_EndScan()
 
@@ -966,14 +908,12 @@ RunUnitTests_CoreStore() {
     ; Test: WL_UpsertWindow marks DirtyHwnds on field change
     WL_Init()
     WL_BeginScan()
-    dtRec := Map("hwnd", 99901, "title", "Original", "class", "C", "pid", 1,
-                 "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
+    dtRec := _TestRec(Map("hwnd", 99901, "title", "Original", "class", "C", "pid", 1, "z", 1))
     WL_UpsertWindow([dtRec], "test")
     WL_EndScan()
     gWS_DirtyHwnds := Map()  ; clear
 
-    dtRec2 := Map("hwnd", 99901, "title", "Changed", "class", "C", "pid", 1,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
+    dtRec2 := _TestRec(Map("hwnd", 99901, "title", "Changed", "class", "C", "pid", 1, "z", 1))
     WL_UpsertWindow([dtRec2], "test")
     AssertEq(gWS_DirtyHwnds.Has(99901), true, "DirtyContract: UpsertWindow marks dirty on title change")
 
@@ -1010,15 +950,12 @@ RunUnitTests_CoreStore() {
     WL_Init()
     WL_BeginScan()
     okRecs := []
-    okRecs.Push(Map("hwnd", 9201, "title", "Charlie", "class", "T", "pid", 1,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 1, "lastActivatedTick", 300))
-    okRecs.Push(Map("hwnd", 9202, "title", "Alpha", "class", "T", "pid", 2,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 2, "lastActivatedTick", 100))
-    okRecs.Push(Map("hwnd", 9203, "title", "Bravo", "class", "T", "pid", 3,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false,
-                     "z", 3, "lastActivatedTick", 200))
+    okRecs.Push(_TestRec(Map("hwnd", 9201, "title", "Charlie", "class", "T", "pid", 1,
+                              "z", 1, "lastActivatedTick", 300)))
+    okRecs.Push(_TestRec(Map("hwnd", 9202, "title", "Alpha", "class", "T", "pid", 2,
+                              "z", 2, "lastActivatedTick", 100)))
+    okRecs.Push(_TestRec(Map("hwnd", 9203, "title", "Bravo", "class", "T", "pid", 3,
+                              "z", 3, "lastActivatedTick", 200)))
     WL_UpsertWindow(okRecs, "test")
     WL_EndScan()
 

--- a/tests/test_unit_storage.ahk
+++ b/tests/test_unit_storage.ahk
@@ -12,23 +12,8 @@ RunUnitTests_Storage() {
     Log("`n--- WL_UpdateFields Tests ---")
 
     ; Ensure store is initialized
-    WL_Init()
-    WL_BeginScan()
-
-    ; Add a test window
     testHwnd := 99999
-    testRec := Map()
-    testRec["hwnd"] := testHwnd
-    testRec["title"] := "Test Bypass Window"
-    testRec["class"] := "TestClass"
-    testRec["pid"] := 999
-    testRec["isVisible"] := true
-    testRec["isCloaked"] := false
-    testRec["isMinimized"] := false
-    testRec["z"] := 1
-    testRec["isFocused"] := false
-    WL_UpsertWindow([testRec], "test")
-    WL_EndScan()
+    _TestSetupStore([_TestRec(Map("hwnd", testHwnd, "title", "Test Bypass Window", "class", "TestClass", "pid", 999, "isFocused", false))])
 
     ; Test: UpdateFields on existing window should return exists=true
     result := WL_UpdateFields(testHwnd, { isFocused: true }, "test")
@@ -74,10 +59,8 @@ RunUnitTests_Storage() {
     global gWS_Store
 
     WL_BeginScan()
-    fakeRec1 := Map("hwnd", 0x9999001, "title", "Fake Win 1", "class", "FakeClass", "pid", 1,
-                    "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
-    fakeRec2 := Map("hwnd", 0x9999002, "title", "Fake Win 2", "class", "FakeClass", "pid", 2,
-                    "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2)
+    fakeRec1 := _TestRec(Map("hwnd", 0x9999001, "title", "Fake Win 1", "class", "FakeClass", "pid", 1, "z", 1))
+    fakeRec2 := _TestRec(Map("hwnd", 0x9999002, "title", "Fake Win 2", "class", "FakeClass", "pid", 2, "z", 2))
     WL_UpsertWindow([fakeRec1, fakeRec2], "test")
     WL_EndScan()
 
@@ -113,8 +96,7 @@ RunUnitTests_Storage() {
     Log("Testing ValidateExistence bumps rev on removal...")
     WL_Init()
     WL_BeginScan()
-    fakeRec3 := Map("hwnd", 0x9999003, "title", "Fake Win 3", "class", "FakeClass", "pid", 3,
-                    "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
+    fakeRec3 := _TestRec(Map("hwnd", 0x9999003, "title", "Fake Win 3", "class", "FakeClass", "pid", 3, "z", 1))
     WL_UpsertWindow([fakeRec3], "test")
     WL_EndScan()
 
@@ -170,10 +152,8 @@ RunUnitTests_Storage() {
         Log("Testing PurgeBlacklisted removes title-matched windows...")
         WL_Init()
         WL_BeginScan()
-        badRec := Map("hwnd", 0xAA01, "title", "BadTitle Test Window", "class", "SafeClass", "pid", 10,
-                      "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
-        goodRec := Map("hwnd", 0xAA02, "title", "GoodTitle Window", "class", "SafeClass", "pid", 11,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2)
+        badRec := _TestRec(Map("hwnd", 0xAA01, "title", "BadTitle Test Window", "class", "SafeClass", "pid", 10, "z", 1))
+        goodRec := _TestRec(Map("hwnd", 0xAA02, "title", "GoodTitle Window", "class", "SafeClass", "pid", 11, "z", 2))
         WL_UpsertWindow([badRec, goodRec], "test")
         WL_EndScan()
 
@@ -208,8 +188,7 @@ RunUnitTests_Storage() {
         Log("Testing PurgeBlacklisted removes class-matched windows...")
         WL_Init()
         WL_BeginScan()
-        classRec := Map("hwnd", 0xAA03, "title", "Safe Title", "class", "BadClass", "pid", 12,
-                        "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
+        classRec := _TestRec(Map("hwnd", 0xAA03, "title", "Safe Title", "class", "BadClass", "pid", 12, "z", 1))
         WL_UpsertWindow([classRec], "test")
         WL_EndScan()
 
@@ -226,8 +205,7 @@ RunUnitTests_Storage() {
         Log("Testing PurgeBlacklisted rev behavior...")
         WL_Init()
         WL_BeginScan()
-        safeRec := Map("hwnd", 0xAA04, "title", "Completely Safe", "class", "SafeClass", "pid", 13,
-                       "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
+        safeRec := _TestRec(Map("hwnd", 0xAA04, "title", "Completely Safe", "class", "SafeClass", "pid", 13, "z", 1))
         WL_UpsertWindow([safeRec], "test")
         WL_EndScan()
 
@@ -345,30 +323,16 @@ RunUnitTests_Storage() {
 
     ; Create a cloaked window record (simulating a window on another workspace)
     cloakedHwnd := 77777
-    cloakedRec := Map()
-    cloakedRec["hwnd"] := cloakedHwnd
-    cloakedRec["title"] := "Test Cloaked Window"
-    cloakedRec["class"] := "TestClass"
-    cloakedRec["pid"] := 999
-    cloakedRec["isVisible"] := true
-    cloakedRec["isCloaked"] := true  ; CLOAKED - simulates other workspace
-    cloakedRec["isMinimized"] := false
-    cloakedRec["z"] := 1
-    cloakedRec["exePath"] := A_WinDir "\notepad.exe"
+    cloakedRec := _TestRec(Map("hwnd", cloakedHwnd, "title", "Test Cloaked Window",
+                                "pid", 999, "isCloaked", true, "z", 1,
+                                "exePath", A_WinDir "\notepad.exe"))
     WL_UpsertWindow([cloakedRec], "test")
 
     ; Create a minimized window record
     minHwnd := 88888
-    minRec := Map()
-    minRec["hwnd"] := minHwnd
-    minRec["title"] := "Test Minimized Window"
-    minRec["class"] := "TestClass"
-    minRec["pid"] := 998
-    minRec["isVisible"] := false  ; Minimized windows often have isVisible=false
-    minRec["isCloaked"] := false
-    minRec["isMinimized"] := true  ; MINIMIZED
-    minRec["z"] := 2
-    minRec["exePath"] := A_WinDir "\explorer.exe"
+    minRec := _TestRec(Map("hwnd", minHwnd, "title", "Test Minimized Window",
+                            "pid", 998, "isVisible", false, "isMinimized", true, "z", 2,
+                            "exePath", A_WinDir "\explorer.exe"))
     WL_UpsertWindow([minRec], "test")
 
     WL_EndScan()
@@ -411,18 +375,10 @@ RunUnitTests_Storage() {
 
     ; Create a window with WM_GETICON icon (eligible for refresh)
     refreshHwnd := 66666
-    refreshRec := Map()
-    refreshRec["hwnd"] := refreshHwnd
-    refreshRec["title"] := "Test Refresh Window"
-    refreshRec["class"] := "TestClass"
-    refreshRec["pid"] := 997
-    refreshRec["isVisible"] := true
-    refreshRec["isCloaked"] := false
-    refreshRec["isMinimized"] := false
-    refreshRec["z"] := 1
-    refreshRec["iconHicon"] := 12345  ; Has icon
-    refreshRec["iconMethod"] := "wm_geticon"  ; Got it via WM_GETICON
-    refreshRec["iconLastRefreshTick"] := 0  ; Never refreshed
+    refreshRec := _TestRec(Map("hwnd", refreshHwnd, "title", "Test Refresh Window",
+                                "pid", 997, "z", 1,
+                                "iconHicon", 12345, "iconMethod", "wm_geticon",
+                                "iconLastRefreshTick", 0))
     WL_UpsertWindow([refreshRec], "test")
     WL_EndScan()
 
@@ -473,17 +429,9 @@ RunUnitTests_Storage() {
 
     ; Create a window that started cloaked (got EXE icon), now visible
     upgradeHwnd := 55555
-    upgradeRec := Map()
-    upgradeRec["hwnd"] := upgradeHwnd
-    upgradeRec["title"] := "Test Upgrade Window"
-    upgradeRec["class"] := "TestClass"
-    upgradeRec["pid"] := 996
-    upgradeRec["isVisible"] := true  ; NOW visible
-    upgradeRec["isCloaked"] := false  ; NOT cloaked anymore
-    upgradeRec["isMinimized"] := false
-    upgradeRec["z"] := 1
-    upgradeRec["iconHicon"] := 12345  ; Has icon
-    upgradeRec["iconMethod"] := "exe"  ; Got it via EXE fallback (not WM_GETICON)
+    upgradeRec := _TestRec(Map("hwnd", upgradeHwnd, "title", "Test Upgrade Window",
+                                "pid", 996, "z", 1,
+                                "iconHicon", 12345, "iconMethod", "exe"))
     WL_UpsertWindow([upgradeRec], "test")
     WL_EndScan()
 
@@ -665,12 +613,9 @@ RunUnitTests_Storage() {
     WL_Init()
     gWS_ProcNameCache := Map()
     WL_BeginScan()
-    fanRec1 := Map("hwnd", 0xBB01, "title", "Fan Win 1", "class", "Test", "pid", 500,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
-    fanRec2 := Map("hwnd", 0xBB02, "title", "Fan Win 2", "class", "Test", "pid", 500,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2)
-    fanRec3 := Map("hwnd", 0xBB03, "title", "Other PID", "class", "Test", "pid", 600,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 3)
+    fanRec1 := _TestRec(Map("hwnd", 0xBB01, "title", "Fan Win 1", "class", "Test", "pid", 500, "z", 1))
+    fanRec2 := _TestRec(Map("hwnd", 0xBB02, "title", "Fan Win 2", "class", "Test", "pid", 500, "z", 2))
+    fanRec3 := _TestRec(Map("hwnd", 0xBB03, "title", "Other PID", "class", "Test", "pid", 600, "z", 3))
     WL_UpsertWindow([fanRec1, fanRec2, fanRec3], "test")
     WL_EndScan()
     ; Drain icon queue from upserts
@@ -702,8 +647,7 @@ RunUnitTests_Storage() {
     WL_Init()
     gWS_ProcNameCache := Map()
     WL_BeginScan()
-    revRec := Map("hwnd", 0xBB04, "title", "Rev Test", "class", "Test", "pid", 700,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
+    revRec := _TestRec(Map("hwnd", 0xBB04, "title", "Rev Test", "class", "Test", "pid", 700, "z", 1))
     WL_UpsertWindow([revRec], "test")
     WL_EndScan()
     WL_PopIconBatch(100)
@@ -1127,30 +1071,27 @@ RunUnitTests_Storage() {
     WL_BeginScan()
 
     ; Window 1: normal, visible, on current workspace, MRU=1000
-    projRec1 := Map("hwnd", 0xF001, "title", "Zulu Window", "class", "Test", "pid", 10,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 3,
-                     "lastActivatedTick", 1000, "isFocused", false,
-                     "workspaceName", "Desktop 1", "isOnCurrentWorkspace", true, "processName", "zulu.exe")
+    projRec1 := _TestRec(Map("hwnd", 0xF001, "title", "Zulu Window", "class", "Test", "pid", 10,
+                              "z", 3, "lastActivatedTick", 1000, "isFocused", false,
+                              "workspaceName", "Desktop 1", "isOnCurrentWorkspace", true, "processName", "zulu.exe"))
     ; Window 2: cloaked (other workspace), MRU=3000 (most recent)
-    projRec2 := Map("hwnd", 0xF002, "title", "Alpha Window", "class", "Test", "pid", 20,
-                     "isVisible", true, "isCloaked", true, "isMinimized", false, "z", 1,
-                     "lastActivatedTick", 3000, "isFocused", false,
-                     "workspaceName", "Desktop 2", "isOnCurrentWorkspace", false, "processName", "alpha.exe")
+    projRec2 := _TestRec(Map("hwnd", 0xF002, "title", "Alpha Window", "class", "Test", "pid", 20,
+                              "isCloaked", true, "z", 1, "lastActivatedTick", 3000, "isFocused", false,
+                              "workspaceName", "Desktop 2", "isOnCurrentWorkspace", false, "processName", "alpha.exe"))
     ; Window 3: minimized, on current workspace, MRU=2000
-    projRec3 := Map("hwnd", 0xF003, "title", "Middle Window", "class", "Test", "pid", 5,
-                     "isVisible", false, "isCloaked", false, "isMinimized", true, "z", 5,
-                     "lastActivatedTick", 2000, "isFocused", false,
-                     "workspaceName", "Desktop 1", "isOnCurrentWorkspace", true, "processName", "middle.exe")
+    projRec3 := _TestRec(Map("hwnd", 0xF003, "title", "Middle Window", "class", "Test", "pid", 5,
+                              "isVisible", false, "isMinimized", true, "z", 5, "lastActivatedTick", 2000,
+                              "isFocused", false, "workspaceName", "Desktop 1", "isOnCurrentWorkspace", true,
+                              "processName", "middle.exe"))
     ; Window 4: normal, visible, on current workspace, MRU=500
-    projRec4 := Map("hwnd", 0xF004, "title", "Beta Window", "class", "Test", "pid", 30,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2,
-                     "lastActivatedTick", 500, "isFocused", false,
-                     "workspaceName", "Desktop 1", "isOnCurrentWorkspace", true, "processName", "beta.exe")
+    projRec4 := _TestRec(Map("hwnd", 0xF004, "title", "Beta Window", "class", "Test", "pid", 30,
+                              "z", 2, "lastActivatedTick", 500, "isFocused", false,
+                              "workspaceName", "Desktop 1", "isOnCurrentWorkspace", true, "processName", "beta.exe"))
     ; Window 5: cloaked + minimized, other workspace, MRU=100
-    projRec5 := Map("hwnd", 0xF005, "title", "Echo Window", "class", "Test", "pid", 15,
-                     "isVisible", false, "isCloaked", true, "isMinimized", true, "z", 4,
-                     "lastActivatedTick", 100, "isFocused", false,
-                     "workspaceName", "Desktop 2", "isOnCurrentWorkspace", false, "processName", "echo.exe")
+    projRec5 := _TestRec(Map("hwnd", 0xF005, "title", "Echo Window", "class", "Test", "pid", 15,
+                              "isVisible", false, "isCloaked", true, "isMinimized", true, "z", 4,
+                              "lastActivatedTick", 100, "isFocused", false,
+                              "workspaceName", "Desktop 2", "isOnCurrentWorkspace", false, "processName", "echo.exe"))
 
     WL_UpsertWindow([projRec1, projRec2, projRec3, projRec4, projRec5], "test")
     WL_EndScan()
@@ -1281,12 +1222,10 @@ RunUnitTests_Storage() {
     gWS_PidQueueDedup := Map()
 
     WL_BeginScan()
-    pidRec1 := Map("hwnd", 0xDD01, "title", "PID Win 1", "class", "Test", "pid", 7001,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1,
-                   "processName", "")
-    pidRec2 := Map("hwnd", 0xDD02, "title", "PID Win 2", "class", "Test", "pid", 7002,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2,
-                   "processName", "")
+    pidRec1 := _TestRec(Map("hwnd", 0xDD01, "title", "PID Win 1", "class", "Test", "pid", 7001,
+                             "z", 1, "processName", ""))
+    pidRec2 := _TestRec(Map("hwnd", 0xDD02, "title", "PID Win 2", "class", "Test", "pid", 7002,
+                             "z", 2, "processName", ""))
     WL_UpsertWindow([pidRec1, pidRec2], "test")
     WL_EndScan()
     WL_PopIconBatch(100)  ; Drain icon queue (not testing icons here)
@@ -1325,12 +1264,10 @@ RunUnitTests_Storage() {
     gWS_PidQueueDedup := Map()
 
     WL_BeginScan()
-    dedupRec1 := Map("hwnd", 0xDD03, "title", "Dedup Win 1", "class", "Test", "pid", 8001,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1,
-                     "processName", "")
-    dedupRec2 := Map("hwnd", 0xDD04, "title", "Dedup Win 2", "class", "Test", "pid", 8001,
-                     "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2,
-                     "processName", "")
+    dedupRec1 := _TestRec(Map("hwnd", 0xDD03, "title", "Dedup Win 1", "class", "Test", "pid", 8001,
+                               "z", 1, "processName", ""))
+    dedupRec2 := _TestRec(Map("hwnd", 0xDD04, "title", "Dedup Win 2", "class", "Test", "pid", 8001,
+                               "z", 2, "processName", ""))
     WL_UpsertWindow([dedupRec1, dedupRec2], "test")
     WL_EndScan()
     WL_PopIconBatch(100)
@@ -1371,12 +1308,9 @@ RunUnitTests_Storage() {
     gWS_PidQueueDedup := Map()
 
     WL_BeginScan()
-    ghRec1 := Map("hwnd", 0xEE01, "title", "GH Win 1", "class", "Test", "pid", 9001,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1)
-    ghRec2 := Map("hwnd", 0xEE02, "title", "GH Win 2", "class", "Test", "pid", 9002,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 2)
-    ghRec3 := Map("hwnd", 0xEE03, "title", "GH Win 3", "class", "Test", "pid", 9001,
-                  "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 3)
+    ghRec1 := _TestRec(Map("hwnd", 0xEE01, "title", "GH Win 1", "class", "Test", "pid", 9001, "z", 1))
+    ghRec2 := _TestRec(Map("hwnd", 0xEE02, "title", "GH Win 2", "class", "Test", "pid", 9002, "z", 2))
+    ghRec3 := _TestRec(Map("hwnd", 0xEE03, "title", "GH Win 3", "class", "Test", "pid", 9001, "z", 3))
     WL_UpsertWindow([ghRec1, ghRec2, ghRec3], "test")
     WL_EndScan()
 
@@ -1440,9 +1374,8 @@ RunUnitTests_Storage() {
     gWS_PidQueueDedup := Map()
 
     WL_BeginScan()
-    enqRec1 := Map("hwnd", 0xFF01, "title", "Enq Win 1", "class", "Test", "pid", 5001,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1,
-                   "processName", "test.exe")  ; Has processName (no PID enqueue)
+    enqRec1 := _TestRec(Map("hwnd", 0xFF01, "title", "Enq Win 1", "class", "Test", "pid", 5001,
+                             "z", 1, "processName", "test.exe"))  ; Has processName (no PID enqueue)
     WL_UpsertWindow([enqRec1], "test")
     WL_EndScan()
 
@@ -1468,10 +1401,9 @@ RunUnitTests_Storage() {
     gWS_PidQueueDedup := Map()
 
     WL_BeginScan()
-    enqRec2 := Map("hwnd", 0xFF02, "title", "Enq Win 2", "class", "Test", "pid", 5002,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1,
-                   "iconHicon", 12345, "iconMethod", "exe",
-                   "processName", "test.exe")
+    enqRec2 := _TestRec(Map("hwnd", 0xFF02, "title", "Enq Win 2", "class", "Test", "pid", 5002,
+                             "z", 1, "iconHicon", 12345, "iconMethod", "exe",
+                             "processName", "test.exe"))
     WL_UpsertWindow([enqRec2], "test")
     WL_EndScan()
 
@@ -1497,10 +1429,9 @@ RunUnitTests_Storage() {
     gWS_PidQueueDedup := Map()
 
     WL_BeginScan()
-    enqRec3 := Map("hwnd", 0xFF03, "title", "Enq Win 3", "class", "Test", "pid", 5003,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1,
-                   "iconHicon", 12345, "iconMethod", "wm_geticon",
-                   "processName", "test.exe")
+    enqRec3 := _TestRec(Map("hwnd", 0xFF03, "title", "Enq Win 3", "class", "Test", "pid", 5003,
+                             "z", 1, "iconHicon", 12345, "iconMethod", "wm_geticon",
+                             "processName", "test.exe"))
     WL_UpsertWindow([enqRec3], "test")
     WL_EndScan()
 
@@ -1526,10 +1457,9 @@ RunUnitTests_Storage() {
     gWS_PidQueueDedup := Map()
 
     WL_BeginScan()
-    enqRec4 := Map("hwnd", 0xFF04, "title", "Enq Win 4", "class", "Test", "pid", 5004,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1,
-                   "iconHicon", 12345, "iconMethod", "wm_geticon",
-                   "processName", "")  ; Empty processName
+    enqRec4 := _TestRec(Map("hwnd", 0xFF04, "title", "Enq Win 4", "class", "Test", "pid", 5004,
+                             "z", 1, "iconHicon", 12345, "iconMethod", "wm_geticon",
+                             "processName", ""))  ; Empty processName
     WL_UpsertWindow([enqRec4], "test")
     WL_EndScan()
     WL_PopIconBatch(100)  ; Drain icon queue
@@ -1556,10 +1486,9 @@ RunUnitTests_Storage() {
     gWS_PidQueueDedup := Map()
 
     WL_BeginScan()
-    enqRec5 := Map("hwnd", 0xFF05, "title", "Enq Win 5", "class", "Test", "pid", 5005,
-                   "isVisible", true, "isCloaked", false, "isMinimized", false, "z", 1,
-                   "iconHicon", 12345, "iconMethod", "wm_geticon",
-                   "processName", "already.exe")  ; Has processName
+    enqRec5 := _TestRec(Map("hwnd", 0xFF05, "title", "Enq Win 5", "class", "Test", "pid", 5005,
+                             "z", 1, "iconHicon", 12345, "iconMethod", "wm_geticon",
+                             "processName", "already.exe"))  ; Has processName
     WL_UpsertWindow([enqRec5], "test")
     WL_EndScan()
     WL_PopIconBatch(100)

--- a/tests/test_utils.ahk
+++ b/tests/test_utils.ahk
@@ -136,6 +136,39 @@ WaitForFlag(&flag, timeoutMs := 2000, pollMs := 20) {
     return flag
 }
 
+; --- WindowList Test Setup Helpers ---
+
+; Build a standard test window record as Map with sensible defaults.
+; Pass overrides as a Map to customize specific fields.
+; Example: _TestRec(Map("hwnd", 12345, "title", "My Window"))
+_TestRec(overrides := "") {
+    rec := Map(
+        "hwnd", 1,
+        "title", "Test Window",
+        "class", "TestClass",
+        "pid", 100,
+        "isVisible", true,
+        "isCloaked", false,
+        "isMinimized", false,
+        "z", 1
+    )
+    if (IsObject(overrides)) {
+        for k, v in overrides
+            rec[k] := v
+    }
+    return rec
+}
+
+; Init store, upsert records, end scan. Wraps the common 4-line test setup.
+; records: array of Map records (build with _TestRec or manually)
+; endScanTTL: optional TTL param for WL_EndScan (default 0 = no TTL)
+_TestSetupStore(records, endScanTTL := 0) {
+    WL_Init()
+    WL_BeginScan()
+    WL_UpsertWindow(records, "test")
+    WL_EndScan(endScanTTL)
+}
+
 ; Join array elements with a separator
 _JoinArray(arr, sep) {
     result := ""


### PR DESCRIPTION
## Summary

- **Error handling**: Log caught errors in WEH MRU fallback instead of silent `catch {}`; add IPC security descriptor failure diagnostic
- **DRY**: Consolidate vis/min/cloak probe into public `BL_ProbeVisMinCloak()` used by both `blacklist.ahk` and `win_utils.ahk`; extract `_ParseLauncherHwnd()` for editor mode handlers; separate `_CL_ComputeDerivedGlobals()` from `_CL_ValidateSettings()`
- **Dead code**: Remove `IconPump_IsRunning()` (zero callers, lint-suppressed)
- **Test quality**: Add `_TestRec()` and `_TestSetupStore()` helpers to reduce boilerplate; fix stale architecture comment

Closes #10

## Test plan

- [x] Full test suite passes (762/762: static 62, unit 505, live 33, GUI 224)
- [x] Static analysis passes (62 checks including function visibility for renamed `BL_ProbeVisMinCloak`)
- [x] Config test updated to call `_CL_ComputeDerivedGlobals()` after `_CL_ValidateSettings()`
- [x] Compilation succeeds (live tests exercise compiled exe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)