### PR TITLE
Code quality: ColorRef dedup, button indexing, timing docs

### DIFF
--- a/src/editors/config_editor_native.ahk
+++ b/src/editors/config_editor_native.ahk
@@ -47,7 +47,7 @@ _CEN_ResetState() {
     gCEN["Pages"] := Map()
     gCEN["CurrentPage"] := ""
     gCEN["Sections"] := []
-    gCEN["FooterBtns"] := []
+    gCEN["FooterBtns"] := Map()
     gCEN["ChangeLabel"] := 0
     gCEN["Controls"] := Map()
     gCEN["OriginalValues"] := Map()
@@ -265,7 +265,9 @@ _CEN_BuildMainGUI() {
     btnReset := gCEN["MainGui"].AddButton("x490 y460 w120 h30", "Reset to Defaults")
     btnSave := gCEN["MainGui"].AddButton("x620 y460 w80 h30", "Save")
     btnCancel := gCEN["MainGui"].AddButton("x710 y460 w80 h30", "Cancel")
-    gCEN["FooterBtns"].Push(btnSave, btnCancel, btnReset)
+    gCEN["FooterBtns"]["Save"] := btnSave
+    gCEN["FooterBtns"]["Cancel"] := btnCancel
+    gCEN["FooterBtns"]["Reset"] := btnReset
     btnReset.OnEvent("Click", _CEN_OnResetDefaults)
     btnSave.OnEvent("Click", _CEN_OnSave)
     btnCancel.OnEvent("Click", _CEN_OnCancel)
@@ -906,12 +908,8 @@ _CEN_SwatchSubclassProc(hwnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) { ; 
 ; Update swatch color + alpha and trigger repaint
 _CEN_UpdateSwatchColor(swCtrl, rgb, alpha := 255) {
     global gCEN_SwatchColors, gCEN_SwatchAlphas
-    ; Convert RGB (0xRRGGBB) to COLORREF (0x00BBGGRR)
-    r := (rgb >> 16) & 0xFF
-    g := (rgb >> 8) & 0xFF
-    b := rgb & 0xFF
     hwnd := swCtrl.Hwnd
-    gCEN_SwatchColors[hwnd] := (b << 16) | (g << 8) | r
+    gCEN_SwatchColors[hwnd] := Theme_RgbToColorRef(rgb)
     gCEN_SwatchAlphas[hwnd] := alpha
     DllCall("InvalidateRect", "Ptr", hwnd, "Ptr", 0, "Int", 0)
 }
@@ -928,11 +926,7 @@ _CEN_OnSwatchCtlColor(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
 ; Open Win32 ChooseColor dialog. Returns RGB (0xRRGGBB) or -1 on cancel.
 _CEN_OpenColorPicker(currentRGB, ownerHwnd := 0) {
     global gCEN_CustomColors
-    ; Convert RGB (0xRRGGBB) to COLORREF (0x00BBGGRR)
-    r := (currentRGB >> 16) & 0xFF
-    g := (currentRGB >> 8) & 0xFF
-    b := currentRGB & 0xFF
-    colorRef := (b << 16) | (g << 8) | r
+    colorRef := Theme_RgbToColorRef(currentRGB)
 
     ; CHOOSECOLOR struct: fixed layout DWORD + HWND + HWND + COLORREF + LPCOLORREF + DWORD + LPARAM + ptr + ptr
     cc := Buffer(A_PtrSize = 8 ? 72 : 36, 0)
@@ -949,12 +943,8 @@ _CEN_OpenColorPicker(currentRGB, ownerHwnd := 0) {
     if (!result)
         return -1
 
-    ; Read result COLORREF (0x00BBGGRR) and convert back to RGB
     resultRef := NumGet(cc, off, "UInt")
-    rr := resultRef & 0xFF
-    gg := (resultRef >> 8) & 0xFF
-    bb := (resultRef >> 16) & 0xFF
-    return (rr << 16) | (gg << 8) | bb
+    return Theme_ColorRefToRgb(resultRef)
 }
 
 ; Create closure for swatch click -> color picker
@@ -1349,10 +1339,10 @@ _CEN_OnResize(gui, minMax, w, h) { ; lint-ignore: dead-param
     btnY := h - CEN_FOOTER_H + 8
     if (gCEN["ChangeLabel"])
         gCEN["ChangeLabel"].Move(16, btnY + 5, 300, 20)
-    if (gCEN["FooterBtns"].Length >= 3) {
-        gCEN["FooterBtns"][2].Move(w - 100, btnY, 80, 30)       ; Cancel
-        gCEN["FooterBtns"][1].Move(w - 190, btnY, 80, 30)       ; Save
-        gCEN["FooterBtns"][3].Move(w - 320, btnY, 120, 30)      ; Reset
+    if (gCEN["FooterBtns"].Count >= 3) {
+        gCEN["FooterBtns"]["Cancel"].Move(w - 100, btnY, 80, 30)
+        gCEN["FooterBtns"]["Save"].Move(w - 190, btnY, 80, 30)
+        gCEN["FooterBtns"]["Reset"].Move(w - 320, btnY, 120, 30)
     }
 
     if (gCEN["CurrentPage"] != "")

--- a/src/shared/config_loader.ahk
+++ b/src/shared/config_loader.ahk
@@ -831,6 +831,8 @@ LogTrim(logPath) {
 ; ============================================================
 ; Centralized timing values to avoid magic numbers throughout codebase.
 ; These are operational delays, not user-configurable settings.
+; See also: cfg.*Ms settings (config_registry.ahk) for user-tunable timings,
+;           IPC_TICK_* (ipc_constants.ahk) for pipe polling intervals.
 
 ; Sleep delays (milliseconds)
 global TIMING_PROCESS_EXIT_WAIT := 500    ; Wait for processes to fully exit

--- a/src/shared/ipc_constants.ahk
+++ b/src/shared/ipc_constants.ahk
@@ -9,6 +9,9 @@ global IPC_MSG_ENRICHMENT := "enrichment"      ; Pump → Main: enrichment resul
 global IPC_MSG_PUMP_SHUTDOWN := "shutdown"      ; Main → Pump: clean exit
 
 ; IPC Timing Constants (milliseconds)
+; Pipe polling intervals, not user-configurable.
+; See also: TIMING_* (config_loader.ahk) for operational delays,
+;           cfg.*Ms settings (config_registry.ahk) for user-tunable timings.
 global IPC_TICK_ACTIVE := 8         ; Server/client tick when active (messages pending)
 global IPC_TICK_SERVER_IDLE := 250  ; Server tick when no clients connected
 global IPC_SERVER_IDLE_STREAK_THRESHOLD := 8  ; Ticks before server enters IDLE (at 100ms = 800ms inactivity)

--- a/src/shared/theme.ahk
+++ b/src/shared/theme.ahk
@@ -911,12 +911,20 @@ Theme_ColorToInt(hexStr) {
     return (bb << 16) | (gg << 8) | rr
 }
 
-; Convert config int (0xRRGGBB) to COLORREF int (0x00BBGGRR)
-_Theme_CfgToColorRef(cfgInt) {
-    rr := (cfgInt >> 16) & 0xFF
-    gg := (cfgInt >> 8) & 0xFF
-    bb := cfgInt & 0xFF
+; Convert RGB int (0xRRGGBB) to COLORREF int (0x00BBGGRR)
+Theme_RgbToColorRef(rgbInt) {
+    rr := (rgbInt >> 16) & 0xFF
+    gg := (rgbInt >> 8) & 0xFF
+    bb := rgbInt & 0xFF
     return (bb << 16) | (gg << 8) | rr
+}
+
+; Convert COLORREF int (0x00BBGGRR) to RGB int (0xRRGGBB)
+Theme_ColorRefToRgb(colorRef) {
+    rr := colorRef & 0xFF
+    gg := (colorRef >> 8) & 0xFF
+    bb := (colorRef >> 16) & 0xFF
+    return (rr << 16) | (gg << 8) | bb
 }
 
 ; ============================================================
@@ -935,18 +943,18 @@ _Theme_ApplyTitleBarColors(hWnd) {
     ; Caption background + text (gated by CustomTitleBarColors)
     if (cfg.Theme_CustomTitleBarColors) {
         ; Caption background (DWMWA_CAPTION_COLOR = 35)
-        NumPut("UInt", _Theme_CfgToColorRef(cfg.%prefix "Bg"%), buf)
+        NumPut("UInt", Theme_RgbToColorRef(cfg.%prefix "Bg"%), buf)
         try DllCall("dwmapi\DwmSetWindowAttribute", "Ptr", hWnd, "Int", 35, "Ptr", buf.Ptr, "Int", 4, "Int")
 
         ; Title text (DWMWA_TEXT_COLOR = 36)
-        NumPut("UInt", _Theme_CfgToColorRef(cfg.%prefix "Text"%), buf)
+        NumPut("UInt", Theme_RgbToColorRef(cfg.%prefix "Text"%), buf)
         try DllCall("dwmapi\DwmSetWindowAttribute", "Ptr", hWnd, "Int", 36, "Ptr", buf.Ptr, "Int", 4, "Int")
     }
 
     ; Border (gated independently by CustomTitleBarBorder)
     if (cfg.Theme_CustomTitleBarBorder) {
         ; Border (DWMWA_BORDER_COLOR = 34)
-        NumPut("UInt", _Theme_CfgToColorRef(cfg.%prefix "Border"%), buf)
+        NumPut("UInt", Theme_RgbToColorRef(cfg.%prefix "Border"%), buf)
         try DllCall("dwmapi\DwmSetWindowAttribute", "Ptr", hWnd, "Int", 34, "Ptr", buf.Ptr, "Int", 4, "Int")
     }
 }
@@ -1023,8 +1031,8 @@ _Theme_OnDrawItem(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
 
     ; Get colors from config
     prefix := btnInfo.isDark ? "Theme_DarkButton" : "Theme_LightButton"
-    hoverBg   := _Theme_CfgToColorRef(cfg.%prefix "HoverBg"%)
-    hoverText := _Theme_CfgToColorRef(cfg.%prefix "HoverText"%)
+    hoverBg   := Theme_RgbToColorRef(cfg.%prefix "HoverBg"%)
+    hoverText := Theme_RgbToColorRef(cfg.%prefix "HoverText"%)
 
     ; Derive pressed color (darken hover by 20%)
     pressedBg := _Theme_DarkenColorRef(hoverBg)


### PR DESCRIPTION
## Summary

- Deduplicated RGB↔COLORREF bit-shifting by making `_Theme_CfgToColorRef` public as `Theme_RgbToColorRef()` and adding `Theme_ColorRefToRgb()`, replacing 3 inline conversion sites in `config_editor_native.ahk`
- Replaced fragile array-indexed footer buttons (`[1]=Save, [2]=Cancel, [3]=Reset`) with named Map keys to prevent silent breakage on reorder
- Added cross-reference comments between the three timing constant namespaces (`TIMING_*`, `cfg.*Ms`, `IPC_TICK_*`)

Closes #33

## Test plan

- [x] Static analysis: all 63 checks passed (including function visibility for renamed public function)
- [x] Unit tests: 505/505 passed
- [x] GUI tests: 224/224 passed
- [x] Live tests: all 43 passed (core, features, network, execution, lifecycle)
- [ ] Manual: Open config editor → change color swatch → verify color picker → resize window → verify button positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)