### PR TITLE
Move monitorHandle/monitorLabel into window store

### DIFF
--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -239,7 +239,7 @@ _WEH_WinEventProc(hWinEventHook, event, hwnd, idObject, idChild, idEventThread, 
 
     ; Filter cosmetic events for non-store windows.
     ; NAMECHANGE alone can't make a window eligible (CREATE/SHOW handles new windows).
-    ; LOCATIONCHANGE doesn't affect any stored field (no position tracking).
+    ; LOCATIONCHANGE updates monitorHandle/monitorLabel for cross-monitor moves.
     if (event = 0x800C || event = 0x800B) {
         if (!gWS_Store.Has(hwnd + 0)) {
             Critical "Off"
@@ -713,7 +713,11 @@ _WEH_UpdateExisting(hwnd) {
     if (!Blacklist_IsWindowEligibleEx(hwnd, title, class, &isVisible, &isMin, &isCloaked))
         return -1
 
+    ; Stamp monitor identity (detects cross-monitor moves via LOCATIONCHANGE)
+    hMon := Win_GetMonitorHandle(hwnd)
+
     ; Return patch Object — caller collects into batch
-    return { title: title, isCloaked: isCloaked, isMinimized: isMin, isVisible: isVisible }
+    return { title: title, isCloaked: isCloaked, isMinimized: isMin, isVisible: isVisible,
+             monitorHandle: hMon, monitorLabel: Win_GetMonitorLabel(hMon) }
 }
 

--- a/src/gui/gui_monitor.ahk
+++ b/src/gui/gui_monitor.ahk
@@ -45,11 +45,10 @@ GUI_FilterByMonitorMode(items) {
     if (!gGUI_OverlayMonitorHandle)
         return items
 
-    ; Only items on the overlay's monitor
+    ; Only items on the overlay's monitor (monitorHandle stamped by producers)
     result := []
     for _, item in items {
-        hMon := Win_GetMonitorHandle(item.hwnd)
-        if (hMon = gGUI_OverlayMonitorHandle)
+        if (item.monitorHandle = gGUI_OverlayMonitorHandle)
             result.Push(item)
     }
     return result
@@ -79,17 +78,4 @@ GUI_GetOverlayMonitorLabel() {
     return Win_GetMonitorLabel(gGUI_OverlayMonitorHandle)
 }
 
-; ========================= MONITOR LABELS =========================
-
-; Stamp monitorLabel property on each item for column display.
-; Call at freeze time (after gGUI_ToggleBase is cloned).
-; Only populates if Col5 is visible (width > 0) to avoid unnecessary DllCalls.
-GUI_StampMonitorLabels(items) {
-    global cfg
-    if (cfg.GUI_ColFixed5 <= 0)
-        return  ; Column hidden, skip DllCall overhead
-    for _, item in items {
-        hMon := Win_GetMonitorHandle(item.hwnd)
-        item.monitorLabel := Win_GetMonitorLabel(hMon)
-    }
-}
+; GUI_StampMonitorLabels removed — monitorLabel is now a store field stamped by producers

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -207,7 +207,6 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
             ; Shallow copy — same item refs, independent array container
             gGUI_ToggleBase := gGUI_LiveItems.Clone()
             GUI_CaptureOverlayMonitor()
-            GUI_StampMonitorLabels(gGUI_ToggleBase)
             gGUI_DisplayItems := GUI_FilterByMonitorMode(GUI_FilterByWorkspaceMode(gGUI_ToggleBase))
 
             ; DEBUG: Log workspace data of display items

--- a/src/gui/gui_win.ahk
+++ b/src/gui/gui_win.ahk
@@ -70,34 +70,7 @@ Win_GetMonitorBoundsFromHwnd(hWnd, &left, &top, &right, &bottom) {
     bottom := NumGet(mi, 16, "Int")
 }
 
-; Get monitor handle for a window (for monitor identity comparison)
-Win_GetMonitorHandle(hWnd) {
-    return DllCall("user32\MonitorFromWindow", "ptr", hWnd, "uint", 2, "ptr")
-}
-
-; Get monitor index (1-based) from monitor handle for display purposes
-; Returns "Mon N" where N is the monitor number, or "" on failure
-Win_GetMonitorLabel(hMon) {
-    if (!hMon)
-        return ""
-    ; Iterate AHK's built-in monitor list to find the matching index
-    count := MonitorGetCount()
-    loop count {
-        ; Get monitor bounds via AHK built-in and compare handle
-        mL := 0, mT := 0, mR := 0, mB := 0
-        MonitorGet(A_Index, &mL, &mT, &mR, &mB)
-        ; Build a rect and get the handle for comparison
-        rc := Buffer(16, 0)
-        NumPut("Int", mL, rc, 0)
-        NumPut("Int", mT, rc, 4)
-        NumPut("Int", mR, rc, 8)
-        NumPut("Int", mB, rc, 12)
-        testMon := DllCall("user32\MonitorFromRect", "ptr", rc.Ptr, "uint", 2, "ptr")
-        if (testMon = hMon)
-            return "Mon " A_Index
-    }
-    return ""
-}
+; Win_GetMonitorHandle and Win_GetMonitorLabel moved to win_utils.ahk
 
 ; Get monitor scale from rect
 Win_GetMonitorScale(left, top, right, bottom) {

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -14,7 +14,8 @@ global WS_SCAN_ID_MAX := 0x7FFFFFFF
 ; hwnd is always included separately as the record key.
 global DISPLAY_FIELDS := ["title", "class", "pid", "z", "lastActivatedTick",
     "isFocused", "isCloaked", "isMinimized", "workspaceName", "workspaceId",
-    "isOnCurrentWorkspace", "processName", "iconHicon"]
+    "isOnCurrentWorkspace", "processName", "iconHicon",
+    "monitorHandle", "monitorLabel"]
 
 global gWS_Store := Map()
 global gWS_Rev := 0
@@ -67,7 +68,7 @@ global gWS_MRUOnlyFields := Map("lastActivatedTick", true)
 global gWS_ContentOnlyFields := Map(
     "iconHicon", true, "title", true, "class", true,
     "pid", true, "workspaceName", true, "workspaceId", true,
-    "isFocused", true)
+    "isFocused", true, "monitorHandle", true, "monitorLabel", true)
 
 ; When true, "title" field changes trigger sort rebuild instead of content-only refresh.
 ; Set by WL_GetDisplayList when sort="Title" is used, cleared on next WL_GetDisplayList
@@ -818,11 +819,13 @@ _WS_NewRecord(hwnd) {
         iconCooldownUntilTick: 0,
         iconGaveUp: false,
         iconMethod: "",           ; IP_METHOD_WM_GETICON, IP_METHOD_UWP, IP_METHOD_EXE, or "" (none yet)
-        iconLastRefreshTick: 0    ; When we last checked WM_GETICON (for refresh throttle)
+        iconLastRefreshTick: 0,   ; When we last checked WM_GETICON (for refresh throttle)
+        monitorHandle: 0,
+        monitorLabel: ""
     }
 }
 
-; PERF: Hardcoded fields avoid 13x dynamic %field% string-to-property-slot resolution per call.
+; PERF: Hardcoded fields avoid dynamic %field% string-to-property-slot resolution per call.
 ; Must stay in sync with DISPLAY_FIELDS (top of file).
 _WS_ToItem(rec) {
     return {
@@ -839,7 +842,9 @@ _WS_ToItem(rec) {
         workspaceId: rec.workspaceId,
         isOnCurrentWorkspace: rec.isOnCurrentWorkspace,
         processName: rec.processName,
-        iconHicon: rec.iconHicon
+        iconHicon: rec.iconHicon,
+        monitorHandle: rec.monitorHandle,
+        monitorLabel: rec.monitorLabel
     }
 }
 

--- a/src/viewer/viewer.ahk
+++ b/src/viewer/viewer.ahk
@@ -52,12 +52,12 @@ global gViewer_HdrBrushCache := Map()   ; color (uint) -> HBRUSH
 global gViewer_HdrPenCache := Map()     ; color (uint) -> HPEN
 
 ; Column names (0-indexed for header draw)
-global gViewer_Columns := ["Z", "MRU", "HWND", "PID", "Title", "Class", "WS", "Cur", "Process", "Foc", "Clk", "Min", "Icon"]
+global gViewer_Columns := ["Z", "MRU", "HWND", "PID", "Title", "Class", "WS", "Cur", "Process", "Mon", "Foc", "Clk", "Min", "Icon"]
 
 ; Column-to-field mapping for sort
-global gViewer_ColFields := ["z", "lastActivatedTick", "hwnd", "pid", "title", "class", "workspaceName", "isOnCurrentWorkspace", "processName", "isFocused", "isCloaked", "isMinimized", "iconHicon"]
+global gViewer_ColFields := ["z", "lastActivatedTick", "hwnd", "pid", "title", "class", "workspaceName", "isOnCurrentWorkspace", "processName", "monitorLabel", "isFocused", "isCloaked", "isMinimized", "iconHicon"]
 ; Columns that use string comparison (all others are numeric)
-global gViewer_ColIsString := Map(4, true, 5, true, 6, true, 8, true)
+global gViewer_ColIsString := Map(4, true, 5, true, 6, true, 8, true, 9, true)
 
 ; ========================= PUBLIC API =========================
 
@@ -434,6 +434,7 @@ _Viewer_BuildRowArgs(rec) {
         _Viewer_Get(rec, "workspaceName", ""),
         _Viewer_Get(rec, "isOnCurrentWorkspace", 0) ? "1" : "0",
         _Viewer_Get(rec, "processName", ""),
+        _Viewer_Get(rec, "monitorLabel", ""),
         _Viewer_Get(rec, "isFocused", 0) ? "Y" : "",
         _Viewer_Get(rec, "isCloaked", 0) ? "Y" : "",
         _Viewer_Get(rec, "isMinimized", 0) ? "Y" : "",

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -295,9 +295,6 @@ INT_SetBypassMode(shouldBypass) {
 GUI_CaptureOverlayMonitor() {
     ; No-op in tests
 }
-GUI_StampMonitorLabels(items) {
-    ; No-op in tests
-}
 GUI_FilterByMonitorMode(items) {
     global gGUI_MonitorMode, MON_MODE_ALL
     if (gGUI_MonitorMode = MON_MODE_ALL)
@@ -423,7 +420,9 @@ CreateTestItems(count, currentWSCount := -1) {
             workspaceName: (A_Index <= currentWSCount) ? "Main" : "Other",
             lastActivatedTick: A_TickCount - (A_Index * 100),  ; MRU order: lower index = more recent
             iconHicon: 0,
-            processName: ""
+            processName: "",
+            monitorHandle: 0,
+            monitorLabel: ""
         })
     }
     return items

--- a/tests/gui_tests_state.ahk
+++ b/tests/gui_tests_state.ahk
@@ -175,11 +175,11 @@ RunGUITests_State() {
     ; Create items where some have empty workspaceName (unmanaged windows)
     ; and some are explicitly NOT on current workspace
     items := []
-    items.Push({ hwnd: 1000, title: "Win1", isOnCurrentWorkspace: true, workspaceName: "Main", lastActivatedTick: A_TickCount - 100, iconHicon: 0 })
-    items.Push({ hwnd: 2000, title: "Win2", isOnCurrentWorkspace: true, workspaceName: "Main", lastActivatedTick: A_TickCount - 200, iconHicon: 0 })
-    items.Push({ hwnd: 3000, title: "Win3", isOnCurrentWorkspace: false, workspaceName: "Other", lastActivatedTick: A_TickCount - 300, iconHicon: 0 })
-    items.Push({ hwnd: 4000, title: "Win4", isOnCurrentWorkspace: true, workspaceName: "", lastActivatedTick: A_TickCount - 400, iconHicon: 0 })  ; Unmanaged
-    items.Push({ hwnd: 5000, title: "Win5", isOnCurrentWorkspace: false, workspaceName: "Other", lastActivatedTick: A_TickCount - 500, iconHicon: 0 })
+    items.Push({ hwnd: 1000, title: "Win1", isOnCurrentWorkspace: true, workspaceName: "Main", lastActivatedTick: A_TickCount - 100, iconHicon: 0, monitorHandle: 0, monitorLabel: "" })
+    items.Push({ hwnd: 2000, title: "Win2", isOnCurrentWorkspace: true, workspaceName: "Main", lastActivatedTick: A_TickCount - 200, iconHicon: 0, monitorHandle: 0, monitorLabel: "" })
+    items.Push({ hwnd: 3000, title: "Win3", isOnCurrentWorkspace: false, workspaceName: "Other", lastActivatedTick: A_TickCount - 300, iconHicon: 0, monitorHandle: 0, monitorLabel: "" })
+    items.Push({ hwnd: 4000, title: "Win4", isOnCurrentWorkspace: true, workspaceName: "", lastActivatedTick: A_TickCount - 400, iconHicon: 0, monitorHandle: 0, monitorLabel: "" })  ; Unmanaged
+    items.Push({ hwnd: 5000, title: "Win5", isOnCurrentWorkspace: false, workspaceName: "Other", lastActivatedTick: A_TickCount - 500, iconHicon: 0, monitorHandle: 0, monitorLabel: "" })
     MockStore_SetItems(items)
     gGUI_LiveItems := items
 

--- a/tests/test_unit_core_store.ahk
+++ b/tests/test_unit_core_store.ahk
@@ -315,6 +315,21 @@ RunUnitTests_CoreStore() {
     }
     AssertEq(foundTitle, true, "Path 2 title: hwnd 5001 found in display list")
 
+    ; --- monitorHandle change triggers Path 2 content refresh ---
+    WL_GetDisplayList()
+    WL_UpdateFields(5001, Map("monitorHandle", 12345, "monitorLabel", "Mon 2"), "test")
+    proj := WL_GetDisplayList()
+    foundMon := false
+    for _, item in proj.items {
+        if (item.hwnd = 5001) {
+            AssertEq(item.monitorHandle, 12345, "Path 2 returns fresh monitorHandle")
+            AssertEq(item.monitorLabel, "Mon 2", "Path 2 returns fresh monitorLabel")
+            foundMon := true
+            break
+        }
+    }
+    AssertEq(foundMon, true, "Path 2 monitorHandle: hwnd 5001 found in display list")
+
     ; --- Coverage test: every _WS_ToItem field must be tracked ---
     ; Prevents future regressions where a new field is added to _WS_ToItem
     ; but not tracked, silently causing stale cache data


### PR DESCRIPTION
## Summary

- Move `Win_GetMonitorHandle` / `Win_GetMonitorLabel` from GUI-side (`gui_win.ahk`) to shared layer (`win_utils.ahk`) so producers can stamp monitor identity
- Add `monitorHandle` + `monitorLabel` as first-class store fields in `window_list.ahk` (schema, projection, content-only dirty tracking)
- Producers stamp monitor data at scan/update time: `WinUtils_ProbeWindow` (initial scan) and `_WEH_UpdateExisting` (LOCATIONCHANGE batch updates)
- Remove `GUI_StampMonitorLabels` — O(windows×monitors) DllCalls no longer needed on freeze hot path
- `GUI_FilterByMonitorMode` reads `item.monitorHandle` from store instead of calling `Win_GetMonitorHandle` per item
- Add `Mon` column to debug viewer
- Add Path 2 content refresh test for `monitorHandle` change

Closes #75

## Test plan

- [x] Static analysis: 67/67 checks pass (including `check_display_fields` DISPLAY_FIELDS ↔ _WS_ToItem sync)
- [x] Unit/Core/Store: 198/198 (including new monitorHandle Path 2 test + field coverage test)
- [x] GUI tests: 242/242 (removed stamp mock, added monitor fields to test items)
- [x] All unit suites: 550/550
- [x] All live suites: 34/34
- [x] Full suite: 826/826 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)