### PR TITLE
Fix systemic anti-patterns: split WEH probe, cache cleanup, defensive IPC

### DIFF
--- a/src/gui/gui_pump.ahk
+++ b/src/gui/gui_pump.ahk
@@ -335,11 +335,13 @@ _GUIPump_OnMessage(msg, hPipe) { ; lint-ignore: dead-param
 
 ; ========================= PIPE WAKE =========================
 
-_GUIPump_OnPipeWake(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param ; lint-ignore: error-boundary
+_GUIPump_OnPipeWake(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
     Critical "On"
-    global _gPump_Client
-    if (IsObject(_gPump_Client))
-        IPC__ClientTick(_gPump_Client)
+    try {
+        global _gPump_Client
+        if (IsObject(_gPump_Client))
+            IPC__ClientTick(_gPump_Client)
+    }
     Critical "Off"
     return 0
 }

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -130,9 +130,12 @@ WS_SnapshotMapKeys(mapObj) {
 ; Helper to delete a window from the store with proper icon cleanup.
 ; Caller MUST hold Critical when calling this function.
 _WS_DeleteWindow(hwnd) {
-    global gWS_Store
+    global gWS_Store, gWS_DLCache_ItemsMap
     try IconPump_CleanupWindow(hwnd)
     gWS_Store.Delete(hwnd)
+    ; Prune stale entry from display list cache to prevent unbounded growth
+    ; between Path 3 rebuilds (Path 1.5 MRU move-to-front preserves the map)
+    try gWS_DLCache_ItemsMap.Delete(hwnd)
 }
 
 WL_Init(config := 0) {


### PR DESCRIPTION
## Summary

- **Split WEH batch probe** into lightweight update path for in-store windows (`_WEH_UpdateExisting`) vs full probe for new windows — eliminates ~50% of redundant cross-process kernel transitions per batch by skipping immutable fields (class, PID) and only fetching title + vis/min/cloak
- **Prune stale display list cache entries** in `_WS_DeleteWindow` — prevents unbounded growth of `gWS_DLCache_ItemsMap` between Path 3 rebuilds on long-running systems with frequent window open/close cycles
- **Add defensive try/catch** in `_GUIPump_OnPipeWake` critical section for consistency with WEH callback pattern

## Test plan

- [x] Static analysis: 63/63 checks passed
- [x] Unit tests: 505/505 passed (all 8 suites)
- [x] Core tests: 8/8 passed
- [x] Live tests: Features 15/15, Network 7/7, Execution 4/4 passed
- [x] GUI tests: 224/224 passed
- [ ] Manual: verify new windows appear in Alt-Tab list (full probe path)
- [ ] Manual: verify existing window title changes are reflected (lightweight update path)
- [ ] Manual: verify ghost windows are still removed (eligibility re-check in lightweight path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)