### PR TITLE
Add explicit COM object cleanup on shutdown

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -27,4 +27,7 @@ gGUI_LiveItems: gui_state, gui_data
 gGUI_OverlayVisible: gui_overlay, gui_state
 gGUI_Revealed: gui_overlay, gui_paint, gui_state
 gGUI_ScrollTop: gui_input, gui_paint, gui_state
+gGUI_AppViewCollection: gui_main, gui_state
+gGUI_ImmersiveShell: gui_main, gui_state
+gGUI_PendingShell: gui_main, gui_state
 gGUI_Sel: gui_input, gui_state

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -479,6 +479,12 @@ _GUI_OnExit(reason, code) { ; lint-ignore: dead-param
     try WL_CleanupExeIconCache()
     try IconPump_CleanupUwpCache()
 
+    ; Release COM objects (OS would clean up, but explicit is good hygiene)
+    global gGUI_PendingShell, gGUI_ImmersiveShell, gGUI_AppViewCollection
+    try gGUI_PendingShell := ""
+    try gGUI_ImmersiveShell := ""
+    try gGUI_AppViewCollection := ""
+
     ; Clean up GDI+
     Gdip_Shutdown()
 


### PR DESCRIPTION
## Summary

- Full resource leak audit (GDI+, pipes, file handles, timers, COM, unbounded collections, CPU churn) found no critical leaks
- Added explicit release of 3 global COM objects (`gGUI_PendingShell`, `gGUI_ImmersiveShell`, `gGUI_AppViewCollection`) in `_GUI_OnExit` before GDI+ shutdown
- Updated `ownership.manifest` for cross-file writes from `gui_main` to `gui_state` globals

Closes #39

## Test plan

- [x] Static analysis pre-gate passes (63 checks)
- [x] All 505 unit tests pass
- [x] All 224 GUI tests pass
- [x] All 43 live tests pass
- [x] Ownership manifest validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)