### PR TITLE
Add QPC high-precision timing for diagnostics

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -131,6 +131,7 @@ for _, arg in A_Args {
 #Include pump_utils.ahk
 #Include resource_utils.ahk
 #Include stats.ahk
+#Include timing.ahk
 #Include window_list.ahk
 
 ; Editor subprocesses (from src/editors/)

--- a/src/gui/gui_flight_recorder.ahk
+++ b/src/gui/gui_flight_recorder.ahk
@@ -117,7 +117,7 @@ FR_Record(ev, d1:=0, d2:=0, d3:=0, d4:=0) {
     Critical "On"
     gFR_Idx := gFR_Idx >= gFR_Size ? 1 : gFR_Idx + 1
     b := gFR_Buffer[gFR_Idx]
-    b[1] := A_TickCount
+    b[1] := QPC()
     b[2] := ev
     b[3] := d1
     b[4] := d2
@@ -149,7 +149,7 @@ _FR_Dump() {
 
     ; --- 1. Capture state atomically (inside Critical) ---
     Critical "On"
-    dumpTick := A_TickCount
+    dumpTick := QPC()
     capturedIdx := gFR_Idx
     capturedCount := gFR_Count
 
@@ -328,7 +328,7 @@ _FR_DumpPhase2() {
         offsetMs := tick - dumpTick
         offsetSec := Abs(offsetMs) / 1000.0
         sign := offsetMs <= 0 ? "-" : "+"
-        timeCol := Format("T{}{:07.3f}", sign, offsetSec)
+        timeCol := Format("T{}{:010.3f}", sign, offsetSec)
 
         evName := _FR_GetEventName(ev)
         details := _FR_FormatDetails(ev, d1, d2, d3, d4, hwndMap)

--- a/src/gui/gui_gdip.ahk
+++ b/src/gui/gui_gdip.ahk
@@ -267,18 +267,18 @@ GUI_EnsureResources(scale) {
         Paint_Log("  ** RECREATING RESOURCES (oldScale=" gGdip_ResScale " newScale=" scale " resCount=" gGdip_Res.Count " idle=" (idleDuration > 0 ? Round(idleDuration/1000, 1) "s" : "first") ")")
     }
 
-    tRes_Start := A_TickCount
+    tRes_Start := QPC()
 
-    t1 := A_TickCount
+    t1 := QPC()
     _Gdip_DisposeResources()
-    tRes_Dispose := A_TickCount - t1
+    tRes_Dispose := QPC() - t1
 
-    t1 := A_TickCount
+    t1 := QPC()
     Gdip_Startup()
-    tRes_Startup := A_TickCount - t1
+    tRes_Startup := QPC() - t1
 
     ; Brushes
-    t1 := A_TickCount
+    t1 := QPC()
     brushes := [
         ["brMain", cfg.GUI_MainARGB],
         ["brMainHi", cfg.GUI_MainARGBHi],
@@ -297,10 +297,10 @@ GUI_EnsureResources(scale) {
         DllCall("gdiplus\GdipCreateSolidFill", "int", b[2], "ptr*", &br)
         gGdip_Res[b[1]] := br
     }
-    tRes_Brushes := A_TickCount - t1
+    tRes_Brushes := QPC() - t1
 
     ; Fonts
-    t1 := A_TickCount
+    t1 := QPC()
 
     fonts := [
         [cfg.GUI_MainFontName, cfg.GUI_MainFontSize, cfg.GUI_MainFontWeight, "ffMain", "fMain"],
@@ -322,10 +322,10 @@ GUI_EnsureResources(scale) {
         gGdip_Res[f[4]] := fam
         gGdip_Res[f[5]] := font
     }
-    tRes_Fonts := A_TickCount - t1
+    tRes_Fonts := QPC() - t1
 
     ; String formats
-    t1 := A_TickCount
+    t1 := QPC()
     fmtFlags := GDIP_STRING_FORMAT_NO_WRAP | GDIP_STRING_FORMAT_LINE_LIMIT
 
     formats := [
@@ -347,14 +347,14 @@ GUI_EnsureResources(scale) {
         DllCall("gdiplus\GdipSetStringFormatLineAlign", "ptr", fmt, "int", fm[3])
         gGdip_Res[fm[1]] := fmt
     }
-    tRes_Formats := A_TickCount - t1
+    tRes_Formats := QPC() - t1
 
     gGdip_ResScale := scale
 
     ; Log resource recreation timing
     if (cfg.DiagPaintTimingLog) {
-        tRes_Total := A_TickCount - tRes_Start
-        Paint_Log("    Resources: total=" tRes_Total "ms | dispose=" tRes_Dispose " startup=" tRes_Startup " brushes=" tRes_Brushes " fonts=" tRes_Fonts " formats=" tRes_Formats)
+        tRes_Total := QPC() - tRes_Start
+        Paint_Log("    Resources: total=" Round(tRes_Total, 2) "ms | dispose=" Round(tRes_Dispose, 2) " startup=" Round(tRes_Startup, 2) " brushes=" Round(tRes_Brushes, 2) " fonts=" Round(tRes_Fonts, 2) " formats=" Round(tRes_Formats, 2))
     }
 }
 

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -45,6 +45,7 @@ A_MenuMaskKey := "vkE8"
 #Include *i %A_ScriptDir%\..\shared\theme.ahk
 #Include *i %A_ScriptDir%\..\shared\theme_msgbox.ahk
 #Include *i %A_ScriptDir%\..\shared\gui_antiflash.ahk
+#Include *i %A_ScriptDir%\..\shared\timing.ahk
 
 ; GUI utilities
 #Include *i %A_ScriptDir%\gui_gdip.ahk

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -509,7 +509,7 @@ _GUI_ShowOverlayWithFrozen() {
     }
 
     ; ===== TIMING: Show sequence start =====
-    tShow_Start := A_TickCount
+    tShow_Start := QPC()
     idleDuration := (gPaint_LastPaintTick > 0) ? (A_TickCount - gPaint_LastPaintTick) : -1
     if (cfg.DiagPaintTimingLog)
         Paint_Log("ShowOverlay START (idle=" (idleDuration > 0 ? Round(idleDuration/1000, 1) "s" : "first") " frozen=" gGUI_DisplayItems.Length " items=" gGUI_LiveItems.Length ")")
@@ -534,14 +534,14 @@ _GUI_ShowOverlayWithFrozen() {
     ; Both windows stay hidden during resize+paint. GUI_RevealBoth() (called from
     ; inside GUI_Repaint) shows both at the same DwmFlush, preventing any frame
     ; where the acrylic base is visible without the overlay window list.
-    t1 := A_TickCount
+    t1 := QPC()
     rowsDesired := GUI_ComputeRowsToShow(gGUI_DisplayItems.Length)
     GUI_ResizeToRows(rowsDesired)
-    tShow_Resize := A_TickCount - t1
+    tShow_Resize := QPC() - t1
 
-    t1 := A_TickCount
+    t1 := QPC()
     GUI_Repaint()  ; Paint + RevealBoth (shows both windows atomically)
-    tShow_Repaint := A_TickCount - t1
+    tShow_Repaint := QPC() - t1
 
     ; RACE FIX: If Alt was released during paint/reveal, RevealBoth already hid
     ; both windows. Abort here to clean up flags and skip hover polling.
@@ -556,9 +556,9 @@ _GUI_ShowOverlayWithFrozen() {
     GUI_StartHoverPolling()
 
     ; ===== TIMING: Log show sequence =====
-    tShow_Total := A_TickCount - tShow_Start
+    tShow_Total := QPC() - tShow_Start
     if (cfg.DiagPaintTimingLog)
-        Paint_Log("ShowOverlay END: total=" tShow_Total "ms | resize=" tShow_Resize " repaint=" tShow_Repaint)
+        Paint_Log("ShowOverlay END: total=" Round(tShow_Total, 2) "ms | resize=" Round(tShow_Resize, 2) " repaint=" Round(tShow_Repaint, 2))
 }
 
 _GUI_MoveSelectionFrozen(delta) {

--- a/src/shared/timing.ahk
+++ b/src/shared/timing.ahk
@@ -1,0 +1,14 @@
+#Requires AutoHotkey v2.0
+; QPC() — sub-microsecond timestamp in milliseconds (float).
+; Cost: ~100ns per call (one DllCall). Use for diagnostics only.
+; Returns: ms since system boot as float, e.g. 12345678.123
+
+QPC() {
+    static f := 0
+    if (f = 0) {
+        DllCall("QueryPerformanceFrequency", "int64*", &freq := 0)
+        f := freq / 1000  ; Convert to ms divisor once
+    }
+    DllCall("QueryPerformanceCounter", "int64*", &c := 0)
+    return c / f
+}

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -20,6 +20,9 @@ global GUI_TestLogPath := A_Temp "\gui_tests_" _guiWorktreeId ".log"
 ; IPC message types (from shared constants - still needed for flight recorder constants)
 #Include %A_ScriptDir%\..\src\shared\ipc_constants.ahk
 
+; QPC timing (used by diagnostic instrumentation in gui_state, gui_paint, etc.)
+#Include %A_ScriptDir%\..\src\shared\timing.ahk
+
 ; GUI state globals
 global gGUI_State := "IDLE"
 global gGUI_LiveItems := []


### PR DESCRIPTION
## Summary

- Add `QPC()` function (`src/shared/timing.ahk`) wrapping QueryPerformanceCounter for sub-microsecond timestamps
- Replace `A_TickCount` with `QPC()` in all diagnostic/instrumentation code: flight recorder, paint timing, resource recreation timing, and show-overlay timing
- Log output now shows 2-decimal precision (e.g., `total=14.23ms` instead of `total=14ms`)
- All functional timing (MRU, debounce, timeout, quick-switch) remains on `A_TickCount`

Closes #67

## Test plan

- [x] Static analysis pre-gate passes (67 checks)
- [x] All 515 unit tests pass
- [x] All 43 live tests pass
- [x] All 242 GUI state machine tests pass
- [ ] Manual: enable `FlightRecorder=true`, Alt-Tab a few times, press F12 — verify dump shows sub-ms precision in event offsets
- [ ] Manual: enable `PaintTimingLog=true`, trigger Alt-Tab shows — verify `tabby_paint_timing.log` shows decimal timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)