### PR TITLE
Fix stale function names in skills and rules files

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -65,7 +65,7 @@ States in display list meta: `"running"`, `"failed"`, `"disabled"`
 ### Focus Event Race Condition (CRITICAL)
 When a new window opens and gets focus:
 1. `EVENT_SYSTEM_FOREGROUND` fires BEFORE WinEnum discovers the window
-2. WinEventHook's `WindowStore_UpdateFields()` returns `exists: false`
+2. WinEventHook's `WL_UpdateFields()` returns `exists: false`
 3. **FIX:** When focus event comes for unknown window, check eligibility and ADD it immediately with MRU data
 4. Without this fix, new windows appear at BOTTOM of Alt+Tab list
 
@@ -74,7 +74,7 @@ Some apps (Outlook, etc.) REUSE HWNDs for temporary windows:
 1. Window is added when eligible
 2. App "closes" window but HWND still exists (just hidden/cloaked)
 3. `IsWindow()` returns true, so standard validation doesn't remove it
-4. **FIX:** `WindowStore_ValidateExistence()` also checks `Blacklist_IsWindowEligible()`
+4. **FIX:** `WL_ValidateExistence()` also checks `Blacklist_IsWindowEligible()`
 5. Ghost windows are removed when they become ineligible
 
 ## State Machine

--- a/.claude/rules/keyboard-hooks.md
+++ b/.claude/rules/keyboard-hooks.md
@@ -3,7 +3,7 @@
 ## Core Rules
 
 - **`SendMode("Event")` is mandatory** — AHK's default `SendInput` temporarily uninstalls all keyboard hooks. User keypresses during that window are lost forever.
-- **`Critical "On"` in all hotkey callbacks** — Without it, one callback can interrupt another mid-execution. Apply to: `INT_Alt_Down/Up`, `INT_Tab_Down/Up`, `INT_Tab_Decide`, `INT_Ctrl_Down`, `INT_Escape_Down`, `GUI_OnInterceptorEvent`.
+- **`Critical "On"` in all hotkey callbacks** — Without it, one callback can interrupt another mid-execution. Apply to: `_INT_Alt_Down/_INT_Alt_Up`, `_INT_Tab_Down/_INT_Tab_Up`, `_INT_Tab_Decide`, `_INT_Ctrl_Down`, `_INT_Escape_Down`, `GUI_OnInterceptorEvent`.
 - **komorebic also uninstalls hooks** — `komorebic focus-named-workspace` uses SendInput internally. Fix: async activation with event buffering.
 
 ## Key Patterns

--- a/.claude/skills/review-criticals/SKILL.md
+++ b/.claude/skills/review-criticals/SKILL.md
@@ -67,7 +67,7 @@ This is not "is this a good idea" — it's "name the exact interleaving." What i
 These Critical sections have been deliberately designed, tested, and documented. Do not propose removing, narrowing, or questioning them:
 
 - **`Critical "On"` through the entire `GUI_OnInterceptorEvent` handler including GDI+ rendering** (~16ms). This was previously narrowed and reverted — releasing before render causes partial glass background, window mapping corruption, and stale projection data. See `keyboard-hooks.md` "Do NOT Release Critical Before Rendering." This is the most important Critical section in the codebase.
-- **`Critical "On"` in `INT_Alt_Down`, `INT_Alt_Up`, `INT_Tab_Down`, `INT_Tab_Up`, `INT_Tab_Decide`, `INT_Ctrl_Down`, `INT_Escape_Down`** — all hotkey callbacks require Critical to prevent callback-interrupting-callback corruption.
+- **`Critical "On"` in `_INT_Alt_Down`, `_INT_Alt_Up`, `_INT_Tab_Down`, `_INT_Tab_Up`, `_INT_Tab_Decide`, `_INT_Ctrl_Down`, `_INT_Escape_Down`** — all hotkey callbacks require Critical to prevent callback-interrupting-callback corruption.
 - **Async activation event buffer** (`gGUI_EventBuffer`) — Critical around buffer push/pop is necessary by design.
 - **Flight recorder `FR_Record()`** — if it uses Critical, it's protecting the ring buffer write pointer. Pre-allocated, intentional.
 

--- a/.claude/skills/review-function-visibility/SKILL.md
+++ b/.claude/skills/review-function-visibility/SKILL.md
@@ -46,7 +46,7 @@ Flag these but apply judgment. Only propose making private when:
 
 ## CRITICAL — Safe Renaming
 
-**Never use `replace_all` when the function name is a substring of another function name.** For example, renaming `Store_Init` would corrupt `WindowStore_Init`.
+**Never use `replace_all` when the function name is a substring of another function name.** For example, renaming `_Init` would corrupt `WL_Init`.
 
 Before every rename:
 1. Use `query_function_visibility.ps1 <funcName>` to get all call sites


### PR DESCRIPTION
## Summary

- Fixed 7 stale `INT_*` → `_INT_*` function references in `review-criticals` skill and `keyboard-hooks.md` rules (functions are private, require underscore prefix)
- Fixed 2 stale `WindowStore_UpdateFields()`/`WindowStore_ValidateExistence()` → `WL_UpdateFields()`/`WL_ValidateExistence()` in `architecture.md`
- Updated stale illustrative example in `review-function-visibility` skill (`WindowStore_Init` → `WL_Init`)

Full audit verified 300+ identifiers across all 44 skills — everything else is current.

## Test plan

- [x] `grep -r "WindowStore_" .claude/rules/ .claude/skills/` returns no matches
- [x] `grep -r "INT_Alt_Down[^\`_]" .claude/rules/ .claude/skills/` returns no matches (no unprefixed references)
- [ ] Verify `review-criticals` skill agent can find `_INT_Alt_Down` via `query_function_visibility.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)