### PR TITLE
Guard two-phase delete paths against concurrent removal

### DIFF
--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -1506,7 +1506,10 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
             addedCount++
         } else {
             ; Window exists - only patch if workspace data actually changed
-            row := gWS_Store[hwnd]
+            ; RACE FIX: Use .Get() — WEH timer can remove hwnd between .Has() check and here
+            row := gWS_Store.Get(hwnd, 0)
+            if (!row)
+                continue
             if (!row.HasOwnProp("workspaceName") || row.workspaceName != info.wsName
                 || !row.HasOwnProp("isOnCurrentWorkspace") || row.isOnCurrentWorkspace != info.isCurrent
                 || !row.HasOwnProp("isCloaked") || row.isCloaked != !info.isCurrent) {

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -622,6 +622,8 @@ WL_ValidateExistence() {
     Critical "On"
     removed := 0
     for _, hwnd in toRemove {
+        if (!gWS_Store.Has(hwnd))
+            continue  ; lint-ignore: critical-section (removed by another producer between phases)
         _WS_DeleteWindow(hwnd)
         removed += 1
     }
@@ -665,6 +667,8 @@ WL_PurgeBlacklisted() {
     ; from seeing deleted entries with stale rev (consistent with ValidateExistence)
     Critical "On"
     for _, hwnd in toRemove {
+        if (!gWS_Store.Has(hwnd))
+            continue  ; lint-ignore: critical-section (removed by another producer between phases)
         _WS_DeleteWindow(hwnd)
         removed += 1
     }


### PR DESCRIPTION
## Summary
- Three two-phase store operations (classify outside Critical, delete inside Critical) were missing `gWS_Store.Has()` re-checks in Phase 2, causing `Map.Delete()` to throw if `_WEH_ProcessBatch` removed the hwnd between phases
- `WL_ValidateExistence` and `WL_PurgeBlacklisted`: added `.Has()` guard before `_WS_DeleteWindow()`, matching existing `WL_EndScan` pattern
- `_KSub_ProcessFullState`: replaced `gWS_Store[hwnd]` with `.Get(hwnd, 0)` + null check for defensive access outside Critical

## Test plan
- [x] Pre-gate static analysis (73 checks pass)
- [x] Unit tests (570/570 pass, including store operations)
- [x] GUI tests (268/268 pass)
- [x] Live tests (63/63 pass, end-to-end producer → store → GUI flow)

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)