### PR TITLE
Fix action button hover hit-test offset when buttons hidden

### DIFF
--- a/src/gui/gui_input.ahk
+++ b/src/gui/gui_input.ahk
@@ -204,19 +204,25 @@ _GUI_DetectActionAtPoint(xPhys, yPhys, &action, &idx1) {
     btnX := ow - marR - size
     btnY := topY + (rowVis - 1) * RowH + (RowH - size) // 2
 
-    if (cfg.GUI_ShowCloseButton && xPhys >= btnX && xPhys < btnX + size && yPhys >= btnY && yPhys < btnY + size) {
-        action := "close"
-        return
+    if (cfg.GUI_ShowCloseButton) {
+        if (xPhys >= btnX && xPhys < btnX + size && yPhys >= btnY && yPhys < btnY + size) {
+            action := "close"
+            return
+        }
+        btnX := btnX - (size + gap)
     }
-    btnX := btnX - (size + gap)
-    if (cfg.GUI_ShowKillButton && xPhys >= btnX && xPhys < btnX + size && yPhys >= btnY && yPhys < btnY + size) {
-        action := "kill"
-        return
+    if (cfg.GUI_ShowKillButton) {
+        if (xPhys >= btnX && xPhys < btnX + size && yPhys >= btnY && yPhys < btnY + size) {
+            action := "kill"
+            return
+        }
+        btnX := btnX - (size + gap)
     }
-    btnX := btnX - (size + gap)
-    if (cfg.GUI_ShowBlacklistButton && xPhys >= btnX && xPhys < btnX + size && yPhys >= btnY && yPhys < btnY + size) {
-        action := "blacklist"
-        return
+    if (cfg.GUI_ShowBlacklistButton) {
+        if (xPhys >= btnX && xPhys < btnX + size && yPhys >= btnY && yPhys < btnY + size) {
+            action := "blacklist"
+            return
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Action button hover regions were misaligned when buttons are hidden (e.g., kill defaulted off) — `btnX` was decremented unconditionally in hit-test but only for visible buttons in paint
- Wrapped each button's hit-test + decrement inside visibility check, mirroring `_GUI_DrawOneActionButton()` logic

## Test plan
- [x] Full test suite passes (797/798 — 1 unrelated lifecycle timing flake)
- [ ] Manual: with kill disabled, hover over blacklist (B) → highlight appears on B, not on empty space to its left
- [ ] Manual: with kill enabled, all three buttons hover correctly

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)