### PR TITLE
Reduce hot-path latency in store, producers, and state machine

### DIFF
--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -540,20 +540,11 @@ _WEH_ProcessBatch() {
         if (_WEH_PendingZNeeded.Has(hwnd))
             zSnapshot[hwnd] := true
     }
-    for _, hwnd in destroyed {
-        _WEH_PendingHwnds.Delete(hwnd)
-        if (_WEH_PendingZNeeded.Has(hwnd))
+    for _, arr in [destroyed, hidden, toProcess] {
+        for _, hwnd in arr {
+            _WEH_PendingHwnds.Delete(hwnd)
             _WEH_PendingZNeeded.Delete(hwnd)
-    }
-    for _, hwnd in hidden {
-        _WEH_PendingHwnds.Delete(hwnd)
-        if (_WEH_PendingZNeeded.Has(hwnd))
-            _WEH_PendingZNeeded.Delete(hwnd)
-    }
-    for _, hwnd in toProcess {
-        _WEH_PendingHwnds.Delete(hwnd)
-        if (_WEH_PendingZNeeded.Has(hwnd))
-            _WEH_PendingZNeeded.Delete(hwnd)
+        }
     }
     Critical "Off"
 

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -495,9 +495,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
 
             for _, col in cols {
                 val := ""
-                if (col.key = "hwndHex")
-                    val := Format("0x{:X}", cur.hwnd)
-                else if (cur.HasOwnProp(col.key))
+                if (cur.HasOwnProp(col.key))
                     val := cur.%col.key%
                 Gdip_DrawText(g, val, col.x, yRow + colY, col.w, colH, brColUse, fColUse, fmtCol)
             }

--- a/tests/check_batch_patterns.ps1
+++ b/tests/check_batch_patterns.ps1
@@ -451,11 +451,11 @@ $CHECKS = @(
         NotPresent = @('Critical "Off"')
     },
     @{
-        Id       = "path15_sort_invariant"
+        Id       = "path15_tracked_hwnd"
         File     = "shared\window_list.ahk"
-        Desc     = "Path 1.5 display list validates sort invariant after move-to-front"
+        Desc     = "Path 1.5 uses tracked MRU hwnd for direct search with invariant check"
         Regex    = $true
-        Patterns = @('lastActivatedTick\s*<\s*sortedRecs')
+        Patterns = @('gWS_MRUBumpedHwnd', 'lastActivatedTick\s*<\s*sortedRecs')
     },
     @{
         Id       = "ghost_window_detection"

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -357,6 +357,9 @@ LogAppend(params*) {
 }
 LogInitSession(params*) {
 }
+GetLogTimestamp() {
+    return "00:00:00.000"
+}
 
 ; Process utility mock (gui_state.ahk calls this)
 ProcessUtils_RunHidden(params*) {


### PR DESCRIPTION
## Summary

Closes #123

- **Store**: Track bumped hwnd for O(1) Path 1.5 MRU leader lookup; in-place `_WS_PatchItem` avoids per-dirty-hwnd Object allocation; pre-compute `hwndHex` field to eliminate per-frame `Format()` in paint
- **Producers**: Merge 3 WEH cleanup loops into single pass; inline `KSafe_Str`/`KSafe_Int` at komorebi state walk call sites; replace per-window `{ wsName, isCurrent, winObj }` Object with 3 parallel Maps
- **State machine**: Buffer `GUI_LogEvent` messages and flush via deferred `SetTimer(-1)` outside Critical sections; use `gGUI_LiveItemsMap` for O(1) item lookup in `_GUI_UpdateLocalMRU`

## Test plan

- [x] Static analysis passes (73 checks)
- [x] Unit/Core/Store: 198/198 (all MRU and batch tests pass)
- [x] GUI tests: 268/268 (state machine tests pass)
- [x] Live tests: Core, Network, Features, Lifecycle all pass
- [ ] Manual: Enable `DiagPaintTimingLog=true`, rapid Alt-Tab, verify display-list build times
- [ ] Manual: With komorebi running, verify workspace switch latency (`--live --invasive`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)