### PR TITLE
Enhance critical-section check to exempt return/continue

### DIFF
--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -1213,7 +1213,7 @@ _KSub_ScheduleCloakPush() {
 
     ; Already scheduled — nothing to do, new cloaks batch into same push
     if (_KSub_CloakPushPending)
-        return  ; lint-ignore: critical-section (AHK v2 auto-releases Critical on return)
+        return
 
     _KSub_CloakPushPending := true
     _KSub_CloakBatchTimerFn := _KSub_FlushCloakBatch.Bind()

--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -568,7 +568,7 @@ _WEH_ProcessBatch() {
         ; only check if it became invisible AND not cloaked. Cloaked = komorebi-managed
         ; on another workspace (keep it). Saves ~50-150μs per window vs full probe.
         global DWMWA_CLOAKED
-        static hiddenCloakBuf := Buffer(4, 0)  ; lint-ignore: static-in-timer
+        static hiddenCloakBuf := Buffer(4, 0)
         for _, hwnd in hidden {
             ; Still visible? Transient HIDE — keep it
             if (DllCall("user32\IsWindowVisible", "ptr", hwnd, "int"))

--- a/src/gui/gui_data.ahk
+++ b/src/gui/gui_data.ahk
@@ -221,11 +221,11 @@ _GUI_PreCacheTick() {
     work := []
     for hwnd, rec in gWS_Store {
         if (!rec.present || !rec.iconHicon)
-            continue  ; lint-ignore: critical-section
+            continue
         if (gGdip_IconCache.Has(hwnd)) {
             cached := gGdip_IconCache[hwnd]
             if (cached.hicon = rec.iconHicon && cached.pBmp)
-                continue  ; lint-ignore: critical-section
+                continue
         }
         work.Push({hwnd: hwnd, hicon: rec.iconHicon})
         if (work.Length >= 4)

--- a/src/gui/gui_input.ahk
+++ b/src/gui/gui_input.ahk
@@ -116,16 +116,16 @@ GUI_RecalcHover() {
         if (gGUI_HoverRow != 0 || gGUI_HoverBtn != "") {
             gGUI_HoverRow := 0
             gGUI_HoverBtn := ""
-            return true  ; lint-ignore: critical-section
+            return true
         }
-        return false  ; lint-ignore: critical-section
+        return false
     }
 
     act := ""
     idx := 0
     _GUI_DetectActionAtPoint(x, y, &act, &idx)
 
-    return _GUI_ApplyHoverState(idx, act)  ; lint-ignore: critical-section
+    return _GUI_ApplyHoverState(idx, act)
 }
 
 ; Atomically update hover state and return true if changed.
@@ -136,7 +136,7 @@ _GUI_ApplyHoverState(idx, act) {
     changed := (idx != gGUI_HoverRow || act != gGUI_HoverBtn)
     gGUI_HoverRow := idx
     gGUI_HoverBtn := act
-    return changed  ; lint-ignore: critical-section
+    return changed
 }
 
 _GUI_PointInRect(px, py, rx, ry, rw, rh) {

--- a/src/gui/gui_interceptor.ahk
+++ b/src/gui/gui_interceptor.ahk
@@ -183,7 +183,7 @@ _INT_Tab_Down(*) {
         GUI_OnInterceptorEvent(TABBY_EV_TAB_STEP, shiftFlag, 0)
         ; NOTE: Don't set gINT_TabHeld here - we process ALL tabs during active session
         Profiler.Leave() ; @profile
-        return  ; lint-ignore: critical-section
+        return
     }
 
     ; FIRST TAB: Check TabHeld to block key repeat (user holding Tab before Alt)
@@ -191,7 +191,7 @@ _INT_Tab_Down(*) {
         if (cfg.DiagEventLog)
             GUI_LogEvent("INT: Tab_Down -> blocked (TabHeld)")
         Profiler.Leave() ; @profile
-        return  ; lint-ignore: critical-section
+        return
     }
 
     ; Session not active yet - this is the FIRST Tab, needs decision delay
@@ -215,7 +215,7 @@ _INT_Tab_Up(*) {
     if (gINT_TabHeld) {
         ; Released from Alt+Tab step
         gINT_TabHeld := false
-        return  ; lint-ignore: critical-section
+        return
     }
 }
 
@@ -224,7 +224,7 @@ _INT_Tab_Decide() {
     global gINT_PendingDecideArmed, gINT_AltUpDuringPending, gINT_AltIsDown, cfg
     global FR_EV_TAB_DECIDE, gFR_Enabled
     if (!gINT_PendingDecideArmed)
-        return  ; lint-ignore: critical-section
+        return
     gINT_PendingDecideArmed := false
     if (gFR_Enabled)
         FR_Record(FR_EV_TAB_DECIDE, gINT_AltIsDown, gINT_AltUpDuringPending)
@@ -307,7 +307,7 @@ _INT_Escape_Down(*) {
     ; Only consume Escape if in active Alt+Tab session
     if (!gINT_SessionActive || gINT_PressCount < 1) {
         Send("{Escape}")
-        return  ; lint-ignore: critical-section
+        return
     }
 
     ; Notify GUI to cancel

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -127,7 +127,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
     global gFR_DumpInProgress
     if (gFR_DumpInProgress) {
         Profiler.Leave() ; @profile
-        return  ; lint-ignore: critical-section
+        return
     }
 
     ; File-based debug logging (no performance impact from tooltips)
@@ -148,7 +148,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
                 FR_Record(FR_EV_STATE, FR_ST_IDLE)
             gGUI_State := "IDLE"
             Profiler.Leave() ; @profile
-            return  ; lint-ignore: critical-section
+            return
         }
 
         ; Overflow protection: check BEFORE push to prevent exceeding max
@@ -163,7 +163,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
                 FR_Record(FR_EV_STATE, FR_ST_IDLE)
             gGUI_State := "IDLE"
             Profiler.Leave() ; @profile
-            return  ; lint-ignore: critical-section
+            return
         }
 
         gGUI_EventBuffer.Push({ev: evCode, flags: flags, lParam: lParam})
@@ -172,7 +172,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
         if (cfg.DiagEventLog)
             GUI_LogEvent("BUFFERING " _GUI_GetEventName(evCode) " (async pending, phase=" gGUI_PendingPhase ")")
         Profiler.Leave() ; @profile
-        return  ; lint-ignore: critical-section
+        return
     }
 
     if (evCode = TABBY_EV_ALT_DOWN) {
@@ -188,7 +188,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
         ; Pre-warm: refresh display list and icon cache before Tab arrives.
         GUI_RefreshLiveItems()  ; lint-ignore: critical-leak
         Profiler.Leave() ; @profile
-        return  ; lint-ignore: critical-section
+        return
     }
 
     if (evCode = TABBY_EV_TAB_STEP) {
@@ -197,7 +197,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
         if (gGUI_State = "IDLE") {
             ; Tab without Alt (shouldn't happen normally, interceptor handles this)
             Profiler.Leave() ; @profile
-            return  ; lint-ignore: critical-section
+            return
         }
 
         if (gGUI_State = "ALT_PENDING") {
@@ -249,7 +249,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
             ; Start grace timer - show GUI after delay
             SetTimer(_GUI_GraceTimerFired, -cfg.AltTabGraceMs)
             Profiler.Leave() ; @profile
-            return  ; lint-ignore: critical-section
+            return
         }
 
         if (gGUI_State = "ACTIVE") {
@@ -284,7 +284,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
             }
         }
         Profiler.Leave() ; @profile
-        return  ; lint-ignore: critical-section
+        return
     }
 
     if (evCode = TABBY_EV_ALT_UP) {
@@ -300,7 +300,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
                 FR_Record(FR_EV_STATE, FR_ST_IDLE)
             gGUI_State := "IDLE"
             Profiler.Leave() ; @profile
-            return  ; lint-ignore: critical-section
+            return
         }
 
         if (gGUI_State = "ACTIVE") {
@@ -334,7 +334,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
             ; Keyboard events are processed normally between timer fires.
         }
         Profiler.Leave() ; @profile
-        return  ; lint-ignore: critical-section
+        return
     }
 
     if (evCode = TABBY_EV_ESCAPE) {
@@ -354,7 +354,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
         ; Resync — refresh live items after ACTIVE state
         GUI_RefreshLiveItems()  ; lint-ignore: critical-leak
         Profiler.Leave() ; @profile
-        return  ; lint-ignore: critical-section
+        return
     }
     Profiler.Leave() ; @profile
 }
@@ -1325,7 +1325,7 @@ _GUI_UpdateLocalMRU(hwnd) {
             FR_Record(FR_EV_MRU_UPDATE, hwnd, 0)
         if (cfg.DiagEventLog)
             GUI_LogEvent("MRU UPDATE: hwnd " hwnd " not in map, skip scan")
-        return false  ; lint-ignore: critical-section
+        return false
     }
 
     if (cfg.DiagEventLog)
@@ -1343,14 +1343,14 @@ _GUI_UpdateLocalMRU(hwnd) {
             WL_UpdateFields(hwnd, {lastActivatedTick: A_TickCount, isFocused: true}, "gui_activate")
             if (gFR_Enabled)
                 FR_Record(FR_EV_MRU_UPDATE, hwnd, 1)
-            return true  ; lint-ignore: critical-section
+            return true
         }
     }
     if (gFR_Enabled)
         FR_Record(FR_EV_MRU_UPDATE, hwnd, 0)
     if (cfg.DiagEventLog)
         GUI_LogEvent("MRU UPDATE: hwnd " hwnd " not found in items")
-    return false  ; lint-ignore: critical-section
+    return false
 }
 
 ; ========================= DIRECT WINDOW UNCLOAKING (COM) =========================

--- a/src/shared/pump_utils.ahk
+++ b/src/shared/pump_utils.ahk
@@ -61,7 +61,7 @@ Pump_EnsureRunning(&timerOn, &idleTicks, intervalMs, timerFn) {
     ; from pausing timer between our timerOn check and SetTimer start
     Critical "On"
     if (timerOn)
-        return  ; lint-ignore: critical-section (AHK v2 auto-releases Critical on return)
+        return
     timerOn := true
     idleTicks := 0
     SetTimer(timerFn, intervalMs)

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -200,7 +200,7 @@ WL_EndScan(graceMs := "") {
     ; Mark komorebi windows as present, preserve their Z value
     for _, hwnd in komorebiKeep {
         if (!gWS_Store.Has(hwnd))
-            continue  ; lint-ignore: critical-section
+            continue
         rec := gWS_Store[hwnd]
         rec.lastSeenScanId := gWS_ScanId
         rec.presentNow := true
@@ -210,7 +210,7 @@ WL_EndScan(graceMs := "") {
     ; Mark missing windows (first miss starts the TTL clock)
     for _, hwnd in toMarkMissing {
         if (!gWS_Store.Has(hwnd))
-            continue  ; lint-ignore: critical-section
+            continue
         rec := gWS_Store[hwnd]
         if (rec.presentNow) {
             rec.presentNow := false
@@ -223,7 +223,7 @@ WL_EndScan(graceMs := "") {
     ; Remove dead windows (re-check IsWindow in case window reappeared between phases)
     for _, hwnd in toRemove {
         if (!gWS_Store.Has(hwnd))
-            continue  ; lint-ignore: critical-section
+            continue
         if (!DllCall("user32\IsWindow", "ptr", hwnd, "int")) {
             _WS_DeleteWindow(hwnd)
             removed += 1
@@ -269,10 +269,10 @@ WL_UpsertWindow(records, source := "") {
     Critical "On"
     for _, rec in records {
         if (!IsObject(rec))
-            continue  ; lint-ignore: critical-section
+            continue
         hwnd := rec.Get("hwnd", 0) + 0
         if (!hwnd)
-            continue  ; lint-ignore: critical-section
+            continue
         isNew := !gWS_Store.Has(hwnd)
         if (isNew) {
             gWS_Store[hwnd] := _WS_NewRecord(hwnd)
@@ -297,7 +297,7 @@ WL_UpsertWindow(records, source := "") {
                     ; (workspaceName starts as "") but guards against future call ordering
                     ; changes where a record could be pre-populated before UpsertWindow.
                     if (hasKomorebiWs && (k = "isCloaked" || k = "isOnCurrentWorkspace"))
-                        continue  ; lint-ignore: critical-section
+                        continue
                     row.%k% := v
                 }
                 rowChanged := true
@@ -307,7 +307,7 @@ WL_UpsertWindow(records, source := "") {
                 for k, v in rec {
                     ; Preserve komorebi workspace state if winenum tries to overwrite
                     if (hasKomorebiWs && (k = "isCloaked" || k = "isOnCurrentWorkspace"))
-                        continue  ; lint-ignore: critical-section
+                        continue
                     ; Only update if value differs
                     if (!row.HasOwnProp(k) || row.%k% != v) {
                         ; Diagnostic: track which fields trigger changes (skip for new records)
@@ -327,7 +327,7 @@ WL_UpsertWindow(records, source := "") {
                 }
             }
         } else {
-            continue  ; lint-ignore: critical-section (skip non-Map records)
+            continue
         }
         ; Update presence flags - check for changes
         if (!row.present) {
@@ -445,7 +445,7 @@ WL_UpdateFields(hwnd, patch, source := "", returnRow := false) {
     Critical "On"
     hwnd := hwnd + 0
     if (!gWS_Store.Has(hwnd))
-        return { changed: false, exists: false, rev: gWS_Rev }  ; lint-ignore: critical-section (AHK v2 auto-releases Critical on return)
+        return { changed: false, exists: false, rev: gWS_Rev }
     row := gWS_Store[hwnd]
 
     ; Apply patch using shared helper
@@ -462,8 +462,8 @@ WL_UpdateFields(hwnd, patch, source := "", returnRow := false) {
     }
     ; Return row when requested to avoid redundant GetByHwnd lookups
     if (returnRow)
-        return { changed: changed, exists: true, rev: gWS_Rev, row: row }  ; lint-ignore: critical-section
-    return { changed: changed, exists: true, rev: gWS_Rev }  ; lint-ignore: critical-section (AHK v2 auto-releases Critical on return)
+        return { changed: changed, exists: true, rev: gWS_Rev, row: row }
+    return { changed: changed, exists: true, rev: gWS_Rev }
 }
 
 ; Batch update multiple windows with a single rev bump
@@ -484,7 +484,7 @@ WL_BatchUpdateFields(patches, source := "") {
     for hwnd, patch in patches {
         hwnd := hwnd + 0
         if (!gWS_Store.Has(hwnd))
-            continue  ; lint-ignore: critical-section
+            continue
         row := gWS_Store[hwnd]
 
         ; Apply patch using shared helper
@@ -522,10 +522,10 @@ WL_RemoveWindow(hwnds, forceRemove := false) {
     for _, h in hwnds {
         hwnd := h + 0
         if (!gWS_Store.Has(hwnd))
-            continue  ; lint-ignore: critical-section
+            continue
         ; Verify window is actually gone before removing (unless forced)
         if (!forceRemove && DllCall("user32\IsWindow", "ptr", hwnd, "int"))
-            continue  ; lint-ignore: critical-section
+            continue
         _WS_DeleteWindow(hwnd)
         removed += 1
         if (gFR_Enabled)
@@ -675,7 +675,7 @@ WL_PurgeBlacklisted() {
         if (gFR_Enabled)
             FR_Record(FR_EV_BLACKLIST_PURGE, removed)
     }
-    return { removed: removed, rev: gWS_Rev }  ; lint-ignore: critical-section (AHK v2 auto-releases Critical on return)
+    return { removed: removed, rev: gWS_Rev }
 }
 
 _WL_GetRev() {
@@ -765,7 +765,7 @@ WL_SetCurrentWorkspace(id, name := "") {
     ; Only recalculate window state if workspace NAME changed
     ; ID is metadata only — GUI cares about name for filtering
     if (gWS_Meta["currentWSName"] = name)
-        return false  ; lint-ignore: critical-section
+        return false
 
     gWS_Meta["currentWSName"] := name
 
@@ -792,7 +792,7 @@ WL_SetCurrentWorkspace(id, name := "") {
     if (gWS_OnWorkspaceChanged)
         gWS_OnWorkspaceChanged()  ; lint-ignore: critical-leak
 
-    return anyFlipped  ; lint-ignore: critical-section
+    return anyFlipped
 }
 
 
@@ -1104,7 +1104,7 @@ WL_UpdateProcessName(pid, name) {
     changed := false
     for _, hwnd in hwnds {
         if (!gWS_Store.Has(hwnd))
-            continue  ; lint-ignore: critical-section
+            continue
         rec := gWS_Store[hwnd]
         if (rec.pid = pid && rec.processName != name) {
             rec.processName := name
@@ -1407,13 +1407,13 @@ WL_GetDisplayList(opts := 0) {
     items := []
     for _, rec in gWS_Store {
         if (!rec.present)
-            continue  ; lint-ignore: critical-section
+            continue
         if (currentOnly && !rec.isOnCurrentWorkspace)
-            continue  ; lint-ignore: critical-section
+            continue
         if (!includeMin && rec.isMinimized)
-            continue  ; lint-ignore: critical-section
+            continue
         if (!includeCloaked && rec.isCloaked)
-            continue  ; lint-ignore: critical-section
+            continue
         items.Push(rec)
     }
     Critical "Off"

--- a/tests/check_batch_simple.ps1
+++ b/tests/check_batch_simple.ps1
@@ -978,7 +978,7 @@ $validLintNames = [System.Collections.Generic.HashSet[string]]::new()
 @(
     'phantom-global',
     'singleinstance', 'winexist-cloaked', 'mixed-returns',
-    'critical-leak', 'critical-section',
+    'critical-leak',
     'ipc-constant', 'dllcall-types', 'isset-with-default',
     'cfg-property', 'duplicate-function',
     'fileappend-encoding',


### PR DESCRIPTION
## Summary

- Enhanced `critical-section` static analysis check to only flag `throw` inside Critical blocks — `return` and `continue` are inherently safe in AHK v2 (auto-release on function exit, loop continuation stays in scope)
- Removed all 49 now-unnecessary `critical-section` lint-ignore suppressions across 7 source files
- Removed 1 stale `static-in-timer` suppression (`Buffer()` auto-exemption already handles it)
- Removed dead `critical-section` tag from lint-ignore registry

Net effect: suppression count drops from 128 to 78 (39% reduction). Remaining 78 are all appropriate.

Closes #113

## Test plan

- [x] Static analysis: all 73 checks pass (up from 60 — previous parse error in check file masked 13 sub-checks)
- [x] Unit tests: 838/838 pass
- [x] GUI tests: 268/268 pass
- [x] Verify `throw` inside Critical still flagged (unsuppressible)
- [x] Verify no stale `critical-section` tags remain in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)