### PR TITLE
Fix elevated mismatch-update config overwrite & add GUI watchdog

### DIFF
--- a/src/launcher/launcher_install.ahk
+++ b/src/launcher/launcher_install.ahk
@@ -274,7 +274,7 @@ _Launcher_UpdateInstalledVersion(installedPath) {
 ; Actually perform the update (called directly or after elevation)
 ; Wrapper for mismatch update flow - uses Update_ApplyCore with appropriate options
 Launcher_DoUpdateInstalled(sourcePath, targetPath) {
-    global cfg, g_GuiPID, g_PumpPID, g_WizardSkippedForExistingInstall
+    global cfg, g_GuiPID, g_PumpPID
     if (cfg.DiagLauncherLog)
         Launcher_Log("UPDATE_INSTALLED source=" sourcePath " target=" targetPath)
     Update_ApplyCore({
@@ -285,7 +285,7 @@ Launcher_DoUpdateInstalled(sourcePath, targetPath) {
         copyMode: true,                ; FileCopy (keep source - it's the running exe)
         successMessage: "Alt-Tabby has been updated at:`n" targetPath,
         cleanupSourceOnFailure: false, ; Don't delete source - it's the running exe
-        overwriteUserData: cfg.SetupFirstRunCompleted && !g_WizardSkippedForExistingInstall,  ; Only push config if source was user-configured (not auto-skipped wizard)
+        overwriteUserData: false,      ; Mismatch-update preserves target config (exe update only)
         killPids: {gui: g_GuiPID, pump: g_PumpPID}
     })
 }

--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -17,10 +17,6 @@ global g_ActiveMutex := 0
 global g_LastFullRestartTick   ; Debounce RESTART_ALL signals
 global LAUNCHER_RESTART_DEBOUNCE_MS := 5000
 
-; Bug 1 fix: Track when wizard was skipped due to existing PF install (not user-configured)
-; Used to prevent overwriteUserData false positive in Launcher_DoUpdateInstalled
-global g_WizardSkippedForExistingInstall := false
-
 ; Win32 error code
 global ERROR_ALREADY_EXISTS := 183
 
@@ -63,7 +59,6 @@ Launcher_LogStartup() {
 Launcher_Init() {
     global g_GuiPID, g_MismatchDialogShown, g_TestingMode, cfg, gConfigIniPath
     global ALTTABBY_TASK_NAME, TIMING_MUTEX_RELEASE_WAIT, TIMING_SUBPROCESS_LAUNCH, TIMING_TASK_INIT_WAIT, g_SplashStartTick, APP_NAME
-    global g_WizardSkippedForExistingInstall
 
     ; Log startup (clears old log if DiagLauncherLog is enabled)
     Launcher_LogStartup()
@@ -162,8 +157,7 @@ Launcher_Init() {
         ; but there's a Program Files install with a valid config
         if (_Launcher_ShouldSkipWizardForExistingInstall()) {
             ; Mismatch check will run on next iteration (already ran above)
-            ; Mark wizard as complete on disk + flag that source wasn't user-configured
-            g_WizardSkippedForExistingInstall := true
+            ; Mark wizard as complete on disk so we don't show wizard again
             Setup_SetFirstRunCompleted(true)
         } else {
             ; Show first-run wizard
@@ -228,6 +222,10 @@ Launcher_StartSubprocesses() {
 
     ; Launch GUI (store runs in-process within GUI)
     LaunchGui()
+
+    ; Start GUI watchdog to detect unexpected crashes (skip in testing mode)
+    if (!g_TestingMode)
+        _Launcher_StartGuiWatchdog()
 
     ; In testing mode, write our HWND + child PIDs to temp file so lifecycle tests
     ; can send WM_COPYDATA and identify which child is GUI vs pump.
@@ -422,16 +420,20 @@ _Launcher_RestartSubprocesses() {
     Launcher_ShutdownSubprocesses()
     LaunchPump()
     LaunchGui()
+    _Launcher_StartGuiWatchdog()
 }
 
 Launcher_RestartGui() {
     global g_GuiPID, TIMING_SUBPROCESS_LAUNCH
+    _Launcher_StopGuiWatchdog()
     LauncherUtils_Restart("gui", &g_GuiPID, TIMING_SUBPROCESS_LAUNCH, Launcher_Log)
+    _Launcher_StartGuiWatchdog()
 }
 
 ; Kills subprocesses + resets PIDs. Optional editor PIDs passed by caller.
 Launcher_ShutdownSubprocesses(editors := 0) {
     global g_GuiPID, g_PumpPID
+    _Launcher_StopGuiWatchdog()
     opts := {pids: {gui: g_GuiPID, pump: g_PumpPID}}
     if (IsObject(editors))
         opts.editors := editors
@@ -943,6 +945,35 @@ LaunchGui() {
             APP_NAME, "Iconx")
     }
     Dash_Refresh()
+}
+
+; ============================================================
+; GUI PROCESS WATCHDOG
+; ============================================================
+; Detects unexpected GUI process exit and auto-restarts.
+; The pump has a recovery path (GUI sends TABBY_CMD_PUMP_FAILED to launcher),
+; but if the GUI itself dies, nobody sends that notification.
+; This low-frequency timer fills that gap.
+
+_Launcher_GuiWatchdog() {
+    global g_GuiPID, APP_NAME, cfg
+    if (g_GuiPID != 0 && !ProcessExist(g_GuiPID)) {
+        if (cfg.DiagLauncherLog)
+            Launcher_Log("WATCHDOG: GUI process " g_GuiPID " no longer exists, restarting")
+        g_GuiPID := 0
+        TrayTip(APP_NAME, "The overlay process exited unexpectedly. Restarting...", "Icon!")
+        LaunchGui()
+        Dash_Refresh()
+    }
+}
+
+_Launcher_StartGuiWatchdog() {
+    global TIMING_GUI_WATCHDOG_INTERVAL
+    SetTimer(_Launcher_GuiWatchdog, TIMING_GUI_WATCHDOG_INTERVAL)
+}
+
+_Launcher_StopGuiWatchdog() {
+    SetTimer(_Launcher_GuiWatchdog, 0)
 }
 
 ; (LaunchViewer removed — viewer is now in-process within GUI, toggled via tray menu)

--- a/src/shared/config_loader.ahk
+++ b/src/shared/config_loader.ahk
@@ -843,6 +843,7 @@ global TIMING_PROCESS_TERMINATE_WAIT := 100  ; Wait for process to terminate
 global TIMING_FILE_WRITE_WAIT := 100     ; Wait for file to write
 global TIMING_PIPE_RETRY_WAIT := 50      ; Pipe connection retry delay
 global TIMING_SETUP_SETTLE := 200        ; Setup settle delay
+global TIMING_GUI_WATCHDOG_INTERVAL := 30000  ; GUI process health check interval (30s)
 
 ; Tooltip durations (milliseconds)
 ; Derived from cfg.GUI_TooltipDurationMs in _CL_ValidateSettings()


### PR DESCRIPTION
## Summary

- **Fix config overwrite bug**: `Launcher_DoUpdateInstalled()` could overwrite Program Files config with defaults when the `g_WizardSkippedForExistingInstall` flag failed to propagate across the elevation boundary. Hardcoded `overwriteUserData: false` since mismatch-update intent is always "copy exe, preserve config"
- **Remove dead global**: Cleaned up `g_WizardSkippedForExistingInstall` (declaration, setter, global statements) — no remaining consumers after the fix
- **Add GUI watchdog**: 30s timer in the launcher detects unexpected GUI process exit and auto-restarts the overlay with a TrayTip notification. Properly stopped during intentional shutdown/restart sequences
- **Add timing constant**: `TIMING_GUI_WATCHDOG_INTERVAL` (30000ms) follows existing `TIMING_*` pattern

Closes #24

## Test plan

- [x] Static analysis pre-gate passes (all 44 checks)
- [x] All unit tests pass (505/505)
- [x] All GUI tests pass (224/224)
- [x] All live tests pass (43/43 across 5 suites)
- [ ] Manual: Kill GUI process via Task Manager, verify TrayTip appears and overlay auto-restarts within 30s
- [ ] Manual: Run newer download against existing PF install → "Yes" to update → verify PF config preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)