### PR TITLE
Adopt MCodeLoader + unified MCode build pipeline

### DIFF
--- a/src/lib/MCodeLoader.ahk
+++ b/src/lib/MCodeLoader.ahk
@@ -1,0 +1,129 @@
+;
+; MCodeLoader.ahk — Runtime loader for embedded machine code
+;
+; Source: thqby/ahk2_lib (MIT License)
+; https://github.com/thqby/ahk2_lib
+;
+; Copyright (c) 2023 thqby
+; Permission is hereby granted under the MIT License.
+; See: https://github.com/thqby/ahk2_lib/blob/master/LICENSE
+;
+
+/************************************************************************
+ * @description Enhanced version of MCode, which can build machine code supporting import symbol,
+ * multi-function export, using strings, setting global variables and other features.
+ * @author thqby
+ * @date 2024/12/29
+ * @version 1.0.1
+ ***********************************************************************/
+
+class MCodeLoader extends Buffer {
+	/**
+	 * Build a c/c++ code buffer, retrieve the function address, and then call it with DllCall to get higher performance.
+	 * @param {{32?:String|$Code, 64?:String|$Code, import?:String, export?:String}} configs
+	 * @param {Integer} bits Number of bits corresponding to the code to be loaded.
+	 * The built code cannot be run when the bits are inconsistent with the current exe.
+	 * @param {Map} import_fn_ptrs Fill in the import address table with the function address obtained by yourself.
+	 * @typedef {Object} $Code
+	 * @property {String} code Base64 format string.
+	 * @property {Integer} size If the code is compressed by LZ, the value is the decompressed size.
+	 * @property {String|Array<String>} export The comma-concatenated names that are sequentially associated with the export function.
+	 * If not specified, it is named by serial number.
+	 * @property {String} import Get the address of dll import symbols in sequence and fill them into the import address table.
+	 * e.g. `dll1:fn1,fn2|dll2:fn3`
+	 */
+	__New(configs, bits := A_PtrSize * 8, import_fn_ptrs := Map()) {
+		if !ObjHasOwnProp(configs, bits)
+			throw ValueError('No matching machine code')
+		import := prop('import'), export_ := prop('export'), configs := configs.%bits%
+		if IsObject(configs)
+			import := prop('import') || import, export_ := prop('export') || export_, configs := configs.code
+		if n := RegExMatch(configs, '^[\da-f]{1,8},\K')
+			this.Size := '0x' SubStr(configs, 1, --n - 1), lz_decompress(base64_decode(StrPtr(configs) + n * 2), this)
+		else base64_decode(StrPtr(configs), this)
+
+		; decode headers
+		; .export: N, offset1, ..., offsetN; .import: N, extry offset; .reloc: offset1, offset2, ..., 0
+		bptr := this.Ptr, cptr := bptr + this.Size, eptr := cptr--, exports := [], relocs := []
+		loop read_int() {
+			if eptr <= n := read_int() + bptr
+				throw ValueError('unknown/corrupt code format')
+			exports.Push(n)
+		} else exports.Push(bptr)
+		import_count := read_int()
+		if import_count && eptr < import_count * 4 + import_entry := read_int() + bptr
+			throw ValueError('unknown/corrupt code format')
+		while n := read_int()
+			if eptr <= n += bptr
+				throw ValueError('unknown/corrupt code format')
+			else relocs.Push(n)
+		(n := eptr - cptr += 2) && DllCall('RtlZeroMemory', 'ptr', cptr, 'uptr', n)
+
+		; relocation
+		for n in relocs
+			if eptr <= t := NumGet(n, 'ptr') + bptr
+				throw ValueError('unknown/corrupt code format')
+			else NumPut('ptr', t, n)
+
+		; import symbols
+		if import_count {
+			tp := bits = 32 ? 'uint' : 'int64'
+			import_fn_ptrs := _fn_ptrs := import_fn_ptrs.Get.Bind(import_fn_ptrs, , 0)
+			if bits = A_PtrSize * 8
+				import_fn_ptrs := ((f, n) => f(n) || DllCall('GetProcAddress', 'ptr', mod, 'astr', n, 'ptr')).Bind(import_fn_ptrs)
+			for n in StrSplit(import || '', '|') {
+				t := InStr(n, ':'), r := SubStr(n, 1, t - 1)
+				if r = '?'
+					import_fn_ptrs := _fn_ptrs
+				else if !mod := DllCall('GetModuleHandle', 'str', r, 'ptr') || DllCall('LoadLibrary', 'str', r, 'ptr')
+					throw OSError(,, r)
+				for n in StrSplit(SubStr(n, t + 1), ',', ' ')
+					if !cptr := import_fn_ptrs(n)
+						throw ValueError('unknown import symbol',, r '\' n)
+					else import_entry := NumPut(tp, cptr, import_entry), import_count--
+			}
+			if import_count
+				throw ValueError('wrong number of import symbols', import_count)
+		}
+
+		if bits = A_PtrSize * 8 && !DllCall('VirtualProtect', 'ptr', bptr, 'uint', this.Size, 'uint', 0x40, 'uint*', 0)
+			throw OSError()
+
+		if export_ {
+			if export_ is String
+				export_ := StrSplit(export_, ',')
+			t := exports, exports := Map()
+			loop Min(export_.Length, t.Length)
+				exports[export_[A_Index]] := t[A_Index]
+		}
+		this.DefineProp('__Item', { value: exports })
+			.DefineProp('__Enum', { call: (*) => exports.__Enum() })
+
+		static base64_decode(b64, buf := Buffer()) {
+			if DllCall('crypt32\CryptStringToBinary', 'ptr', b64, 'uint', 0, 'uint', 1, 'ptr', 0, 'uint*', &sz := 0, 'ptr', 0, 'ptr', 0) &&
+				DllCall('crypt32\CryptStringToBinary', 'ptr', b64, 'uint', 0, 'uint', 1, 'ptr', buf, 'uint*', buf.Size := sz, 'ptr', 0, 'ptr', 0)
+				return buf
+			throw OSError()
+		}
+		static lz_decompress(compressBuf, UncompressBuf) {
+			DllCall('ntdll\RtlDecompressBuffer', 'ushort', 2, 'ptr', UncompressBuf, 'uint', UncompressBuf.Size,
+				'ptr', compressBuf, 'uint', compressBuf.Size, 'uint*', &fuSize := 0, 'hresult')
+			if UncompressBuf.Size != fuSize
+				throw ValueError('unknown/corrupt code format')
+		}
+		prop(name) => ObjHasOwnProp(configs, name) && configs.%name%
+		read_int() {
+			n := NumGet(cptr--, 'uchar')
+			switch n & 0xc0 {
+				case 0x80: n := (n & 0x3f) << 8 | NumGet(cptr--, 'uchar')
+				case 0xc0: n := (n & 0x3f) << 24 | NumGet(cptr--, 'uchar') << 16 | NumGet(cptr--, 'uchar') << 8 | NumGet(cptr--, 'uchar')
+			}
+			return n
+		}
+	}
+
+	; Retrieve the export function address
+	__Item[name] => 0
+	; Enumeration of export function addresses
+	__Enum(*) => 0
+}

--- a/tools/mcode/COFFReader.ahk
+++ b/tools/mcode/COFFReader.ahk
@@ -1,0 +1,668 @@
+;
+; COFFReader.ahk — Build-time COFF parser + MCode extraction
+;
+; Source: thqby/ahk2_lib (MIT License)
+; https://github.com/thqby/ahk2_lib
+; Modified from: https://github.com/G33kDude/MCL.ahk/blob/v2/MCL.ahk
+;
+; Copyright (c) 2023 thqby
+; Permission is hereby granted under the MIT License.
+; See: https://github.com/thqby/ahk2_lib/blob/master/LICENSE
+;
+; NOT included in production code — build-time only.
+;
+
+/************************************************************************
+ * @description Modify from {@link https://github.com/G33kDude/MCL.ahk/blob/v2/MCL.ahk}
+ * COFF(Common Object File Format) file reader, compile c/c++ files with cl.exe to get *.obj files,
+ * and then read them to extract MCode.
+ ***********************************************************************/
+class COFFReader extends Buffer {
+	Exports := [], Functions := Map()
+	Symbols := [], SymbolByName := Map()
+	__New(path) {
+		f := FileOpen(path, 'r'), f.Pos := 0
+		this.Size := f.Length
+		f.RawRead(this), f.Close()
+		this.Read()
+	}
+	__Delete() {
+		for k in ObjOwnProps(this)
+			this.%k% := 0
+	}
+	ReadString(Offset, Length?) => StrGet(this.Ptr + Offset, Length?, 'utf-8')
+	ReadUChar(Offset) => NumGet(this, Offset, 'uchar')
+	ReadUShort(Offset) => NumGet(this, Offset, 'ushort')
+	ReadUInt(Offset) => NumGet(this, Offset, 'uint')
+
+	ReadSection(HeadersBase, HeaderIndex) {
+		static SIZEOF_SECTION_HEADER := 40
+
+		HeaderOffset := HeadersBase + (HeaderIndex * SIZEOF_SECTION_HEADER)
+		Result := {
+			Index: HeaderIndex,
+			Name: this.ReadString(HeaderOffset, 8),
+			VirtualSize: this.ReadUInt(HeaderOffset + 8),
+			VirtualAddress: this.ReadUInt(HeaderOffset + 12),
+			FileSize: this.ReadUInt(HeaderOffset + 16),
+			FileOffset: this.ReadUInt(HeaderOffset + 20),
+			RelocationsOffset: this.ReadUInt(HeaderOffset + 24),
+			RelocationCount: this.ReadUInt(HeaderOffset + 32),
+			Characteristics: this.ReadUInt(HeaderOffset + 36),
+			Relocations: [],
+			Symbols: []
+		}
+
+		align := Result.Characteristics >>> 20 & 0xf
+		Result.Align := align ? 1 << --align : 0
+
+		if (SubStr(Result.Name, 1, 1) = '/') {
+			Result.Name := this.ReadString(this.StringTableOffset + SubStr(Result.Name, 2))
+		} else if Result.Name = '.drectve' {
+			drectve := this.ReadString(Result.FileOffset, Result.FileSize), pos := 1
+			while pos := RegExMatch(drectve, '/EXPORT:(\S+)\K', &m, pos)
+				this.Exports.Push(this.SymbolByName[RegExReplace(m[1], ',DATA$')])
+		}
+
+		if !Result.FileOffset {
+			; As mentioned, a section initialized to 0, which has no space allocated for it in the file. So we
+			;  need to allocate some space for it.
+			_buf := Buffer(Result.FileSize, 0), InitialData := _buf.Ptr
+		} else {
+			InitialData := this.Ptr + Result.FileOffset
+		}
+
+		Result.Data := COFFReader.Data(InitialData, Result.FileSize, _buf?)
+		NextRelocationOffset := Result.RelocationsOffset
+
+		loop Result.RelocationCount {
+			; All relocations are processed later, but it is easiest to read them early and have them ready
+			;  whenever we need.
+			RelocationAddress := this.ReadUInt(NextRelocationOffset)
+			SymbolIndex := this.ReadUInt(NextRelocationOffset + 4)
+			RelocationType := this.ReadUShort(NextRelocationOffset + 8)
+			NextRelocationOffset += 10
+			RelocationSymbol := this.Symbols[SymbolIndex + 1]
+			Result.Relocations.Push({
+				Address: RelocationAddress,
+				Type: RelocationType,
+				Symbol: RelocationSymbol
+			})
+		}
+
+		; Technically, symbols are global. But each one exists inside of a single section, so we can filter the
+		; global list of symbols into the sections living inside of each section to make things a bit easier.
+
+		for Symbol in this.Symbols {
+			if !IsSet(Symbol) || Symbol.SectionIndex != HeaderIndex + 1
+				continue
+			Symbol.Section := Result
+			Result.Symbols.Push(Symbol)
+		}
+
+		return Result
+	}
+
+	ReadSymbolHeader(HeaderOffset) {
+		if (this.ReadUInt(HeaderOffset)) {
+			Name := this.ReadString(HeaderOffset, 8)
+		} else {
+			Name := this.ReadString(this.StringTableOffset + this.ReadUInt(HeaderOffset + 4))
+		}
+
+		return {
+			Name: Name,
+			Value: this.ReadUInt(HeaderOffset + 8),
+			SectionIndex: this.ReadUShort(HeaderOffset + 12),
+			Type: this.ReadUShort(HeaderOffset + 14),
+			StorageClass: this.ReadUChar(HeaderOffset + 16),
+			AuxSymbolCount: this.ReadUChar(HeaderOffset + 17)
+		}
+	}
+
+	MergeSections(Target, Sources*) {
+		; Given a target section, and multiple source sections, join them all into a single section.
+		; This is done by appending the 'source' section's data to the 'target' section's data, and
+		;  then adding the offset of the 'source' inside of the 'target' to every symbol/relocation
+		;   inside of the 'source'.
+		; Then, the 'source' symbols can just be added to the 'target' symbol lists, and the 'source'
+		;  relocations can just be added to the 'target' relocation list.
+
+		for Section in Sources {
+			if Section = Target
+				continue
+
+			OffsetInTarget := Target.Data.Length()
+			Align := Section.Align
+			Section.Offset := Offset := (OffsetInTarget + --Align) & ~Align
+			if Offset > OffsetInTarget {
+				buf := Buffer(Offset - OffsetInTarget, InStr(Section.Name, '.text') = 1 && 0xcc)
+				Target.Data.Push({ Ptr: buf.Ptr, Size: buf.Size, Buf: buf })
+				OffsetInTarget := Offset
+			}
+			Target.Data.Add(Section.Data)	; Merge section data
+
+			for Symbol in Section.Symbols {
+				Symbol.Value += OffsetInTarget
+				Symbol.Section := Target
+				Target.Symbols.Push(Symbol)
+			}
+
+			for Relocation in Section.Relocations {
+				Relocation.Address += OffsetInTarget
+				Target.Relocations.Push(Relocation)
+			}
+
+			Target.RelocationCount += Section.RelocationCount
+		}
+	}
+
+	Read() {
+		; Load all fields from the COFF file loaded into this instance
+
+		static SIZEOF_COFF_HEADER := 20
+		static SIZEOF_SECTION_HEADER := 40
+		static SIZEOF_SYMBOL := 18
+
+		Magic := this.ReadUShort(0)
+		this.Is32Bit := Magic = 0x14c
+		this.Is64Bit := Magic = 0x8664
+
+		if (this.Is32Bit + this.Is64Bit != 1) {
+			throw Error('Not a valid 32/64 bit COFF file')
+		}
+
+		SymbolTableOffset := this.ReadUInt(8)
+		SymbolCount := this.ReadUInt(12)
+		SymbolIndex := 0
+
+		this.StringTableOffset := SymbolTableOffset + (SymbolCount * SIZEOF_SYMBOL)
+		this.Symbols.Default := {}
+
+		while (SymbolIndex < SymbolCount) {
+			this.Symbols.Push(NextSymbol := this.ReadSymbolHeader(SymbolTableOffset + (SymbolIndex * SIZEOF_SYMBOL)))
+
+			if NextSymbol.Type = 0x20
+				this.Functions[NextSymbol.Name] := NextSymbol
+
+			if NextSymbol.StorageClass = 2 && NextSymbol.SectionIndex
+				this.SymbolByName[NextSymbol.Name] := NextSymbol
+
+			; Aux symbols only serve to pad out the symbol table so the indexes inside of relocations are correct.
+			this.Symbols.Length += NextSymbol.AuxSymbolCount
+
+			; IMAGE_SYM_CLASS_WEAK_EXTERNAL
+			if NextSymbol.StorageClass = 105 && NextSymbol.AuxSymbolCount {
+				Offset := SymbolTableOffset + (SymbolIndex + 1) * SIZEOF_SYMBOL
+				Index := this.ReadUInt(Offset), Characteristics := this.ReadUInt(Offset + 4)
+				switch this.ReadUInt(Offset + 4) {
+					case 4:	; IMAGE_WEAK_EXTERN_ANTI_DEPENDENCY
+						throw Error('unimplemented')
+					case 2:	; IMAGE_WEAK_EXTERN_SEARCH_LIBRARY
+						this.Symbols[SymbolIndex + 1].WeakExternal := this.Symbols[Index + 1]
+						throw Error('unimplemented')
+					default:	; IMAGE_WEAK_EXTERN_SEARCH_NOLIBRARY, IMAGE_WEAK_EXTERN_SEARCH_ALIAS
+						this.Symbols[SymbolIndex + 1] := this.Symbols[Index + 1]
+				}
+			}
+
+			SymbolIndex += 1 + NextSymbol.AuxSymbolCount
+		}
+
+		SectionHeaderCount := this.ReadUShort(2)
+		SizeOfOptionalHeader := this.ReadUShort(16)
+		SectionHeaderTableOffset := SIZEOF_COFF_HEADER + SizeOfOptionalHeader
+		this.Sections := [], this.UndefinedSymbols := Map()
+
+		loop SectionHeaderCount {
+			NextSection := this.ReadSection(SectionHeaderTableOffset, (A_Index - 1))
+			this.Sections.Push(NextSection)
+		}
+
+		for Symbol in this.Symbols {
+			if IsSet(Symbol) && !Symbol.HasOwnProp('Section') && !Symbol.SectionIndex
+				this.UndefinedSymbols[Symbol.Name] := Symbol
+		}
+	}
+
+	DoStaticRelocations(Section) {
+		; Resolve any relocations which are independent of the image base/load address.
+		; On 64 bit, this is anything RIP-relative to `Section`, or DISP8/DISP32 operands.
+		; On 32 bit, this is only DISP8/DISP32 operands, since RIP-relative doesn't exist.
+
+		; Note: The relocation list is cloned since we'll be modifying it to remove any relocations resolved
+		;  entirely within this function.
+		relocations := [], data := Section.Data, apply := this.Is32Bit ? ApplyRelx86 : ApplyRelx64
+		for Relocation in Section.Relocations {
+			if (Relocation.Symbol.Section != Section) {
+				; If the data is relocated against a symbol in any other section, we can't resolve it, since
+				;  we don't actually know the offset between the two sections.
+
+				continue
+			}
+
+			apply(Relocation)
+		}
+		return relocations
+		ApplyRelx86(reloc) {
+			static IMAGE_REL_I386_DIR32 := 0x6
+			static IMAGE_REL_I386_DIR32NB := 0x7
+			static IMAGE_REL_I386_REL32 := 0x14
+			off := reloc.Address
+			s := reloc.Symbol.Value
+			switch rt := reloc.Type {
+				case IMAGE_REL_I386_DIR32:
+					data.Write(data.Read(off, 'int') + s, off, 'int')
+					relocations.Push(off)
+				case IMAGE_REL_I386_DIR32NB:
+					data.Write(data.Read(off, 'int') + s, off, 'int')
+				case IMAGE_REL_I386_REL32:
+					data.Write(data.Read(off, 'int') + s - off - 4, off, 'int')
+				default: throw Error(Format('unsupported relocation type: 0x{:02x}', rt))
+			}
+		}
+		ApplyRelx64(reloc) {
+			static IMAGE_REL_AMD64_ADDR64 := 0x1
+			static IMAGE_REL_AMD64_ADDR32 := 0x2
+			static IMAGE_REL_AMD64_ADDR32NB := 0x3
+			static IMAGE_REL_AMD64_REL32 := 0x4
+			static IMAGE_REL_AMD64_REL32_1 := 0x5
+			static IMAGE_REL_AMD64_REL32_2 := 0x6
+			static IMAGE_REL_AMD64_REL32_3 := 0x7
+			static IMAGE_REL_AMD64_REL32_4 := 0x8
+			static IMAGE_REL_AMD64_REL32_5 := 0x9
+			off := reloc.Address
+			s := reloc.Symbol.Value
+			switch rt := reloc.Type {
+				case IMAGE_REL_AMD64_ADDR64:
+					data.Write(data.Read(off, 'int64') + s, off, 'int64')
+					relocations.Push(off)
+				case IMAGE_REL_AMD64_ADDR32:
+					data.Write(data.Read(off, 'int') + s, off, 'int')
+					relocations.Push(off)
+				case IMAGE_REL_AMD64_ADDR32NB:
+					data.Write(data.Read(off, 'int') + s, off, 'int')
+				case IMAGE_REL_AMD64_REL32:
+					data.Write(data.Read(off, 'int') + s - off - 4, off, 'int')
+				case IMAGE_REL_AMD64_REL32_1:
+					data.Write(data.Read(off, 'int') + s - off - 5, off, 'int')
+				case IMAGE_REL_AMD64_REL32_2:
+					data.Write(data.Read(off, 'int') + s - off - 6, off, 'int')
+				case IMAGE_REL_AMD64_REL32_3:
+					data.Write(data.Read(off, 'int') + s - off - 7, off, 'int')
+				case IMAGE_REL_AMD64_REL32_4:
+					data.Write(data.Read(off, 'int') + s - off - 8, off, 'int')
+				case IMAGE_REL_AMD64_REL32_5:
+					data.Write(data.Read(off, 'int') + s - off - 9, off, 'int')
+				default: throw Error(Format('unsupported relocation type: 0x{:02x}', rt))
+			}
+		}
+	}
+
+	/**
+	 * @param {Map} Result - Map to populate with dependencies
+	 */
+	CollectSectionDependencies(Result, Target) {
+		; Given a section `Target`, set `Result[RequiredSectionName] := RequiredSection` for each
+		; section which `Target` requires loaded into memory in order to run correctly.
+		; And of course, this includes any sections which `RequiredSection` itself requires, and so on.
+
+		if (Result.Has(index := Target.Index))
+			return
+
+		Result[index] := Target
+
+		for Relocation in Target.Relocations
+			if Relocation.Symbol.SectionIndex
+				this.CollectSectionDependencies(Result, Relocation.Symbol.Section)
+			else (Result.Get(0, 0) || Result[0] := (t := Map(), t.Default := 0, t))[Relocation.Symbol]++
+	}
+
+	class Data extends Array {
+		; Just a list of 'fragments' of data, aka an easy way to join multiple smaller buffers into one larger one without
+		;  loads of copies (at least until all data needs to be written to a single buffer, aka coalesced)
+
+		__New(Ptr?, Size?, Buf?) => IsSet(Ptr) && this.Push({ Ptr: Ptr, Size: Size, Buf: Buf? })
+		Add(Data, Size?) => IsObject(Data) ? this.Push(Data*) : this.Push({ Ptr: Data, Size: Size })
+		Length() {
+			Result := 0
+			for v in this
+				Result += v.Size
+			return Result
+		}
+		/**
+		 * Merge all fragments into a single buffer
+		 */
+		Coalesce(Dest) {
+			for v in this {
+				DllCall('RtlMoveMemory', 'ptr', Dest, 'ptr', v, 'uptr', v.Size)
+				Dest += v.Size
+			}
+		}
+		Read(Offset, Type) {
+			for v in this {
+				if (Offset < v.Size)
+					return NumGet(v, Offset, Type)
+				Offset -= v.Size
+			}
+			throw Error('Attempt to read from offset past end of section data')
+		}
+		Write(Value, Offset, Type) {
+			for v in this {
+				if (Offset < v.Size)
+					return NumPut(Type, Value, v, Offset)
+				Offset -= v.Size
+			}
+			throw Error('Attempt to write to offset past end of section data')
+		}
+	}
+	static __New() {
+		COFFReader.DeleteProp('__New')
+		if ObjHasOwnProp(Array.Prototype, 'Sort')
+			return
+		for v in ['Filter', 'Join', 'Map', 'Sort']
+			Array.Prototype.DefineProp(v, { call: _%v% })
+		static _Filter(this, fn) {
+			t := []
+			for i in this
+				fn(i) && t.Push(i)
+			return t
+		}
+		static _Join(this, c) {
+			s := '', l := this.Length
+			loop l - 1
+				s .= this[A_Index] c
+			return l ? s this[l] : s
+		}
+		static _Map(this, fn) {
+			t := []
+			for i in this
+				t.Push(fn(i))
+			return t
+		}
+		static _Sort(this, fn) {
+			s := '', c := [this*]
+			loop this.Length
+				s .= ',' A_Index
+			s := Sort(LTrim(s, ','), 'D,', (a, b, *) => fn(this[a], this[b]))
+			for i in StrSplit(s, ',')
+				this[A_Index] := c[i]
+			return this
+		}
+	}
+}
+
+ExtractMCode(msvc_obj, import_dlls := [], api_rename := Map(), debug := true) {
+	static IMAGE_REL_I386_DIR32 := 0x6
+	static IMAGE_REL_AMD64_REL32 := 0x4
+	sections := Map(), exports := msvc_obj.Exports
+	if !exports.Length
+		exports.Push(msvc_obj.Functions.__Enum().Bind(&_)*)
+	for , symbol in exports
+		msvc_obj.CollectSectionDependencies(sections, symbol.Section)
+
+	if sections.Has(0) && (imports := sections.Delete(0)).Count {
+		dlls := Map('?', []), dlln := Map(), dllet := Map(), ptrsize := msvc_obj.Is32Bit ? 4 : 8
+		thunk := {
+			Align: ptrsize,
+			; Data: COFFReader.Data(),
+			Name: '.text',
+			Index: 65535,
+			RelocationCount: 0,
+			Relocations: [],
+			Symbols: []
+		}
+		for n in import_dlls
+			dllet[n] := GetExportTable(n, msvc_obj.Is64Bit), dlln[n] := 0, dlls[n] := []
+
+		has_export := Map.Prototype.Has
+		symbols := [imports*].Sort((a, b) => imports[b] - imports[a])
+		get_name := api_rename.Get.Bind(api_rename, , 0), is32 := msvc_obj.Is32Bit
+		resolved := Map(), RELOCTYPE := msvc_obj.Is32Bit ? IMAGE_REL_I386_DIR32 : IMAGE_REL_AMD64_REL32
+next:
+		for fn in symbols {
+			if isimp := fn.Name ~= '^__imp_'
+				fnn := fn.Name := SubStr(fn.Name, 7)
+			else fnn := fn.Name
+			if resolved.Has(fnn)
+				continue
+			resolved[fnn] := 1
+			if !isimp {
+				imports[_ := fn.Clone()] := imports.Delete(fn)
+				fn.Value := thunk.Symbols.Length * 6
+				thunk.RelocationCount++
+				thunk.Relocations.Push({
+					Address: fn.Value + 2,
+					Type: RELOCTYPE,
+					Symbol: _
+				})
+				thunk.Symbols.Push(fn)
+				fn.Section := thunk
+				fn := _
+				; void __cdecl operator delete(void*, size_t) -> void __cdecl operator delete(void*)
+				if ptrsize = 8 {
+					if fnn == '??3@YAXPEAX_K@Z'
+						fnn := fn.Name := '??3@YAXPEAX@Z'
+				} else if fnn == '??3@YAXPAXI@Z'
+					fnn := fn.Name := '??3@YAXPAX@Z'
+			}
+			for n in import_dlls
+				if has_export(et := dllet[n], fnn) ||
+					; 32bit, __stdcall: fnname -> _fnname, __cdecl: fnname -> _fnname@n
+					(is32 && RegExMatch(fnn, '^_(\S+?)(@\d+)?$', &m) && has_export(et, m := m[1]) ||
+						(m := get_name(fnn)) && has_export(et, m)) && fn.Name := m {
+							dlls[n].Push(fn), dlln[n] += imports[fn]
+							continue next
+				}
+			dlls['?'].Push(fn)
+		}
+
+		imports := '', symbols := [], i := 0
+		import_dlls := import_dlls.Filter(a => dlln[a]).Sort((a, b) => dlln[b] - dlln[a])
+		dlls['?'].Length && import_dlls.Push('?')
+
+		for n in import_dlls {
+			imports .= n ':'
+			for symbol in dlls[n]
+				imports .= symbol.Name ',', symbols.Push(symbol), symbol.Value := ptrsize * i++
+			imports .= '|'
+		}
+
+		buf := Buffer(ptrsize * i, 0)
+		imports := SubStr(StrReplace(imports, ',|', '|'), 1, -1)
+		sections[0] := import_section := {
+			Align: ptrsize,
+			Data: COFFReader.Data(buf.Ptr, buf.Size, buf),
+			Name: '.rdata',
+			Index: 0,
+			RelocationCount: 0,
+			Relocations: [],
+			Symbols: symbols
+		}
+		if i := thunk.Symbols.Length {
+			buf := Buffer(i * 6, 0)
+			thunk.Data := COFFReader.Data(ptr := buf.Ptr, buf.Size, buf)
+			loop i
+				ptr := NumPut('ushort', 0x25ff, ptr) + 4	; jmp: ff 25 00 00 00 00
+			sections[-1] := thunk
+		}
+	}
+
+	sections := [sections.__Enum().Bind(&_)*].Sort((a, b) => StrCompare(b.Name, a.Name) || a.Index - b.Index)
+	mergedSection := {
+		Name: '',
+		Data: COFFReader.Data(),
+		RelocationCount: 0,
+		Relocations: [],
+		RelocationsOffset: 0,
+		Symbols: [],
+		VirtualAddress: 0,
+		VirtualSize: 0
+	}
+
+	msvc_obj.MergeSections(mergedSection, sections*)
+	buf := Buffer(mergedSection.Data.Length())
+	if !buf.Size
+		throw Error('code is empty')
+	mergedSection.Data.Coalesce(basePtr := buf.Ptr)
+	mergedSection.Data := COFFReader.Data(basePtr, buf.Size, buf)
+	relocs := msvc_obj.DoStaticRelocations(mergedSection)
+
+	; The header is appended to the first non-zero at the end with flashback.
+	; .export: N, offset1, ..., offsetN; .import: N, extry offset; .reloc: offset1, offset2, ..., 0
+	; Integer compression format
+	; 1byte: 0xxxxxxx; 2byte: 10xxxxxx xxxxxxxx; 4byte: 11xxxxxx xxxxxxxx xxxxxxxx xxxxxxxx
+	headers := [], obj := {}
+	if exports.Length = 1 && !exports[1].Value		; Only an export and offset = 0
+		headers.Push(0)
+	else headers.Push(exports.Length, exports.Map(v => v.Value)*)
+	obj.export := exports.Map(v => v.Name).Join(',')
+	if IsSet(import_section)
+		obj.import := imports, headers.Push(import_section.Symbols.Length, import_section.Offset)
+	else headers.Push(0)
+	headers.Push(relocs*), header_buf := compress_headers(headers)
+	p := basePtr + buf.Size, lp := Max(p - header_buf.Size, basePtr)
+	while p > lp && !NumGet(p - 1, 'uchar')
+		p--
+	offset := p - basePtr
+	if expand := Max(header_buf.Size + offset - buf.Size, 0)
+		buf.Size += expand
+	DllCall('RtlMoveMemory', 'ptr', buf.Ptr + offset, 'ptr', header_buf, 'uptr', header_buf.Size)
+
+	; LZ format compression code, if the compression rate is low, it will not be compressed.
+	compress := lz_compress(buf), hex_size := Format('{:x}', buf.Size)
+	if (buf.Size - compress.Size) * 1.3333 <= StrLen(hex_size) + 1
+		compress := '', obj.code := base64_encode(buf)
+	else obj.code := hex_size ',' base64_encode(compress)
+
+	if debug {
+		stdout := FileOpen('*', 'w')
+		stdout.Write(Format('BASE64{}:`n', compress && '(LZCompress)') obj.code)
+		stdout.Write('`n`nEXPORT OFFSETS:`n' exports.Map(v => v.Value '`t' v.Name).Join('`n'))
+		stdout.Write(Format('`n`n{}BIT CODE WITH {} BYTE HEADER:`n', 32 << msvc_obj.Is64Bit, header_buf.Size) base64_encode(buf, 0xb))
+		(relocs.Length) && stdout.Write('`nRELOCATION OFFSETS:`n' relocs.Join(', '))
+		if IsSet(import_section) {
+			stdout.Write('`n`nIMPORT TABLE ENTRY OFFSET: ' import_section.Offset)
+			stdout.Write('`n' StrReplace(imports, '|', '`n') '`n')
+			if dlls['?'].Length {
+				stdout.Write('`nUNKNOWN IMPORT SYMBOLS:')
+				for symbol in dlls['?']
+					n := symbol.Name, stdout.Write('`n' n (SubStr(n, 1, 1) = '?' ? (' `t' UnDecorateSymbolName(n)) : ''))
+			}
+		}
+		stdout.Read(0), stdout.Close()
+	}
+
+	return { %32 << msvc_obj.Is64Bit%: ObjOwnPropCount(obj) = 1 ? obj.code : obj }
+
+	static base64_encode(Buf, Codec := 0x40000001) {
+		p := Buf, s := Buf.Size
+		if DllCall('crypt32\CryptBinaryToString', 'Ptr', p, 'UInt', s, 'UInt', Codec, 'Ptr', 0, 'Uint*', &sz := 0) &&
+			(VarSetStrCapacity(&str, sz << 1), DllCall('crypt32\CryptBinaryToString', 'Ptr', p, 'UInt', s, 'UInt', Codec, 'Str', str, 'Uint*', &sz))
+			return (VarSetStrCapacity(&str, -1), str)
+	}
+	static compress_headers(ns) {
+		ps := [0], sz := 1, l := ns.Length
+		loop l {
+			n := ns[l--]
+			if n < 0x80
+				sz++, ps.Push(n)
+			else if n < 0x4000
+				sz += 2, ps.Push(n & 0xff, n >> 8 | 0x80)
+			else if n < 0x40000000
+				sz += 4, ps.Push(n & 0xff, n >> 8 & 0xff, n >> 16 & 0xff, n >> 24 | 0xc0)
+			else throw ValueError('out of range')
+		}
+		buf := Buffer(sz), p := buf.Ptr
+		for n in ps
+			p := NumPut('uchar', n, p)
+		return buf
+	}
+	static lz_compress(data) {
+		DllCall('ntdll\RtlGetCompressionWorkSpaceSize', 'ushort', 0x102, 'uint*', &cbwsSize := 0, 'uint*', &cfwsSize := 0)
+		DllCall('ntdll\RtlCompressBuffer', 'ushort', 0x102, 'ptr', data, 'uint', data.Size,
+			'ptr', cb := Buffer(data.Size << 1), 'uint', cb.Size,
+			'uint', cfwsSize, 'uint*', &fcSize := 0, 'ptr', Buffer(cbwsSize))
+		cb.Size := fcSize
+		return cb
+	}
+	static UnDecorateSymbolName(Decorated) {
+		if (size := DllCall('imagehlp\UnDecorateSymbolName', 'astr', Decorated, 'ptr', UnDecorated := Buffer(2048, 0), 'uint', 2048, 'uint', 0, 'uint'))
+			return StrGet(UnDecorated, size, 'cp0')
+		return Decorated
+	}
+}
+
+GetExportTable(DllPath, Is64bit := true) {
+	static LocSignatureOff := 0x3c, SizeOfCoffHdr := 20, SizeOfSectionHdr := 40, SizeOfSignature := 4
+	SplitPath(DllPath := SearchDllPath(DllPath, !Is64bit), &FileName, , &ext)
+	Exports := Map(), Exports.Name := ext = 'dll' && !InStr(FileName, '.', , , 2) ? SubStr(FileName, 1, -4) : FileName
+
+	DllFile := FileOpen(DllPath, 'r')
+	if DllFile.Pos || DllFile.ReadUShort() != 0x5a4d ||
+		(DllFile.Pos := LocSignatureOff, DllFile.Pos := DllFile.ReadUInt(), DllFile.ReadUInt() != 0x4550)
+		throw Error('not a valid DLL or EXE file')
+
+	DllFile.RawRead(RawBytes := Buffer(SizeOfCoffHdr))
+	Machine := NumGet(RawBytes, 0, 'ushort')
+	if Machine != 0x014c && Machine != 0x8664
+		throw Error('wrong CPU type')
+	NumberOfSections := NumGet(RawBytes, 2, 'ushort')
+	SizeOfOptionalHeader := NumGet(RawBytes, 16, 'ushort')
+	Characteristics := NumGet(RawBytes, 18, 'ushort')
+	if !((Characteristics & 0x2000) || (Characteristics & 0x3))
+		throw Error('not a valid DLL or EXE file')
+
+	DllFile.RawRead(RawBytes := Buffer(SizeOfOptionalHeader))
+	Magic := NumGet(RawBytes, 0, 'ushort')
+	if !Is64bit = (Magic = 0x020b)
+		throw TargetError()
+	OffSet := 92 + (Is64bit && 16)
+	SizeOfImage := NumGet(RawBytes, 56, 'uint')
+	if (NumberOfRvaAndSizes := NumGet(RawBytes, OffSet + 0, 'uint')) < 1
+		|| (ExportAddr := NumGet(RawBytes, OffSet + 4, 'uint')) < 1
+		|| (ExportSize := NumGet(RawBytes, OffSet + 8, 'uint')) < 1
+		return Exports
+
+	DllFile.RawRead(RawBytes := Buffer(SizeOfSectionHdr * NumberOfSections))
+	ImageData := Buffer(SizeOfImage, 0), OffSet := 0
+	loop NumberOfSections {
+		VirtualAddress := NumGet(RawBytes, OffSet + 12, 'uint'), SizeOfRawData := NumGet(RawBytes, OffSet + 16, 'uint')
+		PointerToRawData := NumGet(RawBytes, OffSet + 20, 'uint'), OffSet += SizeOfSectionHdr
+		DllFile.Pos := PointerToRawData, DllFile.RawRead(ImageData.Ptr + VirtualAddress, SizeOfRawData)
+	}
+
+	ImageBase := ImageData.Ptr, EndOfSection := ExportAddr + ExportSize, Addr := ExportAddr + ImageBase
+	FuncCount := NumGet(Addr + 0x14, 'uint')
+	NameCount := NumGet(Addr + 0x18, 'uint')
+	FuncTblPtr := ImageBase + NumGet(Addr + 0x1c, 'uint')
+	NameTblPtr := ImageBase + NumGet(Addr + 0x20, 'uint')
+	OrdTblPtr := ImageBase + NumGet(Addr + 0x24, 'uint')
+
+	loop NameCount {
+		NamePtr := NumGet(NameTblPtr, 'uint'), Ordinal := NumGet(OrdTblPtr, 'ushort')
+		FnAddr := NumGet(FuncTblPtr + (Ordinal * 4), 'uint'), NameTblPtr += 4, OrdTblPtr += 2
+		EntryPt := FnAddr > ExportAddr && FnAddr < EndOfSection ? StrGet(ImageBase + FnAddr, 'cp0') : FnAddr
+		Exports[StrGet(ImageBase + NamePtr, 'cp0')] := EntryPt
+	}
+	return Exports
+	SearchDllPath(path, is32bit := false) {
+		SplitPath(StrReplace(path, '/', '\'), , &dir, &ext, &name)
+		ext := '.' (ext || 'dll'), dir && dir .= '\'
+		if DllCall('SearchPath', 'ptr', 0, 'str', dir name ext, 'ptr', 0, 'uint', 2048, 'ptr', b := Buffer(4096), 'ptr', 0) {
+			path1 := StrGet(b), path := dir name ext
+			if is32bit && A_Is64bitOS && path = SubStr(path2 := StrReplace(path1, A_WinDir '\System32\', A_WinDir '\SysWOW64\'), -StrLen(path))
+				return path2
+			return path1
+		}
+		if FileExist(path1 := dir RegExReplace(name, '(32|64)$', is32bit ? '32' : '64') ext)
+			return path1
+		if dir {
+			if FileExist(path1 := RegExReplace(dir, 'i)(?<=(^|\\))x(86|64)(?=\\)', is32bit ? 'x86' : 'x64') name ext)
+				return path1
+			if FileExist(path1 := RegExReplace(dir, 'i)(?<=(^|\\))(32|64)(?=bit\\)', is32bit ? '32' : '64') name ext)
+				return path1
+		}
+		return path
+	}
+}

--- a/tools/mcode/MCODE_PIPELINE.md
+++ b/tools/mcode/MCODE_PIPELINE.md
@@ -1,0 +1,149 @@
+# MCode Build Pipeline
+
+Embed native C functions as machine code in AHK scripts for performance-critical operations.
+
+## Components
+
+| Component | Location | Role |
+|-----------|----------|------|
+| **MCodeLoader.ahk** | `src/lib/` | Runtime: loads base64 MCode blobs, resolves imports, named exports |
+| **COFFReader.ahk** | `tools/mcode/` | Build-time: parses MSVC `.obj` files, extracts MCode blobs |
+| **build_mcode.ps1** | `tools/mcode/` | Build-time: end-to-end C source → paste-ready AHK blob |
+| **extract_mcode.ahk** | `tools/mcode/` | Build-time: AHK runner wrapping COFFReader + ExtractMCode |
+
+## Prerequisites
+
+- **MSVC** — Visual Studio Build Tools (or full VS) with C++ workload
+- **AutoHotkey v2 x64** — for running the extraction step
+
+## Adding New MCode Functions
+
+### 1. Write C source
+
+```c
+/* No CRT dependency. Use __declspec(dllexport) for all functions. */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT __declspec(dllexport) __cdecl
+#endif
+
+int EXPORT my_function(const unsigned char *data, unsigned int count) {
+    /* pure computation — no CRT calls */
+    return 0;
+}
+```
+
+Constraints:
+- No CRT functions unless you add the DLL to `-ImportDlls`
+- `__declspec(dllexport)` on all functions you want accessible
+- `__cdecl` calling convention on x86 (the `EXPORT` macro handles this)
+
+### 2. Compile + extract
+
+```powershell
+.\tools\mcode\build_mcode.ps1 -Source path\to\my_func.c
+```
+
+This compiles for both x64 and x86, then prints paste-ready base64 blobs.
+
+Compile flags used: `cl /O2 /c /GS- /Zl /nologo`
+- `/O2` — optimize for speed
+- `/c` — compile only (no link)
+- `/GS-` — disable stack buffer security checks (no CRT dependency)
+- `/Zl` — omit default library name from .obj
+- `/nologo` — suppress banner
+
+### 3. Paste into AHK wrapper
+
+```ahk
+#Include MCodeLoader.ahk
+
+class MyNativeFunc {
+    static _mc := MyNativeFunc._Init()
+
+    static DoWork(dataBuf, count) {
+        return DllCall(this._mc['my_function']
+            , "ptr", dataBuf, "uint", count, "cdecl int")
+    }
+
+    static _Init() {
+        static configs := {
+            64: {
+                code: "<paste x64 BASE64 blob here>"
+            },
+            32: {
+                code: "<paste x86 BASE64 blob here>"
+            },
+            export: "my_function"
+        }
+        return MCodeLoader(configs)
+    }
+}
+```
+
+### 4. Call it
+
+```ahk
+result := MyNativeFunc.DoWork(buf.Ptr, buf.Size // 4)
+```
+
+## Import Support
+
+When C code calls Windows APIs (e.g., `MessageBoxA`, `VirtualAlloc`):
+
+```powershell
+.\tools\mcode\build_mcode.ps1 -Source my_func.c -ImportDlls kernel32,user32
+```
+
+MCodeLoader resolves these at load time via `GetProcAddress`. The import info is embedded in the blob by COFFReader.
+
+In the AHK configs, imports appear automatically:
+
+```ahk
+64: {
+    code: "<blob>",
+    import: "kernel32:VirtualAlloc|user32:MessageBoxA"
+}
+```
+
+## Architecture Support
+
+- Compile for both with `-Arch both` (default)
+- Compile for one with `-Arch x64` or `-Arch x86`
+- MCodeLoader selects the right blob at runtime based on `A_PtrSize`
+- If only one architecture is provided, MCodeLoader throws `ValueError` on mismatch
+
+## Existing MCode in the Project
+
+| Module | Loader | Source | Notes |
+|--------|--------|--------|-------|
+| **icon_alpha.ahk** | MCodeLoader | `tools/native_benchmark/native_src/icon_alpha.c` | Alpha scan + mask for icons. 32+64 bit. |
+| **cjson.ahk** | MCLib (G33kDude) | N/A (pre-built) | Third-party JSON parser. Don't touch. |
+| **ShinsOverlayClass.ahk** | Custom GlobalAlloc | N/A (pre-built) | Third-party overlay. Don't touch. |
+
+## Benchmarking
+
+Before embedding new MCode, validate performance gains using `tools/native_benchmark/`:
+
+1. Write an AHK benchmark script comparing native vs AHK implementation
+2. Run multiple iterations to get stable measurements
+3. Verify correctness (same output as AHK version)
+
+## Troubleshooting
+
+**"Could not find vcvarsall.bat"**
+Install Visual Studio Build Tools with "Desktop development with C++" workload.
+
+**"Could not find AutoHotkey64.exe"**
+Install AutoHotkey v2 or ensure it's on PATH.
+
+**"unknown import symbol"**
+The C code references a Windows API that isn't in the listed import DLLs. Add the DLL with `-ImportDlls`.
+
+**"No matching machine code"**
+Running 32-bit AHK but only 64-bit blob provided (or vice versa). Compile for both architectures.
+
+**Wrong results after recompilation**
+If you changed the C source and recompiled, make sure to paste the NEW base64 blob. Old blobs with magic offsets won't work if function layout changed — MCodeLoader's named exports handle this automatically.

--- a/tools/mcode/build_mcode.ps1
+++ b/tools/mcode/build_mcode.ps1
@@ -1,0 +1,166 @@
+#
+# build_mcode.ps1 — Unified MCode build pipeline
+#
+# Compiles C source to .obj via MSVC, then extracts MCode via COFFReader.
+#
+# Usage:
+#   .\tools\mcode\build_mcode.ps1 -Source <path.c> [-Arch <x64|x86|both>] [-ImportDlls <dll1,dll2>]
+#
+# Examples:
+#   .\tools\mcode\build_mcode.ps1 -Source tools\native_benchmark\native_src\icon_alpha.c
+#   .\tools\mcode\build_mcode.ps1 -Source my_func.c -Arch x64 -ImportDlls kernel32,user32
+#
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Source,
+
+    [ValidateSet("x64", "x86", "both")]
+    [string]$Arch = "both",
+
+    [string]$ImportDlls = ""
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Resolve source path
+$Source = Resolve-Path $Source -ErrorAction Stop
+
+# Find vswhere to locate MSVC
+function Find-VsWhere {
+    $paths = @(
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        "${env:ProgramFiles}\Microsoft Visual Studio\Installer\vswhere.exe"
+    )
+    foreach ($p in $paths) {
+        if (Test-Path $p) { return $p }
+    }
+    return $null
+}
+
+function Find-VcVarsAll {
+    $vswhere = Find-VsWhere
+    if ($vswhere) {
+        $installPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
+        if ($installPath) {
+            $vcvars = Join-Path $installPath "VC\Auxiliary\Build\vcvarsall.bat"
+            if (Test-Path $vcvars) { return $vcvars }
+        }
+    }
+
+    # Fallback: hardcoded VS2022 Community path
+    $fallback = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat"
+    if (Test-Path $fallback) { return $fallback }
+
+    throw "Could not find vcvarsall.bat. Install Visual Studio Build Tools with C++ workload."
+}
+
+function Find-AHK {
+    # Try PATH first
+    $ahk = Get-Command "AutoHotkey64.exe" -ErrorAction SilentlyContinue
+    if ($ahk) { return $ahk.Source }
+
+    # Standard install location
+    $standard = "C:\Program Files\AutoHotkey\v2\AutoHotkey64.exe"
+    if (Test-Path $standard) { return $standard }
+
+    throw "Could not find AutoHotkey64.exe. Install AutoHotkey v2."
+}
+
+function Compile-Obj {
+    param([string]$SourceFile, [string]$ArchTarget, [string]$OutputObj)
+
+    $vcvars = Find-VcVarsAll
+
+    $bat = @"
+@echo off
+call "$vcvars" $ArchTarget >nul 2>&1
+if errorlevel 1 (
+    echo VCVARS_FAILED
+    exit /b 1
+)
+cl /O2 /c /GS- /Zl /nologo "$SourceFile" /Fo:"$OutputObj"
+if errorlevel 1 (
+    echo COMPILE_FAILED
+    exit /b 1
+)
+echo COMPILE_OK
+"@
+
+    $tmpBat = Join-Path $env:TEMP "build_mcode_compile.bat"
+    Set-Content $tmpBat $bat -Encoding ASCII
+    $output = cmd.exe /c $tmpBat 2>&1 | Out-String
+    Remove-Item $tmpBat -Force -ErrorAction SilentlyContinue
+
+    if ($output -match "VCVARS_FAILED") {
+        throw "Failed to initialize MSVC environment for $ArchTarget"
+    }
+    if ($output -match "COMPILE_FAILED" -or -not (Test-Path $OutputObj)) {
+        Write-Host $output
+        throw "Compilation failed for $ArchTarget"
+    }
+
+    Write-Host "  Compiled $ArchTarget -> $(Split-Path -Leaf $OutputObj)"
+}
+
+function Extract-MCode {
+    param([string]$ObjFile, [string]$Imports)
+
+    $ahk = Find-AHK
+    $extractScript = Join-Path $scriptDir "extract_mcode.ahk"
+
+    $args = @("/ErrorStdOut", $extractScript, $ObjFile)
+    if ($Imports) {
+        $args += $Imports
+    }
+
+    $output = & $ahk @args 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host $output
+        throw "MCode extraction failed"
+    }
+
+    return $output
+}
+
+# --- Main ---
+
+$sourceName = [System.IO.Path]::GetFileNameWithoutExtension($Source)
+$tempDir = Join-Path $env:TEMP "build_mcode"
+if (-not (Test-Path $tempDir)) { New-Item -ItemType Directory -Path $tempDir -Force | Out-Null }
+
+$archTargets = switch ($Arch) {
+    "x64"  { @("x64") }
+    "x86"  { @("x86") }
+    "both" { @("x64", "x86") }
+}
+
+Write-Host ""
+Write-Host "=== MCode Build Pipeline ==="
+Write-Host "Source: $Source"
+Write-Host "Arch:   $($archTargets -join ', ')"
+if ($ImportDlls) { Write-Host "Imports: $ImportDlls" }
+Write-Host ""
+
+foreach ($target in $archTargets) {
+    $objFile = Join-Path $tempDir "${sourceName}_${target}.obj"
+
+    Write-Host "--- $target ---"
+
+    # Compile
+    Compile-Obj -SourceFile $Source -ArchTarget $target -OutputObj $objFile
+
+    # Extract
+    Write-Host "  Extracting MCode..."
+    $output = Extract-MCode -ObjFile $objFile -Imports $ImportDlls
+
+    Write-Host ""
+    Write-Host "=== ${target} OUTPUT ==="
+    Write-Host $output
+    Write-Host ""
+}
+
+Write-Host "=== Done ==="
+Write-Host ""
+Write-Host "Paste the BASE64 blob(s) into your AHK wrapper class configs object."
+Write-Host "See tools/mcode/MCODE_PIPELINE.md for details."

--- a/tools/mcode/extract_mcode.ahk
+++ b/tools/mcode/extract_mcode.ahk
@@ -1,0 +1,28 @@
+;
+; extract_mcode.ahk — AHK runner for COFFReader + ExtractMCode
+;
+; Usage:
+;   AutoHotkey64.exe extract_mcode.ahk <objPath> [importDlls]
+;
+; Arguments:
+;   objPath     - Path to .obj file compiled by MSVC cl.exe
+;   importDlls  - Optional comma-separated list of DLLs for import resolution
+;                 e.g. "kernel32,user32"
+;
+; Output: Prints base64 MCode blob + export info to stdout (consumed by build_mcode.ps1)
+;
+#Requires AutoHotkey v2.0
+#Include COFFReader.ahk
+
+if (A_Args.Length < 1) {
+    FileOpen('*', 'w').Write('Usage: extract_mcode.ahk <objPath> [importDlls]`n')
+    ExitApp(1)
+}
+
+objPath := A_Args[1]
+importDlls := A_Args.Length > 1 ? StrSplit(A_Args[2], ",") : []
+
+msvc_obj := COFFReader(objPath)
+ExtractMCode(msvc_obj, importDlls)
+
+ExitApp(0)

--- a/tools/native_benchmark/native_src/_compile_mcode.ps1
+++ b/tools/native_benchmark/native_src/_compile_mcode.ps1
@@ -1,3 +1,4 @@
+# LEGACY — See tools/mcode/build_mcode.ps1 for the current pipeline.
 $ErrorActionPreference = "Continue"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 

--- a/tools/native_benchmark/native_src/_extract_mcode.ps1
+++ b/tools/native_benchmark/native_src/_extract_mcode.ps1
@@ -1,3 +1,4 @@
+# LEGACY — See tools/mcode/build_mcode.ps1 for the current pipeline.
 $ErrorActionPreference = "Stop"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $objPath = Join-Path $scriptDir "icon_alpha_mcode.obj"


### PR DESCRIPTION
## Summary

- Add `src/lib/MCodeLoader.ahk` (thqby/ahk2_lib, MIT) as the standard runtime MCode loader
- Convert `icon_alpha.ahk` to use MCodeLoader with named exports and 32-bit support (public API unchanged)
- Create `tools/mcode/` build pipeline: `build_mcode.ps1` + `COFFReader.ahk` + `extract_mcode.ahk` for C→MCode workflow
- Add `MCODE_PIPELINE.md` documentation for future MCode development
- Mark legacy scripts (`_compile_mcode.ps1`, `_extract_mcode.ps1`) with header pointing to new pipeline

Closes #66

## Test plan

- [x] Static analysis pre-gate passes (67 checks, `src/lib/` excluded)
- [x] All unit tests pass (515/515)
- [x] All GUI tests pass (242/242)
- [x] All live tests pass (core, network, execution, features, lifecycle)
- [x] Compilation succeeds — compiled exe runs correctly
- [x] Build pipeline tested: `build_mcode.ps1 -Source icon_alpha.c -Arch both` produces valid blobs
- [x] IconAlpha public API unchanged — callers in `gui_gdip.ahk` need zero changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)