### PR TITLE
Make 2 file-internal functions private (_prefix)

### DIFF
--- a/src/core/icon_pump.ahk
+++ b/src/core/icon_pump.ahk
@@ -346,7 +346,7 @@ _IP_Tick() {
 
         if (mode = IP_MODE_VISIBLE_RETRY || mode = IP_MODE_FOCUS_RECHECK) {
             ; Only try WM_GETICON for upgrade/refresh (window must be visible)
-            h := IP_TryResolveFromWindow(hwnd)
+            h := _IP_TryResolveFromWindow(hwnd)
             if (h) {
                 method := IP_METHOD_WM_GETICON
             }
@@ -355,7 +355,7 @@ _IP_Tick() {
 
             ; Try WM_GETICON first (only if visible)
             if (!isHidden) {
-                h := IP_TryResolveFromWindow(hwnd)
+                h := _IP_TryResolveFromWindow(hwnd)
                 if (h) {
                     method := IP_METHOD_WM_GETICON
                 }
@@ -514,7 +514,7 @@ IP_GetRawWindowIcon(hWnd) {
 ; Try to get icon from window via WM_GETICON or class icon (returns owned copy).
 ; Prefer larger icons (ICON_BIG=32x32) over small (16x16) since we display at 36px+
 ; Uses SendMessageTimeoutW with SMTO_ABORTIFHUNG to avoid blocking on hung windows.
-IP_TryResolveFromWindow(hWnd) {
+_IP_TryResolveFromWindow(hWnd) {
     h := IP_GetRawWindowIcon(hWnd)
     if (h)
         return DllCall("user32\CopyIcon", "ptr", h, "ptr")

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -429,7 +429,7 @@ GUI_ApplyWorkspaceFilter() {
     Critical "On"
     gGUI_DisplayItems := GUI_FilterByWorkspaceMode(gGUI_ToggleBase)
     Critical "Off"
-    GUI_ResetSelectionToMRU()
+    _GUI_ResetSelectionToMRU()
     rowsDesired := GUI_ComputeRowsToShow(gGUI_DisplayItems.Length)
     GUI_ResizeToRows(rowsDesired)
     GUI_Repaint()
@@ -441,7 +441,7 @@ GUI_ApplyWorkspaceFilter() {
 ; Parameters:
 ;   listRef - Optional reference to the list to use (default: gGUI_DisplayItems)
 ; Returns: The new selection index
-GUI_ResetSelectionToMRU(listRef := "") {
+_GUI_ResetSelectionToMRU(listRef := "") {
     global gGUI_Sel, gGUI_ScrollTop, gGUI_DisplayItems, gGUI_WSContextSwitch
     items := (listRef != "") ? listRef : gGUI_DisplayItems
 


### PR DESCRIPTION
## Summary

- Renamed `IP_TryResolveFromWindow` → `_IP_TryResolveFromWindow` in `icon_pump.ahk` (only called from `_IP_Tick` within the same file)
- Renamed `GUI_ResetSelectionToMRU` → `_GUI_ResetSelectionToMRU` in `gui_state.ahk` (only called from `GUI_ApplyWorkspaceFilter` within the same file)
- `IconPump_IsRunning` and `ProcPump_IsRunning` left public (intentional status API with `lint-ignore: dead-function`)

Closes #15

## Test plan

- [x] All 772 tests pass (unit, GUI, live)
- [x] Static analysis pre-gate passes (62 checks)
- [x] `query_visibility.ps1` confirms 0-caller candidates drop from 4 → 2
- [x] `check_function_visibility.ps1` confirms both functions now show as private

🤖 Generated with [Claude Code](https://claude.com/claude-code)