### PR TITLE
Fix admin-disable UAC gap and InStr path checks

### DIFF
--- a/src/launcher/launcher_about.ahk
+++ b/src/launcher/launcher_about.ahk
@@ -705,7 +705,7 @@ _Dash_AddSubprocessRow(dg, themeEntry, dot, &subY, prefix, displayName, pid, isC
 ; ============================================================
 
 _Dash_GetInstallInfo() {
-    global cfg, ALTTABBY_INSTALL_DIR
+    global cfg
 
     if (cfg.HasOwnProp("SetupExePath") && cfg.SetupExePath != "") {
         installDir := ""
@@ -713,7 +713,7 @@ _Dash_GetInstallInfo() {
         return installDir
     }
 
-    if (InStr(StrLower(A_ScriptDir), StrLower(ALTTABBY_INSTALL_DIR)))
+    if (IsInProgramFiles())
         return A_ScriptDir
 
     return A_ScriptDir " (portable)"

--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -834,14 +834,14 @@ _Launcher_CheckConfigWritable() {
 ; Check if we should skip wizard due to existing installation
 ; Returns true if: there's an existing Program Files install with valid config
 _Launcher_ShouldSkipWizardForExistingInstall() {
-    global cfg, ALTTABBY_INSTALL_DIR
+    global cfg
 
     ; Only relevant when FirstRunCompleted is false (would show wizard)
     if (cfg.SetupFirstRunCompleted)
         return false
 
     ; If running from Program Files, don't skip (let wizard show for fresh PF installs)
-    if (InStr(A_ScriptDir, ALTTABBY_INSTALL_DIR))
+    if (IsInProgramFiles())
         return false
 
     ; Check if there's a known installation (config ExePath or PF well-known path)

--- a/src/launcher/launcher_tray.ahk
+++ b/src/launcher/launcher_tray.ahk
@@ -447,7 +447,17 @@ ToggleAdminMode() {
             } catch {
                 TrayTip("Admin Mode", "Could not remove scheduled task. Re-try from the tray menu when running as administrator.", "Icon!")
             }
+            ; Re-check if elevated instance actually deleted the task
+            AdminTask_InvalidateCache()
+            deleted := !AdminTaskExists()
         }
+
+        if (!deleted) {
+            ; Both direct deletion and elevation failed — don't lie about state.
+            ; Task still exists, keep config/cache/shortcuts consistent.
+            return
+        }
+
         g_CachedAdminTaskActive := false
         Setup_SetRunAsAdmin(false, true)
         RecreateShortcuts()  ; Update shortcuts (still point to exe, but description changes)

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -405,7 +405,7 @@ CreateAdminTask(exePath, installId := "", taskNameOverride := "") {
     result := _RunWithTimeout('schtasks /create /tn "' taskName '" /xml "' xmlPath '" /f')
 
     try FileDelete(xmlPath)
-    _AdminTask_InvalidateCache()
+    AdminTask_InvalidateCache()
 
     return (result = 0)
 }
@@ -415,7 +415,7 @@ DeleteAdminTask(taskNameOverride := "") {
     global ALTTABBY_TASK_NAME
     taskName := (taskNameOverride != "") ? taskNameOverride : ALTTABBY_TASK_NAME
     result := _RunWithTimeout('schtasks /delete /tn "' taskName '" /f')
-    _AdminTask_InvalidateCache()
+    AdminTask_InvalidateCache()
     return (result = 0)
 }
 
@@ -446,7 +446,7 @@ _AdminTask_GetCachedData() {
 }
 
 ; Invalidate the admin task cache. Must be called after CreateAdminTask/DeleteAdminTask.
-_AdminTask_InvalidateCache() {
+AdminTask_InvalidateCache() {
     global g_AdminTaskCacheValid
     g_AdminTaskCacheValid := false
 }


### PR DESCRIPTION
## Summary
- **Admin-disable UAC gap**: `ToggleAdminMode()` disable path unconditionally cleared state (`g_CachedAdminTaskActive`, config, shortcuts) even when both `DeleteAdminTask()` and elevation failed. Now invalidates cache, re-checks `AdminTaskExists()`, and early-returns if deletion actually failed — preventing zombie scheduled tasks and config/shortcut desync.
- **InStr → IsInProgramFiles()**: Replaced two inline `InStr` substring checks with the canonical `IsInProgramFiles()` helper to prevent false-positive matches on similar directory names (e.g., `Alt-Tabby-Beta`).
- **Made `AdminTask_InvalidateCache` public**: Renamed from `_AdminTask_InvalidateCache` to support the cross-file call from `launcher_tray.ahk`.

## Test plan
- [x] Pre-gate static analysis: 73/73 passed
- [x] Unit tests: 566/566 passed
- [x] GUI tests: 268/268 passed
- [x] Live tests: 54/54 passed (4 lifecycle failures are pre-existing pump infra)
- [ ] Manual: Disable admin mode with UAC refused → verify tray still shows admin enabled
- [ ] Manual: Disable admin mode with UAC accepted → verify task deleted and config updated

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)