### PR TITLE
Add 3 static analysis checks and fix hot-path Buffer allocation

### DIFF
--- a/src/gui/gui_input.ahk
+++ b/src/gui/gui_input.ahk
@@ -435,7 +435,7 @@ GUI_OnMouseMove(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
     if (!gGUI_MouseTracking) {
         ; TRACKMOUSEEVENT structure: cbSize(4), dwFlags(4), hwndTrack(ptr), dwHoverTime(4)
         static TME_LEAVE := 0x02
-        tme := Buffer(8 + A_PtrSize + 4, 0)
+        static tme := Buffer(8 + A_PtrSize + 4, 0)
         NumPut("uint", 8 + A_PtrSize + 4, tme, 0)  ; cbSize
         NumPut("uint", TME_LEAVE, tme, 4)          ; dwFlags
         NumPut("ptr", hwnd, tme, 8)                ; hwndTrack


### PR DESCRIPTION
## Summary

- Add `config_registry_integrity` sub-check to `check_batch_simple.ps1` — validates type strings are valid (`string`/`int`/`float`/`bool`/`enum`), enum defaults exist in options array, bool defaults are `true`/`false`, and hex-format defaults are within range
- Add `fr_event_coverage` sub-check to `check_batch_simple.ps1` — ensures every `FR_EV_*` constant has a matching case in `_FR_GetEventName()` and vice versa, plus detects duplicate numeric values
- Add `numeric_string_comparison` sub-check to `check_batch_patterns.ps1` — flags comparisons between known-numeric variables (`hwnd`, `pid`, `exitCode`, `h[A-Z]*`) and non-numeric string literals inside conditionals, which always evaluate to false in AHK v2
- Fix non-static `Buffer()` in `gui_input.ahk` WM_MOUSEMOVE handler — was allocating on every mouse move (~100+/sec), now uses `static` per hot-path resource rules

Closes #27

## Test plan

- [x] `check_batch_simple.ps1` passes with both new sub-checks (config_registry_integrity, fr_event_coverage)
- [x] `check_batch_patterns.ps1` passes with numeric_string_comparison (zero false positives)
- [x] Full test suite passes: 66 static analysis checks, 772 tests across all suites
- [ ] Verify checks catch real bugs: temporarily introduce a bad config entry (e.g., `t: "boo"`) and confirm config_registry_integrity flags it
- [ ] Verify FR check catches gaps: temporarily remove a `case` from `_FR_GetEventName()` and confirm fr_event_coverage flags it

🤖 Generated with [Claude Code](https://claude.com/claude-code)