### PR TITLE
Add multi-monitor support

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -176,6 +176,7 @@ for _, arg in A_Args {
 #Include gui_win.ahk
 #Include gui_overlay.ahk
 #Include gui_workspace.ahk
+#Include gui_monitor.ahk
 #Include gui_paint.ahk
 #Include gui_input.ahk
 #Include gui_flight_recorder.ahk

--- a/src/gui/gui_flight_recorder.ahk
+++ b/src/gui/gui_flight_recorder.ahk
@@ -46,6 +46,7 @@ global FR_EV_ACTIVATE_GONE    := 32  ; d1=hwnd — target window closed before a
 ; Workspace events (40-49)
 global FR_EV_WS_SWITCH        := 40  ; d1=0 — komorebi workspace changed (name in dump state)
 global FR_EV_WS_TOGGLE        := 41  ; d1=newMode(1=all,2=current) d2=displayCount
+global FR_EV_MON_TOGGLE       := 42  ; d1=newMode(1=all,2=current) d2=displayCount
 
 ; WinEvent hook events (50-59)
 global FR_EV_FOCUS             := 50  ; d1=hwnd — focus changed to window in store
@@ -425,7 +426,7 @@ _FR_GetEventName(ev) {
     global FR_EV_WINDOW_ADD, FR_EV_WINDOW_REMOVE
     global FR_EV_GHOST_PURGE, FR_EV_BLACKLIST_PURGE
     global FR_EV_SESSION_START, FR_EV_PRODUCER_INIT, FR_EV_ACTIVATE_GONE
-    global FR_EV_WS_SWITCH, FR_EV_WS_TOGGLE
+    global FR_EV_WS_SWITCH, FR_EV_WS_TOGGLE, FR_EV_MON_TOGGLE
     global FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS
     global FR_EV_PRODUCER_BACKOFF, FR_EV_PRODUCER_RECOVER
 
@@ -460,6 +461,7 @@ _FR_GetEventName(ev) {
         case FR_EV_ACTIVATE_GONE:     return "ACTIVATE_GONE"
         case FR_EV_WS_SWITCH:         return "WS_SWITCH"
         case FR_EV_WS_TOGGLE:         return "WS_TOGGLE"
+        case FR_EV_MON_TOGGLE:        return "MON_TOGGLE"
         case FR_EV_FOCUS:             return "FOCUS"
         case FR_EV_FOCUS_SUPPRESS:    return "FOCUS_SUPPRESS"
         case FR_EV_PRODUCER_BACKOFF:  return "PRODUCER_BACKOFF"
@@ -490,7 +492,7 @@ _FR_FormatDetails(ev, d1, d2, d3, d4, hwndMap) {
     global FR_EV_WINDOW_ADD, FR_EV_WINDOW_REMOVE
     global FR_EV_GHOST_PURGE, FR_EV_BLACKLIST_PURGE
     global FR_EV_SESSION_START, FR_EV_PRODUCER_INIT, FR_EV_ACTIVATE_GONE
-    global FR_EV_WS_SWITCH, FR_EV_WS_TOGGLE
+    global FR_EV_WS_SWITCH, FR_EV_WS_TOGGLE, FR_EV_MON_TOGGLE
     global FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS
     global FR_EV_PRODUCER_BACKOFF, FR_EV_PRODUCER_RECOVER
 
@@ -557,6 +559,9 @@ _FR_FormatDetails(ev, d1, d2, d3, d4, hwndMap) {
         case FR_EV_WS_SWITCH:
             return ""
         case FR_EV_WS_TOGGLE:
+            modeStr := (d1 = 1) ? "all" : (d1 = 2) ? "current" : "?(" d1 ")"
+            return "mode=" modeStr "  displayCount=" d2
+        case FR_EV_MON_TOGGLE:
             modeStr := (d1 = 1) ? "all" : (d1 = 2) ? "current" : "?(" d1 ")"
             return "mode=" modeStr "  displayCount=" d2
         case FR_EV_FOCUS:

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -58,6 +58,7 @@ A_MenuMaskKey := "vkE8"
 global gGUI_Revealed := false
 ; gGUI_HoverRow, gGUI_HoverBtn, gGUI_MouseTracking declared in gui_input.ahk (sole writer)
 ; gGUI_FooterText, gGUI_WorkspaceMode declared in gui_workspace.ahk (sole writer)
+; gGUI_MonitorMode, gGUI_OverlayMonitorHandle declared in gui_monitor.ahk (sole writer)
 ; gGUI_CurrentWSName declared in gui_state.ahk (workspace state owner)
 
 global gGUI_OverlayVisible := false
@@ -135,7 +136,10 @@ _GUI_Main_Init() {
     Win_InitDpiAwareness()
     Gdip_Startup()
 
-    ; Initialize footer text based on workspace mode
+    ; Initialize monitor mode from config default
+    GUI_InitMonitorMode()
+
+    ; Initialize footer text based on workspace/monitor mode
     GUI_UpdateFooterText()
 
     ; ========================= PRODUCER INIT =========================

--- a/src/gui/gui_monitor.ahk
+++ b/src/gui/gui_monitor.ahk
@@ -1,0 +1,95 @@
+#Requires AutoHotkey v2.0
+; Alt-Tabby GUI - Monitor Mode
+; Handles monitor filtering and toggle between "all" and "current" modes
+; Mirrors gui_workspace.ahk pattern for consistency
+#Warn VarUnset, Off  ; Suppress warnings for cross-file globals/functions
+
+; Monitor mode constants
+global MON_MODE_ALL := "all"
+global MON_MODE_CURRENT := "current"
+
+; Monitor state
+global gGUI_MonitorMode := MON_MODE_ALL
+global gGUI_OverlayMonitorHandle := 0  ; hMonitor of the overlay's target monitor
+global gStats_MonitorToggles := 0
+
+; ========================= MONITOR TOGGLE =========================
+
+GUI_ToggleMonitorMode() {
+    global gGUI_MonitorMode, gGUI_State, gGUI_OverlayVisible, gGUI_DisplayItems
+    global gStats_MonitorToggles, MON_MODE_ALL, MON_MODE_CURRENT
+    global FR_EV_MON_TOGGLE, gFR_Enabled
+
+    ; RACE FIX: Protect counter increment and mode toggle atomically
+    Critical "On"
+    gStats_MonitorToggles += 1
+    gGUI_MonitorMode := (gGUI_MonitorMode = MON_MODE_ALL) ? MON_MODE_CURRENT : MON_MODE_ALL
+    Critical "Off"
+    if (gFR_Enabled)
+        FR_Record(FR_EV_MON_TOGGLE, (gGUI_MonitorMode = MON_MODE_ALL) ? 1 : 2, gGUI_DisplayItems.Length)
+
+    GUI_UpdateFooterText()
+
+    ; If GUI is visible and active, re-filter from cached items
+    if (gGUI_State = "ACTIVE" && gGUI_OverlayVisible)
+        GUI_ApplyMonitorFilter()
+}
+
+; ========================= MONITOR FILTERING =========================
+
+GUI_FilterByMonitorMode(items) {
+    global gGUI_MonitorMode, gGUI_OverlayMonitorHandle, MON_MODE_ALL
+
+    if (gGUI_MonitorMode = MON_MODE_ALL)
+        return items
+    if (!gGUI_OverlayMonitorHandle)
+        return items
+
+    ; Only items on the overlay's monitor
+    result := []
+    for _, item in items {
+        hMon := Win_GetMonitorHandle(item.hwnd)
+        if (hMon = gGUI_OverlayMonitorHandle)
+            result.Push(item)
+    }
+    return result
+}
+
+; ========================= MONITOR MODE INIT =========================
+
+; Initialize monitor mode from config default
+GUI_InitMonitorMode() {
+    global gGUI_MonitorMode, cfg, MON_MODE_ALL, MON_MODE_CURRENT
+    if (cfg.GUI_MonitorFilterDefault = "Current")
+        gGUI_MonitorMode := MON_MODE_CURRENT
+    else
+        gGUI_MonitorMode := MON_MODE_ALL
+}
+
+; Capture the overlay's target monitor handle (call at overlay show time)
+GUI_CaptureOverlayMonitor() {
+    global gGUI_OverlayMonitorHandle
+    targetHwnd := GUI_GetTargetMonitorHwnd()
+    gGUI_OverlayMonitorHandle := Win_GetMonitorHandle(targetHwnd)
+}
+
+; Get monitor label for the overlay's current monitor
+GUI_GetOverlayMonitorLabel() {
+    global gGUI_OverlayMonitorHandle
+    return Win_GetMonitorLabel(gGUI_OverlayMonitorHandle)
+}
+
+; ========================= MONITOR LABELS =========================
+
+; Stamp monitorLabel property on each item for column display.
+; Call at freeze time (after gGUI_ToggleBase is cloned).
+; Only populates if Col5 is visible (width > 0) to avoid unnecessary DllCalls.
+GUI_StampMonitorLabels(items) {
+    global cfg
+    if (cfg.GUI_ColFixed5 <= 0)
+        return  ; Column hidden, skip DllCall overhead
+    for _, item in items {
+        hMon := Win_GetMonitorHandle(item.hwnd)
+        item.monitorLabel := Win_GetMonitorLabel(hMon)
+    }
+}

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -92,7 +92,7 @@ GUI_Repaint() {
     yDip := 0
     wDip := 0
     hDip := 0
-    GUI_GetWindowRect(&xDip, &yDip, &wDip, &hDip, rowsDesired, gGUI_BaseH)
+    GUI_GetWindowRect(&xDip, &yDip, &wDip, &hDip, rowsDesired)
     waL := 0
     waT := 0
     waR := 0
@@ -243,6 +243,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale) {
     global gGUI_ScrollTop, gGUI_HoverRow, gGUI_FooterText, cfg, gGdip_Res, gGdip_IconCache
     global gPaint_SessionPaintCount, gPaint_LastPaintTick
     global PAINT_TEXT_RIGHT_PAD_DIP, gGUI_WorkspaceMode, WS_MODE_CURRENT
+    global gGUI_MonitorMode, MON_MODE_CURRENT
 
     ; ===== TIMING: EnsureResources =====
     tPO_Start := A_TickCount
@@ -284,7 +285,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale) {
     ; dataKey matches store wire format property names directly
     static colDefs := [
         ["GUI_ColFixed6", "GUI_Col6Name", "Col6"],
-        ["GUI_ColFixed5", "GUI_Col5Name", "Col5"],
+        ["GUI_ColFixed5", "GUI_Col5Name", "monitorLabel"],
         ["GUI_ColFixed4", "GUI_Col4Name", "workspaceName"],
         ["GUI_ColFixed3", "GUI_Col3Name", "pid"],
         ["GUI_ColFixed2", "GUI_Col2Name", "hwndHex"]
@@ -360,8 +361,12 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale) {
             rectY := contentTopY
         }
         emptyText := cfg.GUI_EmptyListText
-        if (gGUI_WorkspaceMode = WS_MODE_CURRENT)
+        if (gGUI_MonitorMode = MON_MODE_CURRENT && gGUI_WorkspaceMode = WS_MODE_CURRENT)
+            emptyText := "No windows on this workspace and monitor"
+        else if (gGUI_WorkspaceMode = WS_MODE_CURRENT)
             emptyText := "No windows on this workspace"
+        else if (gGUI_MonitorMode = MON_MODE_CURRENT)
+            emptyText := "No windows on this monitor"
         Gdip_DrawCenteredText(g, emptyText, rectX, rectY, rectW, rectH, gGdip_Res["brMain"], gGdip_Res["fMain"], gGdip_Res["fmtCenter"])
     } else if (rowsToDraw > 0) {
         ; ===== TIMING: Row loop start =====

--- a/src/gui/gui_workspace.ahk
+++ b/src/gui/gui_workspace.ahk
@@ -28,13 +28,24 @@ GUI_GetItemIsOnCurrent(item) {
 
 GUI_UpdateFooterText() {
     global gGUI_FooterText, gGUI_WorkspaceMode, gGUI_CurrentWSName, WS_MODE_ALL
+    global gGUI_MonitorMode, MON_MODE_ALL
 
+    ; Build workspace part
+    wsPart := ""
     if (gGUI_WorkspaceMode = WS_MODE_ALL) {
-        gGUI_FooterText := "All Workspaces"
+        wsPart := "All Workspaces"
     } else {
-        ; WS_MODE_CURRENT mode
         wsName := (gGUI_CurrentWSName != "") ? gGUI_CurrentWSName : "Unknown"
-        gGUI_FooterText := "Current (" wsName ")"
+        wsPart := "Current (" wsName ")"
+    }
+
+    ; Build monitor part
+    if (gGUI_MonitorMode != MON_MODE_ALL) {
+        monLabel := GUI_GetOverlayMonitorLabel()
+        monPart := monLabel ? monLabel : "Current Monitor"
+        gGUI_FooterText := wsPart " · " monPart
+    } else {
+        gGUI_FooterText := wsPart
     }
 }
 

--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -381,6 +381,14 @@ global gConfigRegistry := [
      min: 0, max: 100,
      d: "Window corner radius in pixels"},
 
+    {s: "GUI", k: "OverlayMonitor", g: "GUI_OverlayMonitor", t: "enum", default: "FocusedWindow",
+     options: ["FocusedWindow", "Primary"],
+     d: "Which monitor the overlay appears on. FocusedWindow = the monitor where you're working. Primary = always the primary monitor."},
+
+    {s: "GUI", k: "MonitorFilterDefault", g: "GUI_MonitorFilterDefault", t: "enum", default: "All",
+     options: ["All", "Current"],
+     d: "Default monitor filter. All = windows from all monitors. Current = only windows on the overlay's monitor. Toggle with backtick key during use."},
+
     {type: "subsection", section: "GUI", name: "Size Config",
      desc: "Window and row sizing"},
 
@@ -604,7 +612,7 @@ global gConfigRegistry := [
 
     {s: "GUI", k: "ColFixed5", g: "GUI_ColFixed5", t: "int", default: 0,
      min: 0, max: 500,
-     d: "Column 5 width (0=hidden)"},
+     d: "Column 5 width — Monitor label (0=hidden). Set to 50 to show Mon 1/Mon 2 per row."},
 
     {s: "GUI", k: "ColFixed6", g: "GUI_ColFixed6", t: "int", default: 0,
      min: 0, max: 500,
@@ -619,8 +627,8 @@ global gConfigRegistry := [
     {s: "GUI", k: "Col4Name", g: "GUI_Col4Name", t: "string", default: "WS",
      d: "Column 4 header name"},
 
-    {s: "GUI", k: "Col5Name", g: "GUI_Col5Name", t: "string", default: "",
-     d: "Column 5 header name"},
+    {s: "GUI", k: "Col5Name", g: "GUI_Col5Name", t: "string", default: "Mon",
+     d: "Column 5 header name (Monitor label)"},
 
     {s: "GUI", k: "Col6Name", g: "GUI_Col6Name", t: "string", default: "",
      d: "Column 6 header name"},

--- a/tests/check_batch_patterns.ps1
+++ b/tests/check_batch_patterns.ps1
@@ -388,8 +388,8 @@ $CHECKS = @(
     @{
         Id       = "bypass_fullscreen_detection"
         File     = "gui\gui_interceptor.ahk"
-        Desc     = "INT_IsFullscreenHwnd checks screen dimensions"
-        Patterns = @("INT_IsFullscreenHwnd", "A_ScreenWidth", "A_ScreenHeight")
+        Desc     = "INT_IsFullscreenHwnd checks per-monitor dimensions"
+        Patterns = @("INT_IsFullscreenHwnd", "Win_GetMonitorBoundsFromHwnd")
     },
     @{
         Id       = "bypass_hotkey_toggle"


### PR DESCRIPTION
## Summary
- **Overlay follows focus**: Overlay appears on the focused window's monitor instead of always primary (`OverlayMonitor` config: FocusedWindow/Primary)
- **Per-monitor fullscreen detection**: Game-mode bypass now checks against the window's actual monitor bounds with origin-relative tolerance, fixing false negatives on secondary monitors
- **Monitor filter toggle**: Backtick key filters the window list to only show windows on the overlay's monitor (`MonitorFilterDefault` config: All/Current)
- **Monitor labels**: Column 5 can display monitor identity (Mon 1, Mon 2) per row — opt-in via `ColFixed5` width

Closes #65

## Test plan
- [x] Static analysis passes (67 checks)
- [x] All 515 unit tests pass
- [x] All 43 live tests pass
- [x] All 242 GUI state machine tests pass
- [ ] Manual: verify overlay appears on correct monitor with multi-monitor setup
- [ ] Manual: verify fullscreen detection works on secondary monitor
- [ ] Manual: verify backtick toggle filters to current monitor
- [ ] Manual: verify Col5 shows Mon N labels when ColFixed5 > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)