### PR TITLE
Rename /plan-issue skill to /issue-from-plan

### DIFF
--- a/.claude/skills/issue-from-plan/SKILL.md
+++ b/.claude/skills/issue-from-plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: plan-issue
+name: issue-from-plan
 description: Create a GitHub issue from an approved plan before implementation
 user-invocable: true
 disable-model-invocation: true

--- a/.claude/skills/review-reviews/SKILL.md
+++ b/.claude/skills/review-reviews/SKILL.md
@@ -89,7 +89,7 @@ These are style issues, not correctness — report them but don't prioritize ove
 
 All files in `.claude/skills/*/SKILL.md`. Also check `.claude/rules/*.md` as cross-reference targets (but don't audit the rules files themselves — they're the source of truth, not the skills).
 
-Do NOT audit non-review skills (like `ship`, `worktree`, `clean-all`, `merge-all`, `plan-issue`, `profile`) unless they reference codebase identifiers that could drift.
+Do NOT audit non-review skills (like `ship`, `worktree`, `clean-all`, `merge-all`, `issue-from-plan`, `profile`) unless they reference codebase identifiers that could drift.
 
 ## Explore Strategy
 


### PR DESCRIPTION
## Summary
- Renames `/plan-issue` to `/issue-from-plan` to avoid prefix collision with `/plan`
- Updates reference in `review-reviews` skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)