### PR TITLE
Post-refactor code quality cleanup

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -212,8 +212,7 @@ if (g_AltTabbyMode = "config") {
 ; Run blacklist editor and exit when launched with --blacklist
 if (g_AltTabbyMode = "blacklist") {
     launcherHwnd := _ParseLauncherHwnd()
-    ; Initialize config + theme for blacklist editor process
-    _ModeInit()
+    ; Config + theme init is handled inside BlacklistEditor_Run (matches ConfigEditor_Run pattern)
     BlacklistEditor_Run(launcherHwnd)
     _NotifyEditorClosed(launcherHwnd)
     ExitApp()

--- a/src/editors/blacklist_editor.ahk
+++ b/src/editors/blacklist_editor.ahk
@@ -38,12 +38,18 @@ global gBE_LauncherHwnd := 0
 ; Returns: true if changes were saved, false otherwise
 BlacklistEditor_Run(launcherHwnd := 0) {
     global gBE_Gui, gBE_SavedChanges, gBE_LauncherHwnd, gBlacklist_FilePath, gBlacklist_Loaded
+    global gConfigLoaded
     gBE_LauncherHwnd := launcherHwnd
 
     ; Hide tray icon - only launcher should have one
     A_IconHidden := true
 
     gBE_SavedChanges := false
+
+    ; Initialize config + theme if not already done (matches ConfigEditor_Run pattern)
+    if (!gConfigLoaded)
+        ConfigLoader_Init()
+    Theme_Init()
 
     ; Initialize blacklist if not already done
     if (!gBlacklist_Loaded)

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -9,12 +9,12 @@ global gGUI_Base := 0
 global gGUI_Overlay := 0
 global gGUI_BaseH := 0
 global gGUI_OverlayH := 0
-global gGUI_HideCount := 0  ; Track hides for periodic log trim
 global GUI_LOG_TRIM_EVERY_N_HIDES := 10
 
 GUI_HideOverlay() {
     global gGUI_OverlayVisible, gGUI_Base, gGUI_Overlay, gGUI_Revealed
-    global gGUI_HideCount, cfg, GUI_LOG_TRIM_EVERY_N_HIDES
+    global cfg, GUI_LOG_TRIM_EVERY_N_HIDES
+    static hideCount := 0
 
     if (!gGUI_OverlayVisible) {
         return
@@ -40,8 +40,8 @@ GUI_HideOverlay() {
 
     ; Periodically trim paint timing log (every 10 hide cycles)
     ; Other diagnostic logs are rotated by _GUI_RotateDiagLogs() on housekeeping timer.
-    gGUI_HideCount += 1
-    if (Mod(gGUI_HideCount, GUI_LOG_TRIM_EVERY_N_HIDES) = 0) {
+    hideCount += 1
+    if (Mod(hideCount, GUI_LOG_TRIM_EVERY_N_HIDES) = 0) {
         Paint_LogTrim()
     }
 }

--- a/src/shared/ipc_constants.ahk
+++ b/src/shared/ipc_constants.ahk
@@ -14,7 +14,7 @@ global IPC_MSG_PUMP_SHUTDOWN := "shutdown"      ; Main → Pump: clean exit
 ;           cfg.*Ms settings (config_registry.ahk) for user-tunable timings.
 global IPC_TICK_ACTIVE := 8         ; Server/client tick when active (messages pending)
 global IPC_TICK_SERVER_IDLE := 250  ; Server tick when no clients connected
-global IPC_SERVER_IDLE_STREAK_THRESHOLD := 8  ; Ticks before server enters IDLE (at 100ms = 800ms inactivity)
+global IPC_SERVER_IDLE_STREAK_THRESHOLD := 8  ; Ticks before server enters IDLE (at 250ms tick = 2000ms inactivity)
 global IPC_WAIT_PIPE_TIMEOUT := 200 ; WaitNamedPipe timeout for client connect
 global IPC_WAIT_SINGLE_OBJ := 1     ; WaitForSingleObject timeout (busy poll)
 


### PR DESCRIPTION
## Summary

- Fix stale IPC comment: idle threshold was documented as 800ms but is actually 2000ms (250ms × 8 ticks)
- Unify editor init pattern: moved `ConfigLoader_Init` + `Theme_Init` into `BlacklistEditor_Run()` to match `ConfigEditor_Run()` — callers no longer responsible for external `_ModeInit()`
- Add PID cache pruning to enrichment pump: dead PIDs in `_Pump_ProcNameCache` and `_Pump_FailedPidCache` are now cleaned on the existing 5-minute prune timer
- Convert `gGUI_HideCount` global to `static` — it was only used within `GUI_HideOverlay()`

Closes #48

## Test plan

- [x] Full test suite passes (791/791 — unit, GUI, live)
- [x] Static analysis pre-gate passes (66/66 checks)
- [ ] Manual: open blacklist editor standalone (`--blacklist`) — verify theme renders correctly
- [ ] Manual: verify enrichment pump logs show PID pruning after 5 min idle with `DiagPumpLog=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)