### PR TITLE
Prevent working set trimming after long idle

### DIFF
--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -1117,6 +1117,18 @@ global gConfigRegistry := [
      d: "Interval (ms) between housekeeping cycles: cache pruning, log rotation, and stats flush. Lower = more responsive cleanup but slightly more CPU. Default 5 minutes."},
 
     ; ============================================================
+    ; Performance
+    ; ============================================================
+    {type: "section", name: "Performance", desc: "Performance",
+     long: "Memory management to maintain responsiveness after long idle periods."},
+
+    {s: "Performance", k: "KeepInMemory", g: "PerfKeepInMemory", t: "bool", default: true,
+     d: "Set a hard working set floor after warm-up. Tells Windows not to trim resident memory below the measured baseline. Trades slightly higher steady-state memory for instant responsiveness after long idle."},
+
+    {s: "Performance", k: "ForceTouchMemory", g: "PerfForceTouchMemory", t: "bool", default: true,
+     d: "Periodically read key data structures (icon cache, window store, GDI+ resources) to keep their memory pages resident. Runs on the housekeeping cycle with negligible CPU cost."},
+
+    ; ============================================================
     ; Diagnostics
     ; ============================================================
     {type: "section", name: "Diagnostics",

--- a/tests/test_unit_core_config.ahk
+++ b/tests/test_unit_core_config.ahk
@@ -479,6 +479,29 @@ RunUnitTests_CoreConfig() {
     try DirDelete(testCfgDir)
 
     ; ============================================================
+    ; Performance Config Default Tests
+    ; ============================================================
+    Log("`n--- Performance Config Default Tests ---")
+
+    perfOptions := ["PerfKeepInMemory", "PerfForceTouchMemory"]
+    allPerfDefaultTrue := true
+    for _, opt in perfOptions {
+        if (!cfg.HasOwnProp(opt)) {
+            Log("FAIL: cfg missing performance option: " opt)
+            TestErrors++
+            allPerfDefaultTrue := false
+        } else if (cfg.%opt% != true) {
+            Log("FAIL: " opt " should default to true, got: " cfg.%opt%)
+            TestErrors++
+            allPerfDefaultTrue := false
+        }
+    }
+    if (allPerfDefaultTrue) {
+        Log("PASS: All " perfOptions.Length " performance options default to true")
+        TestPassed++
+    }
+
+    ; ============================================================
     ; Diagnostic Logging Guard Tests
     ; ============================================================
     ; These tests verify that logging functions respect their config flags


### PR DESCRIPTION
## Summary

- Add `Performance` config section with `KeepInMemory` and `ForceTouchMemory` options (both default `true`)
- `_GUI_LockWorkingSet()`: one-shot timer (5s delay) measures working set via `K32GetProcessMemoryInfo`, then sets a hard floor via `SetProcessWorkingSetSizeEx` with `QUOTA_LIMITS_HARDWS_MIN_ENABLE | QUOTA_LIMITS_HARDWS_MAX_DISABLE` (0x9)
- `_GUI_TouchMemoryPages()`: piggybacks on housekeeping cycle, reads one entry from each key data structure (icon cache, window store, GDI+ resources, live items, brush cache) to keep pages resident
- Timer cleanup in `_GUI_OnExit()`, unit tests for config defaults

Closes #94

## Test plan

- [x] Pre-gate static analysis passes (70 checks)
- [x] All 896 tests pass (unit, GUI, live)
- [ ] Launch compiled exe, wait 5+ seconds, check `%TEMP%\tabby_store_error.log` for `LockWorkingSet: set hard min=XXmb`
- [ ] Watch working set in Task Manager over 10+ minutes — should remain stable
- [ ] Set both to `false` in config.ini, restart, confirm no LockWorkingSet log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)