### PR TITLE
Remove dead code: unused functions and stale lint-ignore

### DIFF
--- a/src/core/proc_pump.ahk
+++ b/src/core/proc_pump.ahk
@@ -92,12 +92,6 @@ ProcPump_Stop() {
     SetTimer(_PP_Tick, 0)
 }
 
-; Query whether the process pump timer is running
-ProcPump_IsRunning() { ; lint-ignore: dead-function
-    global _PP_TimerOn
-    return _PP_TimerOn
-}
-
 ; Query whether the process pump has been configured (may be idle-paused but functional)
 ProcPump_IsEnabled() {
     global ProcTimerIntervalMs

--- a/src/shared/blacklist.ahk
+++ b/src/shared/blacklist.ahk
@@ -284,13 +284,6 @@ Blacklist_IsWindowEligible(hwnd, title := "", class := "") {
     return Blacklist_IsWindowEligibleEx(hwnd, title, class, &vis, &min, &clk)
 }
 
-; Alt-Tab eligibility rules (matches Windows behavior)
-; Delegates to Ex variant for shared implementation
-_BL_IsAltTabEligible(hwnd) {
-    vis := false, min := false, clk := false
-    return _BL_IsAltTabEligibleEx(hwnd, &vis, &min, &clk)
-}
-
 ; Shared vis/min/cloak probe — single source for the DllCall trio
 ; Used by _BL_IsAltTabEligibleEx, Blacklist_IsWindowEligibleEx, and WinUtils_ProbeWindow
 BL_ProbeVisMinCloak(hwnd, &outVis, &outMin, &outCloak) {

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -12,7 +12,7 @@ global WS_SCAN_ID_MAX := 0x7FFFFFFF
 ; Canonical list of fields copied from store records into display list items.
 ; Used by static analysis (check_batch_patterns) to verify _WS_ToItem stays in sync.
 ; hwnd is always included separately as the record key.
-global DISPLAY_FIELDS := ["title", "class", "pid", "z", "lastActivatedTick", ; lint-ignore: dead-global
+global DISPLAY_FIELDS := ["title", "class", "pid", "z", "lastActivatedTick",
     "isFocused", "isCloaked", "isMinimized", "workspaceName", "workspaceId",
     "isOnCurrentWorkspace", "processName", "iconHicon"]
 


### PR DESCRIPTION
## Summary
- Remove `ProcPump_IsRunning()` — zero callers, already lint-ignored as dead
- Remove `_BL_IsAltTabEligible()` — private wrapper with zero callers; all callsites use `_BL_IsAltTabEligibleEx()` directly
- Remove incorrect `lint-ignore: dead-global` from `DISPLAY_FIELDS` (actually used by `check_batch_patterns.ps1` and `test_unit_core_store.ahk`)

Closes #29

## Test plan
- [x] Static analysis pre-gate passes (63 checks)
- [x] All 772 tests pass (unit, GUI, live, core, network, execution, features, lifecycle)
- [x] Compilation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)