### PR TITLE
Consolidate query tools from tests/ into tools/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,9 @@ Enforced by pre-gate. Don't create `_` functions intended for cross-file use.
 
 ## Query Tools (context-efficient search)
 
-When investigating the codebase, prefer query tools over reading full files or grepping:
-- `check_global_ownership.ps1 -Query <globalName>` — who declares, writes, and reads a global. `-Generate` previews manifest diff. `-Discover` shows all coupling hotspots
-- `check_function_visibility.ps1 -Query <funcName>` — where defined, public/private, all callers
+Query tools live in `tools/`. Prefer these over reading full files or grepping:
+- `query_global_ownership.ps1 <globalName>` — who declares, writes, and reads a global. `-Generate` previews manifest diff. `-Discover` shows all coupling hotspots
+- `query_function_visibility.ps1 <funcName>` — where defined, public/private, all callers
 - `query_function.ps1 <funcName>` — extract full function body without loading the entire file
 - `query_interface.ps1 <filename>` — public functions + globals for a file (like help(module))
 - `query_config.ps1` — no args: shows section/group index. With keyword: fuzzy search. `-Section <name>`: list section. `-Usage <key>`: which files consume a config value

--- a/ownership.manifest
+++ b/ownership.manifest
@@ -2,7 +2,7 @@
 #
 # Contract: If a global is NOT listed here, only the declaring file may
 # mutate it. If it IS listed, all writers are shown explicitly.
-# The declaring file is always authorized. Enforced by check_global_ownership.ps1.
+# The declaring file is always authorized. Enforced by query_global_ownership.ps1 -Check.
 #
 # Freshness: The pre-gate validates this manifest against actual code.
 #   Stale entries (globals no longer cross-file) are auto-removed.
@@ -16,9 +16,9 @@
 #   Basenames without .ahk. All files that write are listed.
 #
 # Maintenance:
-#   Query a specific global: powershell -File tests/check_global_ownership.ps1 -Query <name>
-#   Preview manifest changes: powershell -File tests/check_global_ownership.ps1 -Generate
-#   Discover full landscape: powershell -File tests/check_global_ownership.ps1 -Discover
+#   Query a specific global: powershell -File tools/query_global_ownership.ps1 <name>
+#   Preview manifest changes: powershell -File tools/query_global_ownership.ps1 -Generate
+#   Discover full landscape: powershell -File tools/query_global_ownership.ps1 -Discover
 
 cfg: config_loader, launcher_tray, setup_utils
 gGUI_LiveItems: gui_state, gui_data

--- a/tools/query_config.ps1
+++ b/tools/query_config.ps1
@@ -4,10 +4,10 @@
 # Returns semantic answers: section, key, type, default, description.
 #
 # Usage:
-#   powershell -File tests/query_config.ps1                       (show section/group index)
-#   powershell -File tests/query_config.ps1 theme                 (fuzzy search for "theme")
-#   powershell -File tests/query_config.ps1 -Section GUI          (list all settings in a section)
-#   powershell -File tests/query_config.ps1 -Usage GUI_RowHeight  (find all consumers of cfg.X)
+#   powershell -File tools/query_config.ps1                       (show section/group index)
+#   powershell -File tools/query_config.ps1 theme                 (fuzzy search for "theme")
+#   powershell -File tools/query_config.ps1 -Section GUI          (list all settings in a section)
+#   powershell -File tools/query_config.ps1 -Usage GUI_RowHeight  (find all consumers of cfg.X)
 
 param(
     [Parameter(Position=0)]

--- a/tools/query_function.ps1
+++ b/tools/query_function.ps1
@@ -4,9 +4,9 @@
 # Reduces context bloat when investigating "what does this function do?" questions.
 #
 # Usage:
-#   powershell -File tests/query_function.ps1 <funcName>
-#   powershell -File tests/query_function.ps1 GUI_Show
-#   powershell -File tests/query_function.ps1 _GUI_BuildLayout
+#   powershell -File tools/query_function.ps1 <funcName>
+#   powershell -File tools/query_function.ps1 GUI_Show
+#   powershell -File tools/query_function.ps1 _GUI_BuildLayout
 
 param(
     [Parameter(Position=0)]

--- a/tools/query_interface.ps1
+++ b/tools/query_interface.ps1
@@ -5,9 +5,9 @@
 # the implementation.
 #
 # Usage:
-#   powershell -File tests/query_interface.ps1 <filename>
-#   powershell -File tests/query_interface.ps1 gui_overlay
-#   powershell -File tests/query_interface.ps1 gui_overlay.ahk
+#   powershell -File tools/query_interface.ps1 <filename>
+#   powershell -File tools/query_interface.ps1 gui_overlay
+#   powershell -File tools/query_interface.ps1 gui_overlay.ahk
 
 param(
     [Parameter(Position=0)]

--- a/tools/query_ipc.ps1
+++ b/tools/query_ipc.ps1
@@ -3,9 +3,9 @@
 # Shows who sends and who handles each IPC message type.
 #
 # Usage:
-#   powershell -File tests/query_ipc.ps1                   (list all message types)
-#   powershell -File tests/query_ipc.ps1 snapshot           (query by string value)
-#   powershell -File tests/query_ipc.ps1 IPC_MSG_SNAPSHOT   (query by constant name)
+#   powershell -File tools/query_ipc.ps1                   (list all message types)
+#   powershell -File tools/query_ipc.ps1 snapshot           (query by string value)
+#   powershell -File tools/query_ipc.ps1 IPC_MSG_SNAPSHOT   (query by constant name)
 
 param(
     [Parameter(Position=0)]

--- a/tools/query_messages.ps1
+++ b/tools/query_messages.ps1
@@ -4,10 +4,10 @@
 # Maps raw hex constants to human-readable WM_ names.
 #
 # Usage:
-#   powershell -File tests/query_messages.ps1                  (list all messages)
-#   powershell -File tests/query_messages.ps1 0x0138           (query by hex)
-#   powershell -File tests/query_messages.ps1 WM_CTLCOLORSTATIC  (query by WM_ name)
-#   powershell -File tests/query_messages.ps1 GUI_OnClick      (query by handler name)
+#   powershell -File tools/query_messages.ps1                  (list all messages)
+#   powershell -File tools/query_messages.ps1 0x0138           (query by hex)
+#   powershell -File tools/query_messages.ps1 WM_CTLCOLORSTATIC  (query by WM_ name)
+#   powershell -File tools/query_messages.ps1 GUI_OnClick      (query by handler name)
 
 param(
     [Parameter(Position=0)]

--- a/tools/query_state.ps1
+++ b/tools/query_state.ps1
@@ -4,9 +4,9 @@
 # without loading the full 234-line function.
 #
 # Usage:
-#   powershell -File tests/query_state.ps1                       (list states and events)
-#   powershell -File tests/query_state.ps1 ACTIVE                (all handlers for state)
-#   powershell -File tests/query_state.ps1 ACTIVE TAB_STEP       (specific branch)
+#   powershell -File tools/query_state.ps1                       (list states and events)
+#   powershell -File tools/query_state.ps1 ACTIVE                (all handlers for state)
+#   powershell -File tools/query_state.ps1 ACTIVE TAB_STEP       (specific branch)
 
 param(
     [Parameter(Position=0)]

--- a/tools/query_timers.ps1
+++ b/tools/query_timers.ps1
@@ -4,8 +4,8 @@
 # enclosing function, and file location.
 #
 # Usage:
-#   powershell -File tests/query_timers.ps1               (full inventory)
-#   powershell -File tests/query_timers.ps1 heartbeat      (fuzzy search)
+#   powershell -File tools/query_timers.ps1               (full inventory)
+#   powershell -File tools/query_timers.ps1 heartbeat      (fuzzy search)
 
 param(
     [Parameter(Position=0)]

--- a/tools/query_visibility.ps1
+++ b/tools/query_visibility.ps1
@@ -5,8 +5,8 @@
 # Functions with 1 caller may be candidates for inlining or making private.
 #
 # Usage:
-#   powershell -File tests/query_visibility.ps1
-#   powershell -File tests/query_visibility.ps1 -MinCallers 1
+#   powershell -File tools/query_visibility.ps1
+#   powershell -File tools/query_visibility.ps1 -MinCallers 1
 #
 # Parameters:
 #   -MinCallers  Show functions with at most this many external callers (0 or 1, default 0)


### PR DESCRIPTION
## Summary

- Move all 10 query tools (`query_*.ps1`) from `tests/` to `tools/`, clarifying boundary: `tests/` = enforcement, `tools/` = developer info tools
- Rename dual-duty scripts (`check_global_ownership` → `query_global_ownership`, `check_function_visibility` → `query_function_visibility`) with query mode as default and `-Check` for enforcement
- `static_analysis.ps1` hardcodes two `tools/` paths with `-Check` flag; auto-discovery for `tests/check_*.ps1` unchanged
- Update CLAUDE.md, `ownership.manifest`, and all header comments to reflect new paths
- Rename `-Verbose` → `-Detail` to avoid PowerShell common parameter conflict with `[Parameter(Position=0)]`

Closes #87

## Test plan

- [x] Pre-gate passes (`static_analysis.ps1` finds and runs both tools/ scripts with `-Check`)
- [x] `query_global_ownership.ps1 cfg` — positional query works as default mode
- [x] `query_function_visibility.ps1 GUI_OnInterceptorEvent` — positional query works
- [x] Both tools show usage hints when invoked with no args
- [x] `query_timers.ps1` works from new `tools/` location
- [ ] Full test suite (`.\tests\test.ps1 --live`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)