### PR TITLE
Remove dead function, privatize WriteStateFile

### DIFF
--- a/src/gui/gui_workspace.ahk
+++ b/src/gui/gui_workspace.ahk
@@ -79,20 +79,4 @@ GUI_WorkspaceItemPasses(item) {
     return GUI_GetItemIsOnCurrent(item)
 }
 
-GUI_FilterByWorkspaceMode(items) {
-    global gGUI_WorkspaceMode, WS_MODE_ALL
-
-    if (gGUI_WorkspaceMode = WS_MODE_ALL) {
-        return items
-    }
-
-    ; WS_MODE_CURRENT mode - only items on current workspace
-    result := []
-    for _, item in items {
-        if (GUI_WorkspaceItemPasses(item)) {
-            result.Push(item)
-        }
-    }
-    return result
-}
 

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -67,7 +67,7 @@ Setup_GetInstalledPath() {
 Setup_ElevateWithState(opts) {
     global APP_NAME
     if (opts.HasOwnProp("source") && opts.HasOwnProp("target"))
-        WriteStateFile(opts.stateFile, opts.source, opts.target)
+        _WriteStateFile(opts.stateFile, opts.source, opts.target)
     try {
         if (!Launcher_RunAsAdmin(opts.flag))
             throw Error("RunAsAdmin failed")
@@ -1437,7 +1437,7 @@ ReadStateFile(filePath) {
 }
 
 ; Write a state file in source<|>target format (companion to ReadStateFile).
-WriteStateFile(filePath, sourcePath, targetPath) {
+_WriteStateFile(filePath, sourcePath, targetPath) {
     global UPDATE_INFO_DELIMITER
     try FileDelete(filePath)
     FileAppend(sourcePath UPDATE_INFO_DELIMITER targetPath, filePath, "UTF-8")

--- a/tests/gui_tests_data.ahk
+++ b/tests/gui_tests_data.ahk
@@ -759,7 +759,7 @@ RunGUITests_Data() {
     items := CreateTestItems(3, 2)
     gGUI_ToggleBase := items
     ; In "current" mode, display should show only 2 items (on Main)
-    gGUI_DisplayItems := GUI_FilterByWorkspaceMode(gGUI_ToggleBase)
+    gGUI_DisplayItems := GUI_FilterDisplayItems(gGUI_ToggleBase)
     GUI_AssertEq(gGUI_DisplayItems.Length, 2, "CosmeticPatch WS refilter setup: 2 items in current mode")
 
     ; Simulate store says item 1 moved to "Other" workspace

--- a/tests/gui_tests_state.ahk
+++ b/tests/gui_tests_state.ahk
@@ -273,7 +273,7 @@ RunGUITests_State() {
         gGUI_LiveItemsMap[item.hwnd] := item
     gGUI_ToggleBase := items.Clone()
     ; WS=current filters to Main (2 items), then toggle monitor to current
-    gGUI_DisplayItems := GUI_FilterByWorkspaceMode(gGUI_ToggleBase)
+    gGUI_DisplayItems := GUI_FilterDisplayItems(gGUI_ToggleBase)
     GUI_AssertEq(gGUI_DisplayItems.Length, 2, "Combined setup: WS=current shows 2 Main items")
 
     GUI_ToggleMonitorMode()  ; all -> current (MonA)


### PR DESCRIPTION
## Summary

- Delete `GUI_FilterByWorkspaceMode` — dead code with 0 callers (filtering handled per-item via `GUI_WorkspaceItemPasses` in `GUI_FilterDisplayItems`)
- Rename `WriteStateFile` → `_WriteStateFile` — only caller is same-file `Setup_ElevateWithState`
- Update 2 test files to use `GUI_FilterDisplayItems` instead of the deleted function

Closes #132

## Test plan

- [x] Pre-gate static analysis: 73/73 checks passed
- [x] Unit tests: 570/570 passed
- [x] GUI tests: 268/268 passed
- [x] Live tests: 48/48 passed (1 pre-existing Features failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)