### PR TITLE
Fix bypass mode stuck ON after focus leaves bypass window

### DIFF
--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -274,12 +274,15 @@ _GUI_OnProducerRevChanged(isStructural := true) {
             ; Cosmetic changes: patch title/icon/processName in-place
             if (!isStructural)
                 GUI_PatchCosmeticUpdates()
-            ; Always check bypass mode on focus changes
-            fgHwnd := DllCall("GetForegroundWindow", "Ptr")
-            if (fgHwnd) {
-                shouldBypass := INT_ShouldBypassWindow(fgHwnd)
-                INT_SetBypassMode(shouldBypass)
-            }
+        }
+
+        ; Check bypass mode on every focus change regardless of state.
+        ; Previously gated to ACTIVE-only, which caused a deadlock: bypass
+        ; disabled Tab hooks, and only ACTIVE state (requires Tab) could clear it.
+        fgHwnd := DllCall("GetForegroundWindow", "Ptr")
+        if (fgHwnd) {
+            shouldBypass := INT_ShouldBypassWindow(fgHwnd)
+            INT_SetBypassMode(shouldBypass)
         }
     } catch as e {
         global LOG_PATH_STORE

--- a/tests/check_batch_patterns.ps1
+++ b/tests/check_batch_patterns.ps1
@@ -398,6 +398,13 @@ $CHECKS = @(
         Patterns = @('Hotkey("$*Tab", "Off")', 'Hotkey("$*Tab", "On")')
     },
     @{
+        Id       = "bypass_eval_all_states"
+        File     = "gui\gui_main.ahk"
+        Function = "_GUI_OnProducerRevChanged"
+        Desc     = "Bypass evaluation runs in all GUI states, not just ACTIVE (issue #91)"
+        Patterns = @("INT_SetBypassMode(shouldBypass)", "INT_ShouldBypassWindow(fgHwnd)")
+    },
+    @{
         Id       = "config_validation_completeness_loader"
         File     = "shared\config_loader.ahk"
         Desc     = "_CL_ValidateSettings uses registry-driven clamping loop"


### PR DESCRIPTION
## Summary

- Bypass mode (game mode) in `_GUI_OnProducerRevChanged()` was only re-evaluated during `ACTIVE` state, creating a deadlock: bypass disabled Tab hooks, and only ACTIVE state (which requires Tab) could clear it
- Moved bypass evaluation outside the state if/else chain so it runs on every producer callback regardless of GUI state
- Added `bypass_eval_all_states` static analysis check to prevent regression

## Test plan

- [x] All 70 static analysis checks pass (including new `bypass_eval_all_states`)
- [x] All 268 GUI tests pass
- [x] All live tests pass (core, features, network, execution, lifecycle)
- [ ] Manual: focus a bypass-eligible window (Steam/fullscreen game), then click a normal window — verify Alt-Tab works immediately after

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)