### PR TITLE
Consolidate config parsing, remove stale comment and dead code

### DIFF
--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -712,7 +712,6 @@ _WEH_ProbeWindow(hwnd) {
 
 ; Lightweight update for windows already in the store.
 ; Skips immutable fields (class, PID) - only fetches title + vis/min/cloak.
-; Returns: true if updated, false if skipped (hung/dead), -1 if ineligible (should remove)
 ; Returns: Object patch (success), -1 (ineligible/destroyed), false (skipped/error)
 ; Caller batches patches and calls WL_BatchUpdateFields once for the whole batch.
 _WEH_UpdateExisting(hwnd) {


### PR DESCRIPTION
## Summary

- Extract `_CL_CoerceValue()` for shared bool/int/float/string type coercion, used by both `CL_ParseValue` (editor UIs) and `_CL_LoadAllSettings` (startup loader) — eliminates parsing drift where the two had diverged on bool validation and hex int handling
- Delete stale return-type comment in `_WEH_UpdateExisting` that described a previous API contract (said `true`, function returns Object)
- Remove redundant `SubStr` hex check in `CL_ParseValue` — `Integer()` handles `0x` natively

## Test plan

- [x] Static analysis: 73/73 checks pass (new `_CL_CoerceValue` passes globals checker)
- [x] Unit/Core/Config: 50/50 tests pass (config parsing exercised)
- [x] Full suite: 897/901 pass (4 pre-existing lifecycle infra failures unrelated)

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)