### PR TITLE
Promote 5 hardcoded constants to config registry

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -28,3 +28,4 @@ gGUI_OverlayVisible: gui_overlay, gui_state
 gGUI_Revealed: gui_overlay, gui_paint, gui_state
 gGUI_ScrollTop: gui_input, gui_paint, gui_state
 gGUI_Sel: gui_input, gui_state
+gViewer_RefreshIntervalMs: gui_main

--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -53,7 +53,7 @@ global _KSub_ReadBufferLen := 0    ; Tracked length to avoid O(n) StrLen calls
 global _KSub_LastWorkspaceName := ""
 global _KSub_FallbackMode := false
 global _KSub_LastPromotionTick := 0
-global _KSub_PromotionIntervalMs := 30000  ; 30s between subscription promotion attempts
+global _KSub_PromotionIntervalMs  ; Set from cfg.KomorebiSubPromotionRetryMs at init
 
 ; Cache of window workspace assignments (persists even when windows leave komorebi)
 ; Each entry is { wsName: "name", tick: timestamp } for staleness detection
@@ -74,7 +74,7 @@ global _KSub_FocusedHwndByWS := Map()
 global gKSub_MruSuppressUntilTick := 0
 
 ; Delay before initial komorebi poll (wait for winenum to populate store first)
-global KSUB_INITIAL_POLL_DELAY_MS := 1500
+global KSUB_INITIAL_POLL_DELAY_MS  ; Set from cfg.KomorebiSubInitialPollDelayMs at init
 
 ; Cloak event batching state
 global _KSub_CloakPushPending := false
@@ -88,12 +88,14 @@ KomorebiSub_Init() {
     global _KSub_FallbackMode
 
     ; Load config values (ConfigLoader_Init has already run)
-    global KSub_MruSuppressionMs
+    global KSub_MruSuppressionMs, _KSub_PromotionIntervalMs, KSUB_INITIAL_POLL_DELAY_MS
     KSub_PollMs := cfg.KomorebiSubPollMs
     KSub_IdleRecycleMs := cfg.KomorebiSubIdleRecycleMs
     KSub_FallbackPollMs := cfg.KomorebiSubFallbackPollMs
     _KSub_CacheMaxAgeMs := cfg.KomorebiSubCacheMaxAgeMs
     KSub_MruSuppressionMs := cfg.KomorebiMruSuppressionMs
+    _KSub_PromotionIntervalMs := cfg.KomorebiSubPromotionRetryMs
+    KSUB_INITIAL_POLL_DELAY_MS := cfg.KomorebiSubInitialPollDelayMs
 
     _KSub_PipeName := "tabby_" A_TickCount "_" Random(1000, 9999)
     _KSub_WorkspaceCache := Map()

--- a/src/editors/config_editor_native.ahk
+++ b/src/editors/config_editor_native.ahk
@@ -24,7 +24,7 @@ global CEN_SIF_ALL := 0x17
 global CEN_SIDEBAR_W := 210
 global CEN_CONTENT_X := CEN_SIDEBAR_W + 1  ; +1 for sidebar border pixel
 global CEN_FOOTER_H := 48
-global CEN_SCROLL_STEP := 60               ; pixels per wheel notch
+global CEN_SCROLL_STEP := 60               ; Default, overridden from cfg in ConfigEditorNative_Show
 global CEN_SETTING_PAD := 8
 global CEN_DESC_LINE_H := 15
 global CEN_LABEL_W := 180
@@ -90,6 +90,10 @@ CE_RunNative(launcherHwnd := 0) {
     ; Initialize config system if not already done
     if (!gConfigLoaded)
         ConfigLoader_Init()
+
+    ; Load config-driven editor constants
+    global CEN_SCROLL_STEP, cfg
+    CEN_SCROLL_STEP := cfg.LauncherEditorScrollStep
 
     ; Parse registry into sections structure
     _CEN_ParseRegistry()

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -89,7 +89,7 @@ global gGUI_DisplayItems := []  ; Items being rendered (may be filtered by works
 
 ; Producer state
 global _gGUI_ScanInProgress := false  ; Re-entrancy guard for full WinEnum scan
-global HOUSEKEEPING_INTERVAL_MS := 300000  ; 5 minutes — cache pruning, log rotation, stats flush
+global HOUSEKEEPING_INTERVAL_MS  ; Set from cfg.HousekeepingIntervalMs at init
 
 ; Staggered startup delays (primes to avoid timer alignment on first tick)
 global STAGGER_ZPUMP_MS := 17
@@ -105,9 +105,14 @@ global STAGGER_HOUSEKEEPING_MS := 53
 
 _GUI_Main_Init() {
     global cfg, FR_EV_PRODUCER_INIT, gFR_Enabled, STAGGER_ZPUMP_MS, STAGGER_VALIDATE_MS, STAGGER_HOUSEKEEPING_MS
+    global HOUSEKEEPING_INTERVAL_MS, gViewer_RefreshIntervalMs
 
     ; CRITICAL: Initialize config FIRST - sets all global defaults
     ConfigLoader_Init()
+
+    ; Load config-driven constants (declared at file scope, set from cfg here)
+    HOUSEKEEPING_INTERVAL_MS := cfg.HousekeepingIntervalMs
+    gViewer_RefreshIntervalMs := cfg.DiagViewerRefreshMs
 
     ; Initialize theme (for blacklist dialog and MsgBox calls in GUI process)
     Theme_Init()

--- a/src/pump/enrichment_pump.ahk
+++ b/src/pump/enrichment_pump.ahk
@@ -27,7 +27,7 @@ global _Pump_ExeIconCache := Map()  ; exePath → master HICON (dedup across win
 global _Pump_PrevIconSource := Map() ; hwnd → {method, rawH, exePath} (nochange detection)
 global _Pump_ProcNameCache := Map() ; pid → processName (positive cache)
 global _Pump_FailedPidCache := Map() ; pid → tick (negative cache)
-global _Pump_FailedPidCacheTTL := 60000
+global _Pump_FailedPidCacheTTL  ; Set from cfg.ProcPumpFailedPidRetryMs at init
 global _Pump_IconPruneIntervalMs := 300000  ; Default 5min, overridden from config
 global _Pump_DiagEnabled := false
 global _Pump_GuiHwnd := 0             ; GUI process hwnd (for PostMessage wake on response)
@@ -36,7 +36,7 @@ global _Pump_HelloAcked := false       ; Whether we've sent our pumpHwnd back to
 ; ========================= INIT =========================
 
 _Pump_Init() {
-    global cfg, _Pump_Server, _Pump_IconPruneIntervalMs, _Pump_DiagEnabled
+    global cfg, _Pump_Server, _Pump_IconPruneIntervalMs, _Pump_DiagEnabled, _Pump_FailedPidCacheTTL
 
     ; Cloaked windows (other komorebi workspaces) are hidden from AHK by default.
     ; Without this, WinGetPID/WinGetTitle fail for cloaked windows → no processName/icon.
@@ -47,6 +47,7 @@ _Pump_Init() {
 
     ; Load config values
     _Pump_IconPruneIntervalMs := cfg.PumpIconPruneIntervalMs
+    _Pump_FailedPidCacheTTL := cfg.ProcPumpFailedPidRetryMs
     _Pump_DiagEnabled := cfg.DiagPumpLog
 
     ; Initialize blacklist (for title-based re-check on enrichment)

--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -140,6 +140,10 @@ global gConfigRegistry := [
     {s: "Launcher", k: "ShowTrayDebugItems", g: "LauncherShowTrayDebugItems", t: "bool", default: false,
      d: "Show the Dev menu and extra editor options in the tray menu. Useful for testing dialogs and debugging."},
 
+    {s: "Launcher", k: "EditorScrollStep", g: "LauncherEditorScrollStep", t: "int", default: 60,
+     min: 20, max: 200,
+     d: "Scroll speed for the native config editor (pixels per mouse wheel notch). Increase for faster scrolling through settings, decrease for precision."},
+
     ; ============================================================
     ; Theme & Dark Mode
     ; ============================================================
@@ -868,6 +872,14 @@ global gConfigRegistry := [
      min: 500, max: 5000,
      d: "Duration (ms) to suppress WinEventHook MRU updates after a workspace switch. Prevents focus events from corrupting window order during transitions."},
 
+    {s: "Komorebi", k: "SubPromotionRetryMs", g: "KomorebiSubPromotionRetryMs", t: "int", default: 30000,
+     min: 5000, max: 300000,
+     d: "Retry interval (ms) for promoting from polling to subscription mode after komorebi starts. Lower = faster promotion when komorebi restarts, but more frequent probing."},
+
+    {s: "Komorebi", k: "SubInitialPollDelayMs", g: "KomorebiSubInitialPollDelayMs", t: "int", default: 1500,
+     min: 500, max: 10000,
+     d: "Delay (ms) before first komorebi state poll at startup. Allows komorebi pipe to initialize. Increase on slow systems where komorebi takes longer to start."},
+
     ; ============================================================
     ; Setup & Installation
     ; ============================================================
@@ -1075,6 +1087,13 @@ global gConfigRegistry := [
      min: 5, max: 500,
      d: "Maximum number of cached UWP logo paths. Prevents repeated manifest parsing for multi-window UWP apps."},
 
+    {type: "subsection", section: "Store", name: "Housekeeping",
+     desc: "Periodic maintenance cycle for caches, logs, and stats"},
+
+    {s: "Store", k: "HousekeepingIntervalMs", g: "HousekeepingIntervalMs", t: "int", default: 300000,
+     min: 30000, max: 3600000,
+     d: "Interval (ms) between housekeeping cycles: cache pruning, log rotation, and stats flush. Lower = more responsive cleanup but slightly more CPU. Default 5 minutes."},
+
     ; ============================================================
     ; Diagnostics
     ; ============================================================
@@ -1091,6 +1110,10 @@ global gConfigRegistry := [
 
     {s: "Diagnostics", k: "FlightRecorderHotkey", g: "DiagFlightRecorderHotkey", t: "string", default: "*F12",
      d: "Hotkey to dump the flight recorder buffer. Use AHK v2 hotkey syntax (e.g. *F12, ^F12, +F11). * prefix = fire regardless of modifiers (works during Alt-Tab). Pass-through: the key still reaches other apps."},
+
+    {s: "Diagnostics", k: "ViewerRefreshMs", g: "DiagViewerRefreshMs", t: "int", default: 500,
+     min: 100, max: 5000,
+     d: "Debug viewer refresh interval (ms). Lower = more responsive viewer but slightly more CPU. Only applies while the viewer window is visible."},
 
     {s: "Diagnostics", k: "ChurnLog", g: "DiagChurnLog", t: "bool", default: false,
      d: "Log revision bump sources to %TEMP%\\tabby_store_error.log. Use when store rev is churning rapidly when idle."},

--- a/src/viewer/viewer.ahk
+++ b/src/viewer/viewer.ahk
@@ -22,7 +22,7 @@ global gViewer_IncludeCloaked := true
 global gViewer_Status := 0
 global gViewer_CurrentWSLabel := 0
 global gViewer_RefreshTimerFn := 0
-global gViewer_RefreshIntervalMs := 500  ; Polling interval when visible
+global gViewer_RefreshIntervalMs  ; Set from cfg.DiagViewerRefreshMs at init
 global gViewer_LastRev := -1
 global gViewer_ShuttingDown := false
 global gBlacklistChoice := ""  ; Blacklist dialog result


### PR DESCRIPTION
## Summary
- Audited ~100+ hardcoded constants across the codebase; promoted the 5 with genuine end-user value to the config registry
- New config entries: `HousekeepingIntervalMs` (Store), `ViewerRefreshMs` (Diagnostics), `EditorScrollStep` (Launcher), `SubPromotionRetryMs` and `SubInitialPollDelayMs` (Komorebi)
- Fixed bug where enrichment pump hardcoded `_Pump_FailedPidCacheTTL=60000` instead of reading existing `cfg.ProcPumpFailedPidRetryMs`
- All defaults unchanged — no behavioral change for existing users

Closes #26

## Test plan
- [x] Static analysis pre-gate passes (63 checks)
- [x] All 772 tests pass (unit, GUI, live)
- [ ] Open native config editor, verify new entries appear in correct sections
- [ ] Change values in config.ini, verify they take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)