### PR TITLE
Add callback invocation arity check, fix missing isStructural param

### DIFF
--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -469,7 +469,7 @@ _WEH_ProcessBatch() {
     ; itself queued an entry in _WEH_PendingHwnds, the Count=0 early-exit below is bypassed.
     ; Without this push, the GUI sees the new window with lastActivatedTick=0 (wrong MRU).
     if (focusProcessed && gWS_OnStoreChanged)
-        gWS_OnStoreChanged()
+        gWS_OnStoreChanged(false)
 
     if (_WEH_PendingHwnds.Count = 0)
         return


### PR DESCRIPTION
## Summary

- Fix `winevent_hook.ahk:472`: `gWS_OnStoreChanged()` → `gWS_OnStoreChanged(false)` — MRU-only focus updates were defaulting to `isStructural := true`, skipping cosmetic patching during ACTIVE state
- Add `check_callback_invocation_arity` sub-check to `check_batch_guards.ps1` — resolves SetCallbacks wiring to validate argument counts at every callback global invocation site
- The new check catches both hard arity violations (too few/too many args) and inconsistent arity across call sites (outlier detection — the pattern that let the line 472 bug through)

Closes #49

## Test plan

- [x] New check detects the bug when reverted (verified: `"passes 0 arg(s) but 3/4 sites pass 1"`)
- [x] All 67 static analysis checks pass with fix applied
- [x] All 242 GUI tests pass
- [x] All unit tests pass (515/515)
- [x] All live tests pass (lifecycle pump-restart flake is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)