### PR TITLE
Suppress hotkey registration during test pipeline

### DIFF
--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -104,7 +104,7 @@ global STAGGER_HOUSEKEEPING_MS := 53
 ; by alt_tabby.ahk before this file. They reference globals declared above.
 
 _GUI_Main_Init() {
-    global cfg, FR_EV_PRODUCER_INIT, gFR_Enabled, STAGGER_ZPUMP_MS, STAGGER_VALIDATE_MS, STAGGER_HOUSEKEEPING_MS
+    global cfg, FR_EV_PRODUCER_INIT, gFR_Enabled, STAGGER_ZPUMP_MS, STAGGER_VALIDATE_MS, STAGGER_HOUSEKEEPING_MS, g_TestingMode
     global HOUSEKEEPING_INTERVAL_MS, gViewer_RefreshIntervalMs
 
     ; CRITICAL: Initialize config FIRST - sets all global defaults
@@ -221,10 +221,13 @@ _GUI_Main_Init() {
     SetTimer(_GUI_StartHousekeeping, -STAGGER_HOUSEKEEPING_MS)
 
     ; Set up interceptor keyboard hooks — MUST be LAST (no hotkeys before data is populated)
-    INT_SetupHotkeys()
+    ; Skip in testing mode to avoid intercepting developer's real keystrokes during test runs
+    if (!g_TestingMode) {
+        INT_SetupHotkeys()
 
-    ; Check initial bypass state based on current focused window
-    INT_SetBypassMode(INT_ShouldBypassWindow(0))
+        ; Check initial bypass state based on current focused window
+        INT_SetBypassMode(INT_ShouldBypassWindow(0))
+    }
 }
 
 ; ========================= PRODUCER CALLBACKS =========================

--- a/src/launcher/launcher_utils.ahk
+++ b/src/launcher/launcher_utils.ahk
@@ -14,13 +14,17 @@
 ;   logFunc   - Optional log function(msg) for diagnostics
 ; Returns: true if launched, false on failure
 LauncherUtils_Launch(component, &pidVar, logFunc := "") {
+    global g_TestingMode
     ; Build command based on compiled status and component
     launcherArg := " --launcher-hwnd=" A_ScriptHwnd
 
     if (A_IsCompiled) {
         exe := '"' A_ScriptFullPath '" '
         switch component {
-            case "gui":    cmd := exe "--gui-only" launcherArg
+            case "gui":
+                cmd := exe "--gui-only" launcherArg
+                if (g_TestingMode)
+                    cmd .= " --testing-mode"
             case "pump":   cmd := exe "--pump"
             default:       return false
         }
@@ -34,7 +38,6 @@ LauncherUtils_Launch(component, &pidVar, logFunc := "") {
             default:       return false
         }
         ; In testing mode, pass --test to child processes so they hide tray icons
-        global g_TestingMode
         if (g_TestingMode)
             cmd .= " --test"
     }


### PR DESCRIPTION
## Summary

- Propagate `--testing-mode` flag from launcher to GUI subprocess in compiled mode so the child process knows it's in a test run
- Guard `INT_SetupHotkeys()` behind `!g_TestingMode` to skip real keyboard hook registration during live tests
- Hoist `global g_TestingMode` to function scope in `LauncherUtils_Launch()` (was inside switch block, caught by static analysis)

Closes #28

## Test plan

- [x] Full test suite passes (772/772 — unit, GUI, live, all suites)
- [ ] While tests run, verify Alt+Tab works normally on the host
- [ ] Run production `AltTabby.exe` normally — hotkeys register as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)