### PR TITLE
Add foreground focus drift guard for untracked windows

### DIFF
--- a/src/core/winenum_lite.ahk
+++ b/src/core/winenum_lite.ahk
@@ -39,6 +39,11 @@ WinEnumLite_ScanAll() {
     list := WinGetList()
     DetectHiddenWindows(prevDetect)
 
+    ; Capture foreground window once — stamp MRU if scan discovers it as new.
+    ; Safety net: if the REFRESH guard missed this window, at least the scan
+    ; gives it MRU #1 instead of lastActivatedTick: 0 (bottom of list).
+    fgHwnd := DllCall("GetForegroundWindow", "Ptr")
+
     for _, hwnd in list {
         ; Skip shell window
         if (hwnd = _WN_ShellWindow)
@@ -49,6 +54,9 @@ WinEnumLite_ScanAll() {
         rec := WinUtils_ProbeWindow(hwnd, z, false, true)
         if (!rec)
             continue
+
+        if (hwnd = fgHwnd)
+            rec["lastActivatedTick"] := A_TickCount
 
         z += 1
         records.Push(rec)

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -274,6 +274,15 @@ WL_UpdateFields(hwnd, fields, source := "") {
     ; No-op in tests
 }
 
+WL_UpsertWindow(records, source := "") {
+    ; No-op in tests (foreground guard calls this)
+}
+
+WinUtils_ProbeWindow(hwnd, z := 0, includeCloaked := false, checkEligible := false) {
+    ; Return 0 (ineligible) in tests — foreground guard skips when probe fails
+    return 0
+}
+
 WL_PurgeBlacklisted() {
     ; No-op in tests
 }
@@ -302,7 +311,7 @@ global FR_EV_WINDOW_ADD := 24, FR_EV_WINDOW_REMOVE := 25, FR_EV_GHOST_PURGE := 2
 global FR_EV_COSMETIC_PATCH := 28, FR_EV_SCAN_COMPLETE := 29
 global FR_EV_SESSION_START := 30, FR_EV_PRODUCER_INIT := 31, FR_EV_ACTIVATE_GONE := 32, FR_EV_ACTIVATE_RETRY := 33
 global FR_EV_WS_SWITCH := 40, FR_EV_WS_TOGGLE := 41, FR_EV_MON_TOGGLE := 42
-global FR_EV_FOCUS := 50, FR_EV_FOCUS_SUPPRESS := 51
+global FR_EV_FOCUS := 50, FR_EV_FOCUS_SUPPRESS := 51, FR_EV_FG_GUARD := 53
 global FR_ST_IDLE := 0, FR_ST_ALT_PENDING := 1, FR_ST_ACTIVE := 2
 FR_Record(ev, d1:=0, d2:=0, d3:=0, d4:=0) {
 }
@@ -342,6 +351,63 @@ class _MockGui {
 }
 global gGUI_Base := _MockGui()
 global gGUI_Overlay := _MockGui()
+
+; Logging mocks (gui_data.ahk, gui_state.ahk call these)
+LogAppend(params*) {
+}
+LogInitSession(params*) {
+}
+
+; Process utility mock (gui_state.ahk calls this)
+ProcessUtils_RunHidden(params*) {
+}
+
+; Blacklist editor mocks (gui_input.ahk calls these)
+Blacklist_AddClass(params*) {
+}
+Blacklist_AddPair(params*) {
+}
+Blacklist_AddTitle(params*) {
+}
+
+; Anti-flash mocks (gui_input.ahk calls these)
+GUI_AntiFlashPrepare(params*) {
+}
+GUI_AntiFlashReveal(params*) {
+}
+
+; Layout mocks (gui_input.ahk, gui_math.ahk call these)
+GUI_GetActionBtnMetrics(params*) {
+    return {x: 0, y: 0, w: 0, h: 0, gap: 0}
+}
+GUI_HeaderBlockDip(params*) {
+    return 0
+}
+
+; Theme mocks (gui_input.ahk calls these)
+Theme_ApplyToControl(params*) {
+}
+Theme_ApplyToGui(params*) {
+}
+Theme_GetAccentColor(params*) {
+    return "FFFFFF"
+}
+Theme_GetMutedColor(params*) {
+    return "888888"
+}
+Theme_MarkAccent(params*) {
+}
+Theme_MarkMuted(params*) {
+}
+Theme_UntrackGui(params*) {
+}
+
+; Window utility mocks (gui_input.ahk calls these)
+Win_ConfirmTopmost(params*) {
+}
+Win_GetRectPhys(params*) {
+    return {x: 0, y: 0, w: 0, h: 0}
+}
 
 ; ============================================================
 ; 3. INCLUDE ACTUAL PRODUCTION FILES

--- a/tests/run_tests.ahk
+++ b/tests/run_tests.ahk
@@ -57,7 +57,7 @@ global FR_EV_WINDOW_ADD := 24, FR_EV_WINDOW_REMOVE := 25, FR_EV_GHOST_PURGE := 2
 global FR_EV_COSMETIC_PATCH := 28, FR_EV_SCAN_COMPLETE := 29
 global FR_EV_PRODUCER_INIT := 31, FR_EV_ACTIVATE_GONE := 32, FR_EV_PRODUCER_BACKOFF := 60
 global FR_EV_WS_SWITCH := 40, FR_EV_WS_TOGGLE := 41
-global FR_EV_FOCUS := 50, FR_EV_FOCUS_SUPPRESS := 51, FR_EV_KSUB_MRU_STALE := 52
+global FR_EV_FOCUS := 50, FR_EV_FOCUS_SUPPRESS := 51, FR_EV_KSUB_MRU_STALE := 52, FR_EV_FG_GUARD := 53
 FR_Record(ev, d1:=0, d2:=0, d3:=0, d4:=0) {
 }
 
@@ -184,6 +184,100 @@ _Test_OnError(err, *) {
 try FileDelete(TestLogPath)
 Log("=== Alt-Tabby Test Run " FormatTime(, "yyyy-MM-dd HH:mm:ss") " ===")
 Log("Log file: " TestLogPath)
+
+; ============================================================
+; Production function mocks (defined BEFORE includes)
+; Functions called in production code paths not exercised during
+; tests. Mocks prevent AHK v2 "undefined variable" popups.
+; ============================================================
+
+; Icon pump mocks (icon_pump.ahk)
+Pump_EnsureRunning(params*) {
+}
+Pump_HandleIdle(params*) {
+}
+
+; Launcher / UI mocks (launcher_about.ahk)
+GUI_AntiFlashPrepare(params*) {
+}
+GUI_AntiFlashReveal(params*) {
+}
+IsInProgramFiles(params*) {
+    return false
+}
+LaunchBlacklistEditor(params*) {
+}
+LaunchConfigEditor(params*) {
+}
+LauncherUtils_IsRunning(params*) {
+    return false
+}
+LauncherUtils_LoadGdipThumb(params*) {
+    return 0
+}
+LaunchGui(params*) {
+}
+LaunchPump(params*) {
+}
+RestartBlacklistEditor(params*) {
+}
+RestartConfigEditor(params*) {
+}
+RestartGui(params*) {
+}
+RestartPump(params*) {
+}
+ShowStatsDialog(params*) {
+}
+ToggleAdminMode(params*) {
+}
+ToggleAutoUpdate(params*) {
+}
+ToggleStartMenuShortcut(params*) {
+}
+ToggleStartupShortcut(params*) {
+}
+Tray_InstallToProgramFiles(params*) {
+}
+Tray_ToggleViewer(params*) {
+}
+
+; Theme mocks (launcher_about.ahk)
+Theme_ApplyToControl(params*) {
+}
+Theme_ApplyToGui(params*) {
+}
+Theme_GetMutedColor(params*) {
+    return "888888"
+}
+Theme_MarkAccent(params*) {
+}
+Theme_MarkMuted(params*) {
+}
+Theme_MarkSemantic(params*) {
+}
+Theme_UntrackGui(params*) {
+}
+
+; Config utility mock (config_loader.ahk)
+clamp(params*) {
+    return 0
+}
+
+; Theme dialog mock (process_utils.ahk, setup_utils.ahk)
+ThemeMsgBox(params*) {
+    return "OK"
+}
+
+; Setup utility mock (setup_utils.ahk)
+RecreateShortcuts(params*) {
+}
+
+; Process pump mocks (window_list.ahk)
+GUIPump_EnsureRunning(params*) {
+}
+ProcPump_EnsureRunning(params*) {
+}
 
 ; ============================================================
 ; Include PRODUCTION files (tests call real functions)


### PR DESCRIPTION
## Summary

- **Foreground guard at REFRESH** (`gui_data.ahk`): At Alt-press time, check `GetForegroundWindow()` against the display list. If missing, probe and add at MRU #1 before freeze. Matches Windows native Alt-Tab behavior — zero continuous cost, one DllCall + Map.Has (~1μs) common path.
- **Scan-time MRU stamp** (`winenum_lite.ahk`): When periodic scan discovers a window matching the current foreground, stamp `lastActivatedTick` so it gets MRU #1 instead of bottom-of-list.
- **FR_EV_FG_GUARD** flight recorder event for diagnostics.
- **New static analysis sub-check** (`test_production_calls`): catches undefined functions in production code included by tests — closes the gap that let `WinUtils_ProbeWindow`/`WL_UpsertWindow` slip through as runtime popup dialogs.
- **Fix `BT_ResolveAhkInclude`**: strip inline comments from `#Include` lines — was silently dropping `komorebi_state.ahk` from the include tree.
- **No-op mocks** for all production functions referenced in test include chains (19 in gui_tests_common.ahk, 34 in run_tests.ahk).

Closes #99

## Test plan

- [x] Static analysis: all 72 checks pass (including new sub-check 7)
- [x] GUI tests: 268/268 pass
- [x] Unit tests: all 10 suites pass (566+ tests)
- [x] Live tests: all 5 suites pass (core, network, execution, features, lifecycle)
- [x] Manual: reproduced Directory Opus viewer scenario — Alt-Tab now returns to correct window

🤖 Generated with [Claude Code](https://claude.com/claude-code)