### PR TITLE
Fix wizard writing RunAsAdmin=true after CreateAdminTask failure

### DIFF
--- a/src/launcher/launcher_wizard.ahk
+++ b/src/launcher/launcher_wizard.ahk
@@ -296,7 +296,7 @@ _WizardApplyChoices(startMenu, startup, install, admin, autoUpdate) {
                 } else {
                     ; Task creation failed - notify user
                     ThemeMsgBox("Admin mode could not be enabled.`nAlt-Tabby will run with standard permissions — most features still work.", APP_NAME, "Icon!")
-                    ; Don't set cfg.SetupRunAsAdmin since task creation failed
+                    admin := false  ; Prevent Step 3 (line 312) from writing RunAsAdmin=true
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

- Fixed `_WizardApplyChoices()` leaving `RunAsAdmin=true` in config when `CreateAdminTask()` fails
- The `admin` variable was not set to `false` on task creation failure, so `Setup_SetRunAsAdmin(admin)` at line 312 wrote `true` despite no task existing
- Added `admin := false` after the failure ThemeMsgBox, matching the existing pattern at line 291 for the temp-location warning path

Closes #18

## Test plan

- [x] Static analysis pre-gate passes (62 checks)
- [x] All 772 tests pass (unit, GUI, live, lifecycle)
- [x] Verified the fix mirrors existing pattern at line 291
- [ ] Manual: run wizard with Task Scheduler service stopped, confirm config shows `RunAsAdmin=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)