### PR TITLE
Reduce ownership.manifest coupling (8 → 6 entries)

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -21,8 +21,6 @@
 #   Discover full landscape: powershell -File tests/check_global_ownership.ps1 -Discover
 
 cfg: config_loader, launcher_tray, setup_utils
-gGUI_CurrentWSName: gui_main, gui_state
-gGUI_DisplayItems: gui_state
 gGUI_LiveItems: gui_state, gui_data
 gGUI_OverlayVisible: gui_overlay, gui_state
 gGUI_Revealed: gui_overlay, gui_paint, gui_state

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -66,6 +66,7 @@ global gStats_LastSent := Map()
 
 ; Store globals (mocked for GUI tests — production uses embedded store in gui_main.ahk)
 global gWS_Store := Map()
+global gWS_Meta := Map()
 global gWS_DirtyHwnds := Map()
 
 ; Cosmetic repaint debounce (from gui_main.ahk - not included in GUI test chain)
@@ -76,6 +77,7 @@ global DWMWA_CLOAKED := 14
 
 ; Constants from config_loader.ahk
 global LOG_PATH_EVENTS := A_Temp "\tabby_events.log"
+global LOG_PATH_STORE := A_Temp "\tabby_store_error.log"
 global LOG_PATH_COSMETIC_PATCH := A_Temp "\tabby_cosmetic_patch.log"
 
 ; Cached config values (from config_loader.ahk _CL_CacheHotPathValues)


### PR DESCRIPTION
## Summary

- Move `gGUI_DisplayItems` declaration from `gui_main.ahk` to `gui_state.ahk` (sole writer, 7 mutations)
- Move `gGUI_CurrentWSName` declaration and `_GUI_OnWorkspaceFlips()` callback to `gui_state.ahk` (workspace state owner)
- Rename `_GUI_OnWorkspaceFlips` → `GUI_OnWorkspaceFlips` (public, called via cross-file callback)
- Remove 2 manifest entries; manifest reduced from 8 → 6 entries, coupling hotspots from 7 → 6

Closes #22

## Test plan

- [x] Static analysis pre-gate passes (63 checks)
- [x] All 772 tests pass (224 GUI + 505 unit + 43 live)
- [x] `check_global_ownership.ps1 -Generate` confirms manifest is up to date (6 entries)
- [x] `check_global_ownership.ps1 -Discover` confirms hotspots reduced from 7 to 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)