### PR TITLE
Consolidate installation/elevation helpers, fix repair suppression

### DIFF
--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -832,24 +832,27 @@ _Launcher_CheckConfigWritable() {
 ; Check if we should skip wizard due to existing installation
 ; Returns true if: there's an existing Program Files install with valid config
 _Launcher_ShouldSkipWizardForExistingInstall() {
-    global cfg
+    global cfg, ALTTABBY_INSTALL_DIR
 
     ; Only relevant when FirstRunCompleted is false (would show wizard)
     if (cfg.SetupFirstRunCompleted)
         return false
 
-    ; Check for Program Files installation (localized for non-English Windows)
-    global ALTTABBY_INSTALL_DIR
-    pfDir := ALTTABBY_INSTALL_DIR
-    pfPath := pfDir "\AltTabby.exe"
-    pfConfigPath := pfDir "\config.ini"
-
     ; If running from Program Files, don't skip (let wizard show for fresh PF installs)
-    if (InStr(A_ScriptDir, pfDir))
+    if (InStr(A_ScriptDir, ALTTABBY_INSTALL_DIR))
         return false
 
-    ; Check if Program Files install exists with completed setup
-    if (FileExist(pfPath) && FileExist(pfConfigPath)) {
+    ; Check if there's a known installation (config ExePath or PF well-known path)
+    installedPath := Setup_GetInstalledPath()
+    if (installedPath = "")
+        return false
+
+    ; Resolve the installed directory and check for a config with completed setup
+    installedDir := ""
+    SplitPath(installedPath, , &installedDir)
+    pfConfigPath := installedDir "\config.ini"
+
+    if (FileExist(installedPath) && FileExist(pfConfigPath)) {
         if (ReadIniBool(pfConfigPath, "Setup", "FirstRunCompleted")) {
             ; Existing install has completed setup - skip wizard
             ; The mismatch dialog will offer to launch installed version or run from here

--- a/src/launcher/launcher_tray.ahk
+++ b/src/launcher/launcher_tray.ahk
@@ -631,19 +631,17 @@ Tray_InstallToProgramFiles() {
     if (result = "Cancel")
         return
 
-    ; Write state file: source<|>target (same format as update-installed)
-    targetPath := ALTTABBY_INSTALL_DIR "\AltTabby.exe"
-    WriteStateFile(TEMP_INSTALL_PF_STATE, A_ScriptFullPath, targetPath)
-
     ; Self-elevate and exit (elevated instance handles install + relaunch)
-    try {
-        if (!Launcher_RunAsAdmin("--install-to-pf"))
-            throw Error("RunAsAdmin failed")
+    targetPath := ALTTABBY_INSTALL_DIR "\AltTabby.exe"
+    if (Setup_ElevateWithState({
+        stateFile: TEMP_INSTALL_PF_STATE,
+        flag: "--install-to-pf",
+        errorMessage: "Installation requires administrator privileges.`nThe UAC prompt may have been cancelled.",
+        errorIcon: "Icon!",
+        source: A_ScriptFullPath,
+        target: targetPath
+    }))
         _ExitAll()
-    } catch {
-        try FileDelete(TEMP_INSTALL_PF_STATE)
-        ThemeMsgBox("Installation requires administrator privileges.`nThe UAC prompt may have been cancelled.", APP_NAME, "Icon!")
-    }
 }
 
 ToggleAutoUpdate() {


### PR DESCRIPTION
## Summary

- Extract `Setup_GetInstalledPath()` into `setup_utils.ahk` — single source of truth for finding the installed exe path (replaces duplicated config + PF fallback logic in `launcher_install.ahk` and `launcher_main.ahk`)
- Extract `Setup_ElevateWithState()` into `setup_utils.ahk` — consolidates the "write state file → RunAsAdmin → cleanup on failure" pattern from 3 call sites (`launcher_install`, `launcher_tray`, `setup_utils`)
- Fix "Always Run From Here" + UAC refusal: now sets `SuppressAdminRepairPrompt=true` so users aren't pestered with repair dialogs after declining elevation
- Add stale task XML files (`alttabby_task.xml`, `alttabby_task_query.xml`) to `Update_CleanupStaleTempFiles()`

## Test plan

- [x] Static analysis passes (66 checks)
- [x] Unit tests pass (515 tests)
- [x] GUI tests pass (242 tests)
- [x] Live tests pass (43 tests)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)