### PR TITLE
Add query_includes.ps1 and update skill cross-references

### DIFF
--- a/.claude/skills/flight-recorder/SKILL.md
+++ b/.claude/skills/flight-recorder/SKILL.md
@@ -47,6 +47,8 @@ Read the USER NOTE and any user-provided description. Form a hypothesis about wh
 
 ### Step 3 — Trace the event chain
 
+Use `query_state.ps1` to extract the expected state machine branches for comparison with the event trace. Use `query_messages.ps1` to identify WM_ message handlers/senders when Windows messages appear in the trace.
+
 Read the event trace bottom-to-top (chronological order). Look for:
 
 **Complete sequences** — A normal Alt-Tab is:

--- a/.claude/skills/profile/SKILL.md
+++ b/.claude/skills/profile/SKILL.md
@@ -25,7 +25,7 @@ Run these via `python tools/query_profile.py <file>`:
 
 1. **Summary** (no flags) — always run first. Show the table to the user.
 2. **Reentrancy check** (`--reentrant`) — always run. Flag any reentrant calls as potential bugs.
-3. **Deep dive** — based on the summary, pick the top 2-3 functions by total time and run `--function <name>` on each. Focus on:
+3. **Deep dive** — based on the summary, pick the top 2-3 functions by total time and run `--function <name>` on each. Use `query_timers.ps1` to check if hot functions are timer callbacks — this helps interpret high call counts (timer-driven vs event-driven). Focus on:
    - Unexpected caller chains (who is triggering this function and should they be?)
    - High call counts relative to session activity
    - Large max vs avg gaps (outliers worth investigating)

--- a/.claude/skills/review-blocking/SKILL.md
+++ b/.claude/skills/review-blocking/SKILL.md
@@ -49,6 +49,8 @@ Produce a categorized function list:
 
 Only functions in `src/core/` and `src/gui/` (plus `src/shared/` files they call into). Exclude `src/lib/` (third-party), `src/editors/` (not on main thread during Alt-Tab), `src/pump/` (separate process).
 
+Use `query_state.ps1` to determine if a blocking function is only reachable from specific state machine branches — a function that blocks only during `IDLE` is less critical than one that blocks during `ACTIVE`.
+
 ## Phase 2 — Micro-Audit
 
 **Use an agent team.** Split the discovery list into batches and assign each batch to a parallel agent. Each agent reads the function body (use `query_function.ps1 <funcName>`) and audits it in isolation.

--- a/.claude/skills/review-code-quality/SKILL.md
+++ b/.claude/skills/review-code-quality/SKILL.md
@@ -79,6 +79,8 @@ Split by area for parallel scanning:
 
 Exclude `src/lib/` (third-party code).
 
+Use `query_interface.ps1` to compare module public surfaces — similar API shapes across files can reveal DRY violations or misplaced responsibilities.
+
 ## Validation
 
 After explore agents report back, **validate every finding yourself**. Code quality is subjective — what looks like a concern violation may be an intentional design choice for performance or simplicity.

--- a/.claude/skills/review-mcode/SKILL.md
+++ b/.claude/skills/review-mcode/SKILL.md
@@ -12,7 +12,7 @@ MCode replaces AHK-interpreted tight loops with native C machine code embedded a
 
 All four must be true:
 
-1. **Hot path** — called frequently OR scales with data (per-window, per-pixel, per-byte)
+1. **Hot path** — called frequently OR scales with data (per-window, per-pixel, per-byte). Use `query_function_visibility.ps1` to check call frequency — a loop called 1x/session vs 100x/sec changes the MCode ROI.
 2. **Pure buffer computation** — operates on `Buffer` / `NumGet` / `NumPut`, not AHK objects
 3. **Interpreter-bound** — the bottleneck is AHK loop overhead, not an underlying Win32/native call
 4. **Measurable** — worst-case cost exceeds ~100μs (below that, DllCall overhead eats the savings)

--- a/.claude/skills/review-race-conditions/SKILL.md
+++ b/.claude/skills/review-race-conditions/SKILL.md
@@ -61,6 +61,7 @@ Split by concurrency boundary, not just file location:
 - **Komorebi callbacks** — `komorebi_sub.ahk`, `komorebi_lite.ahk`: subscription event handlers
 - **IPC handlers** — `ipc_pipe.ahk`, pump files: pipe read/write paths
 - **State machine** — use `query_state.ps1` to extract specific branches from `GUI_OnInterceptorEvent` without loading the full function
+- **Call graph** — use `query_function_visibility.ps1` to map which interrupt sources can reach vulnerable code (e.g., "is this function called from both timer callbacks and hotkey handlers?")
 
 ## Validation
 

--- a/.claude/skills/review-resource-leaks/SKILL.md
+++ b/.claude/skills/review-resource-leaks/SKILL.md
@@ -72,7 +72,7 @@ Data structures that grow over time without pruning:
 Split by resource type for independent parallel exploration:
 
 - **GDI+** — `src/gui/gui_paint.ahk`, `src/gui/gui_overlay.ahk`, any file using `Gdip_*`
-- **Win32 handles** — `src/core/` producers, `src/shared/ipc_pipe.ahk`, DllCall-heavy files
+- **Win32 handles** — `src/core/` producers, `src/shared/ipc_pipe.ahk`, DllCall-heavy files. Use `query_function_visibility.ps1` to trace cleanup call chains — verify every Create/Open has a corresponding Close/Delete reachable from all callers.
 - **Timers** — use `query_timers.ps1` to inventory all timers, then check each for proper cleanup
 - **Pipe IPC** — `src/shared/ipc_pipe.ahk`, `src/pump/` files
 - **Data growth** — `src/shared/window_list.ahk` (window store), icon/process caches

--- a/tools/query_includes.ps1
+++ b/tools/query_includes.ps1
@@ -1,0 +1,298 @@
+# query_includes.ps1 - #Include dependency query
+#
+# Shows which files include a given module, or the full include tree.
+#
+# Usage:
+#   powershell -File tools/query_includes.ps1                 (full include tree)
+#   powershell -File tools/query_includes.ps1 window_list     (who includes this file?)
+#   powershell -File tools/query_includes.ps1 window_list.ahk (same, with extension)
+
+param(
+    [Parameter(Position=0)]
+    [string]$Target
+)
+
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\_query_helpers.ps1"
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+$projectRoot = Split-Path $PSScriptRoot -Parent
+$srcDir = Join-Path $projectRoot "src"
+
+if (-not (Test-Path $srcDir)) {
+    Write-Host "  ERROR: Cannot find $srcDir" -ForegroundColor Red
+    exit 1
+}
+
+# === Parse all #Include directives across all .ahk files ===
+# Returns: array of { Source, Target, Optional, LineNum }
+# Source/Target are relative paths from project root (e.g., src\gui\gui_main.ahk)
+
+$allFiles = Get-AhkSourceFiles $srcDir
+# Also include files in src\lib\ as potential include sources (entry points include them)
+$libFiles = @(Get-ChildItem -Path (Join-Path $srcDir "lib") -Filter "*.ahk" -Recurse -ErrorAction SilentlyContinue)
+
+# Build a filename-to-relpath lookup for all .ahk files
+$fileIndex = @{}
+foreach ($f in @($allFiles) + @($libFiles)) {
+    $relPath = $f.FullName.Replace("$projectRoot\", '')
+    $fileIndex[$f.Name.ToLower()] = $relPath
+}
+
+# Parse includes
+$includes = [System.Collections.ArrayList]::new()  # { Source, Target, Optional, LineNum }
+
+foreach ($file in @($allFiles) + @($libFiles)) {
+    $relPath = $file.FullName.Replace("$projectRoot\", '')
+    $lines = [System.IO.File]::ReadAllLines($file.FullName)
+    $currentDir = $file.DirectoryName
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i].Trim()
+        if (-not $line.StartsWith('#Include')) { continue }
+
+        # Strip inline comments
+        $commentIdx = $line.IndexOf(' ;')
+        if ($commentIdx -gt 0) { $line = $line.Substring(0, $commentIdx).Trim() }
+
+        $optional = $false
+
+        # Match: #Include *i <path>  (optional include)
+        if ($line -match '^#Include\s+\*i\s+(.+)$') {
+            $path = $Matches[1].Trim()
+            $optional = $true
+        }
+        # Match: #Include <path>
+        elseif ($line -match '^#Include\s+(.+)$') {
+            $path = $Matches[1].Trim()
+        }
+        else { continue }
+
+        # Resolve %A_ScriptDir% and %A_LineFile% variables
+        $resolved = $path
+        $resolved = $resolved -replace '%A_ScriptDir%', $file.DirectoryName
+        $resolved = $resolved -replace '%A_LineFile%', $file.FullName
+
+        # Resolve to absolute path
+        if (-not [System.IO.Path]::IsPathRooted($resolved)) {
+            $resolved = Join-Path $currentDir $resolved
+        }
+        $resolved = [System.IO.Path]::GetFullPath($resolved)
+
+        # Directory change: #Include %A_ScriptDir%\gui\
+        if ($resolved.EndsWith('\') -or (Test-Path $resolved -PathType Container -ErrorAction SilentlyContinue)) {
+            $currentDir = $resolved.TrimEnd('\')
+            continue
+        }
+
+        # File include — resolve relative path
+        $targetRelPath = $resolved.Replace("$projectRoot\", '')
+
+        [void]$includes.Add(@{
+            Source   = $relPath
+            Target   = $targetRelPath
+            Optional = $optional
+            LineNum  = ($i + 1)
+        })
+    }
+}
+
+# === Build forward and reverse maps ===
+# Forward: source → targets[]
+# Reverse: target → sources[]
+
+$forwardMap = @{}
+$reverseMap = @{}
+
+foreach ($inc in $includes) {
+    $src = $inc.Source
+    $tgt = $inc.Target
+
+    if (-not $forwardMap.ContainsKey($src)) { $forwardMap[$src] = [System.Collections.ArrayList]::new() }
+    [void]$forwardMap[$src].Add($inc)
+
+    if (-not $reverseMap.ContainsKey($tgt)) { $reverseMap[$tgt] = [System.Collections.ArrayList]::new() }
+    [void]$reverseMap[$tgt].Add($inc)
+}
+
+# === No-arg mode: full include tree from entry points ===
+if (-not $Target) {
+    # Find entry points: files that are NOT included by anyone
+    $allSources = [System.Collections.Generic.HashSet[string]]::new(
+        [string[]]@($forwardMap.Keys), [System.StringComparer]::OrdinalIgnoreCase)
+    $allTargets = [System.Collections.Generic.HashSet[string]]::new(
+        [string[]]@($reverseMap.Keys), [System.StringComparer]::OrdinalIgnoreCase)
+
+    $entryPoints = [System.Collections.ArrayList]::new()
+    foreach ($src in $allSources) {
+        if (-not $allTargets.Contains($src)) {
+            [void]$entryPoints.Add($src)
+        }
+    }
+    $entryPoints.Sort()
+
+    Write-Host ""
+    Write-Host "  Include Tree ($($includes.Count) directives across $($allFiles.Count + $libFiles.Count) files)" -ForegroundColor White
+    Write-Host ""
+
+    function Show-Tree {
+        param([string]$File, [string]$Indent, [System.Collections.Generic.HashSet[string]]$Visited)
+        if ($Visited.Contains($File)) {
+            Write-Host "${Indent}(circular) $File" -ForegroundColor DarkYellow
+            return
+        }
+        [void]$Visited.Add($File)
+
+        if (-not $forwardMap.ContainsKey($File)) { return }
+        $children = $forwardMap[$File] | Sort-Object { $_.LineNum }
+        foreach ($child in $children) {
+            $marker = if ($child.Optional) { "*" } else { "" }
+            $tgt = $child.Target
+            $hasChildren = $forwardMap.ContainsKey($tgt)
+            $color = if ($hasChildren) { "Cyan" } else { "Green" }
+            Write-Host "${Indent}${marker}$tgt" -ForegroundColor $color
+            if ($hasChildren) {
+                Show-Tree $tgt "${Indent}  " $Visited
+            }
+        }
+        [void]$Visited.Remove($File)
+    }
+
+    foreach ($entry in $entryPoints) {
+        Write-Host "  $entry" -ForegroundColor White
+        $visited = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        Show-Tree $entry "    " $visited
+        Write-Host ""
+    }
+
+    Write-Host "  Legend: " -NoNewline -ForegroundColor DarkGray
+    Write-Host "white" -NoNewline -ForegroundColor White
+    Write-Host "=entry point  " -NoNewline -ForegroundColor DarkGray
+    Write-Host "cyan" -NoNewline -ForegroundColor Cyan
+    Write-Host "=has children  " -NoNewline -ForegroundColor DarkGray
+    Write-Host "green" -NoNewline -ForegroundColor Green
+    Write-Host "=leaf  " -NoNewline -ForegroundColor DarkGray
+    Write-Host "*=optional" -ForegroundColor DarkGray
+
+    $elapsed = $sw.ElapsedMilliseconds
+    Write-Host "  Completed in ${elapsed}ms" -ForegroundColor DarkGray
+    exit 0
+}
+
+# === Target mode: who includes this file? ===
+
+# Normalize target: add .ahk if missing
+$search = $Target
+if (-not $search.EndsWith('.ahk')) { $search = "$search.ahk" }
+$searchLower = $search.ToLower()
+
+# Find matching files (by filename or partial path)
+$matches = [System.Collections.ArrayList]::new()
+foreach ($tgt in $reverseMap.Keys) {
+    $tgtLower = $tgt.ToLower()
+    if ($tgtLower.EndsWith("\$searchLower") -or $tgtLower -eq $searchLower -or
+        [System.IO.Path]::GetFileName($tgtLower) -eq $searchLower) {
+        [void]$matches.Add($tgt)
+    }
+}
+
+# Also check files that exist but have no includers (leaf files or entry points)
+if ($matches.Count -eq 0) {
+    foreach ($name in $fileIndex.Keys) {
+        if ($name -eq $searchLower) {
+            $relPath = $fileIndex[$name]
+            [void]$matches.Add($relPath)
+        }
+    }
+}
+
+if ($matches.Count -eq 0) {
+    Write-Host "`n  No file matching '$Target' found in the codebase" -ForegroundColor Red
+    Write-Host ""; exit 1
+}
+if ($matches.Count -gt 1) {
+    Write-Host "`n  Ambiguous: '$Target' matches $($matches.Count) files:" -ForegroundColor Yellow
+    foreach ($m in ($matches | Sort-Object)) { Write-Host "    $m" -ForegroundColor Cyan }
+    Write-Host "`n  Use a more specific path (e.g., shared\$search)" -ForegroundColor DarkGray
+    Write-Host ""; exit 1
+}
+
+$targetFile = $matches[0]
+
+Write-Host ""
+Write-Host "  $targetFile" -ForegroundColor White
+Write-Host ""
+
+# Direct includers
+if ($reverseMap.ContainsKey($targetFile)) {
+    $includers = @($reverseMap[$targetFile] | Sort-Object { $_.Source }, { $_.LineNum })
+    Write-Host "  included by ($($includers.Count)):" -ForegroundColor Cyan
+    $maxLocLen = 10
+    foreach ($inc in $includers) {
+        $len = "$($inc.Source):$($inc.LineNum)".Length
+        if ($len -gt $maxLocLen) { $maxLocLen = $len }
+    }
+    foreach ($inc in $includers) {
+        $loc = "$($inc.Source):$($inc.LineNum)".PadRight($maxLocLen + 2)
+        $marker = if ($inc.Optional) { " (optional)" } else { "" }
+        Write-Host "    $loc$marker" -ForegroundColor Green
+    }
+} else {
+    Write-Host "  included by: (none - entry point or orphan)" -ForegroundColor DarkGray
+}
+Write-Host ""
+
+# What this file includes (forward)
+if ($forwardMap.ContainsKey($targetFile)) {
+    $children = @($forwardMap[$targetFile] | Sort-Object { $_.LineNum })
+    Write-Host "  includes ($($children.Count)):" -ForegroundColor Cyan
+    $maxLocLen = 10
+    foreach ($child in $children) {
+        $len = "$($child.Target)".Length
+        if ($len -gt $maxLocLen) { $maxLocLen = $len }
+    }
+    foreach ($child in $children) {
+        $tgt = $child.Target.PadRight($maxLocLen + 2)
+        $marker = if ($child.Optional) { " (optional)" } else { "" }
+        Write-Host "    ${tgt}line $($child.LineNum)$marker" -ForegroundColor Green
+    }
+} else {
+    Write-Host "  includes: (none - leaf file)" -ForegroundColor DarkGray
+}
+Write-Host ""
+
+# Transitive reverse: who ultimately reaches this file?
+$transitiveIncluders = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$queue = [System.Collections.Queue]::new()
+$queue.Enqueue($targetFile)
+while ($queue.Count -gt 0) {
+    $current = $queue.Dequeue()
+    if ($reverseMap.ContainsKey($current)) {
+        foreach ($inc in $reverseMap[$current]) {
+            if ($transitiveIncluders.Add($inc.Source)) {
+                $queue.Enqueue($inc.Source)
+            }
+        }
+    }
+}
+
+if ($transitiveIncluders.Count -gt 0) {
+    # Find entry points in the transitive set
+    $entryRoots = [System.Collections.ArrayList]::new()
+    foreach ($t in $transitiveIncluders) {
+        if (-not $reverseMap.ContainsKey($t)) {
+            [void]$entryRoots.Add($t)
+        }
+    }
+    if ($entryRoots.Count -gt 0) {
+        $entryRoots.Sort()
+        Write-Host "  entry points that reach this file:" -ForegroundColor Cyan
+        foreach ($e in $entryRoots) {
+            Write-Host "    $e" -ForegroundColor Green
+        }
+        Write-Host ""
+    }
+}
+
+$elapsed = $sw.ElapsedMilliseconds
+Write-Host "  Completed in ${elapsed}ms" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary

- Add `tools/query_includes.ps1` for `#Include` dependency analysis — two modes: full include tree (no args) and reverse lookup ("who includes this file?")
- Wire missing query tool references into 7 skills: `flight-recorder`, `review-resource-leaks`, `review-race-conditions`, `review-blocking`, `profile`, `review-code-quality`, `review-mcode`
- Full audit found all 12 existing tools accurate, zero retirement candidates

Closes #114

## Test plan

- [x] `query_includes.ps1` no-args mode shows correct include tree (103 directives, 2 entry points)
- [x] `query_includes.ps1 window_list` reverse lookup shows correct includer and entry point
- [x] `query_includes.ps1 error_format` shows all 4 includers correctly
- [x] `query_includes.ps1 nonexistent_file` errors gracefully
- [x] All 901 tests pass (unit, GUI, live, core, network, execution, features, lifecycle)
- [x] Static analysis: 73/73 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)