### PR TITLE
Cache Win_GetMonitorLabel to avoid per-window enumeration

### DIFF
--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -152,6 +152,7 @@ _GUI_Main_Init() {
     Paint_LogStartSession()
 
     Win_InitDpiAwareness()
+    Win_InitMonitorCache()
     Gdip_Startup()
 
     ; Initialize monitor mode from config default

--- a/src/shared/win_utils.ahk
+++ b/src/shared/win_utils.ahk
@@ -18,6 +18,9 @@ global GW_OWNER := 4
 ; DWM cloaking attribute constant
 global DWMWA_CLOAKED := 14
 
+; Monitor handle → label cache (invalidated on WM_DISPLAYCHANGE)
+global gWin_MonitorLabelCache := Map()
+
 ; Probe a single window - returns Map or empty string
 ; Parameters:
 ;   hwnd           - Window handle to probe
@@ -104,27 +107,51 @@ Win_GetMonitorHandle(hWnd) {
     return DllCall("user32\MonitorFromWindow", "ptr", hWnd, "uint", 2, "ptr")
 }
 
+; Register WM_DISPLAYCHANGE handler to invalidate monitor label cache
+; when monitor topology changes (connect/disconnect/resolution change).
+; Call from _GUI_Main_Init alongside other init functions.
+Win_InitMonitorCache() {
+    OnMessage(0x007E, _Win_OnDisplayChange)  ; WM_DISPLAYCHANGE
+}
+
 ; Get monitor index (1-based) from monitor handle for display purposes
 ; Returns "Mon N" where N is the monitor number, or "" on failure
+; Uses lazy-fill cache: first call enumerates all monitors, subsequent calls
+; are O(1) Map lookups. Cache invalidated on WM_DISPLAYCHANGE.
 Win_GetMonitorLabel(hMon) {
+    global gWin_MonitorLabelCache
     if (!hMon)
         return ""
-    ; Iterate AHK's built-in monitor list to find the matching index
+    if (gWin_MonitorLabelCache.Has(hMon))
+        return gWin_MonitorLabelCache[hMon]
+    _Win_RebuildMonitorCache()
+    return gWin_MonitorLabelCache.Get(hMon, "")
+}
+
+; Rebuild the full monitor handle → label cache.
+; Enumerates all monitors once, populating every entry.
+; Uses static Buffer to avoid per-call allocation.
+_Win_RebuildMonitorCache() {
+    global gWin_MonitorLabelCache
+    static rc := Buffer(16, 0)
+    gWin_MonitorLabelCache := Map()
     count := MonitorGetCount()
     loop count {
-        ; Get monitor bounds via AHK built-in and compare handle
         mL := 0, mT := 0, mR := 0, mB := 0
         MonitorGet(A_Index, &mL, &mT, &mR, &mB)
-        ; Build a rect and get the handle for comparison
-        rc := Buffer(16, 0)
         NumPut("Int", mL, rc, 0)
         NumPut("Int", mT, rc, 4)
         NumPut("Int", mR, rc, 8)
         NumPut("Int", mB, rc, 12)
-        testMon := DllCall("user32\MonitorFromRect", "ptr", rc.Ptr, "uint", 2, "ptr")
-        if (testMon = hMon)
-            return "Mon " A_Index
+        hMon := DllCall("user32\MonitorFromRect", "ptr", rc.Ptr, "uint", 2, "ptr")
+        if (hMon)
+            gWin_MonitorLabelCache[hMon] := "Mon " A_Index
     }
-    return ""
+}
+
+; WM_DISPLAYCHANGE handler — clear cache so next lookup triggers rebuild
+_Win_OnDisplayChange(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+    global gWin_MonitorLabelCache
+    gWin_MonitorLabelCache := Map()
 }
 


### PR DESCRIPTION
## Summary

- `Win_GetMonitorLabel` now uses a lazy-fill `Map` cache instead of iterating all monitors per call
- First call triggers a full enumeration that populates every handle→label entry; subsequent calls are O(1) lookups
- `WM_DISPLAYCHANGE` handler clears the cache so monitor topology changes are picked up on next access
- Static `Buffer` in the rebuild path eliminates per-iteration allocation

Closes #108

## Test plan

- [x] Pre-gate: all 73 static analysis checks pass
- [x] Unit tests: 570/570 pass
- [x] GUI tests: 268/268 pass
- [x] Live tests: 63/63 pass
- [ ] Manual: Alt-Tab with monitor filter — verify "Mon N" labels are correct
- [ ] Manual: Change display configuration — verify labels update

🤖 Generated with [Claude Code](https://claude.com/claude-code)