### PR TITLE
Replace blind sleeps with poll loops in test suite

### DIFF
--- a/tests/test_live_pump.ahk
+++ b/tests/test_live_pump.ahk
@@ -212,12 +212,20 @@ RunLiveTests_Pump() {
         Log("Pump PID before kill: " pumpPid " (from launcher)")
         ProcessClose(pumpPid)
 
-        ; Verify kill actually worked
-        Sleep(100)
-        if (ProcessExist(pumpPid))
-            Log("WARNING: Pump process " pumpPid " still alive after ProcessClose!")
+        ; Poll for process death (don't assume Sleep is enough)
+        pumpDead := false
+        deadStart := A_TickCount
+        while ((A_TickCount - deadStart) < 2000) {
+            if (!ProcessExist(pumpPid)) {
+                pumpDead := true
+                break
+            }
+            Sleep(50)
+        }
+        if (pumpDead)
+            Log("Pump process " pumpPid " confirmed dead (" (A_TickCount - deadStart) "ms)")
         else
-            Log("Pump process " pumpPid " confirmed dead")
+            Log("WARNING: Pump process " pumpPid " still alive after 2s!")
 
         newPumpPid := 0
         killRestartStart := A_TickCount

--- a/tests/test_live_watcher.ahk
+++ b/tests/test_live_watcher.ahk
@@ -117,8 +117,13 @@ RunLiveTests_Watcher() {
     settleReady := false
     while ((A_TickCount - settleStart) < 8000) {
         if (FileExist(storeLogPath)) {
-            settleReady := true
-            break
+            try {
+                content := FileRead(storeLogPath)
+                if (StrLen(content) > 0) {
+                    settleReady := true
+                    break
+                }
+            }
         }
         Sleep(100)
     }

--- a/tests/test_utils.ahk
+++ b/tests/test_utils.ahk
@@ -197,31 +197,52 @@ _RepeatStr(str, count) {
 
 ; Kill all running AltTabby.exe processes (blanket — use scoped variants for parallel safety)
 _Test_KillAllAltTabby() {
+    pids := []
     for _, proc in _Test_EnumProcesses("AltTabby.exe") {
         try ProcessClose(proc.pid)
+        pids.Push(proc.pid)
     }
-    ; Give processes time to fully exit
-    Sleep(200)
+    deadline := A_TickCount + 2000
+    for _, pid in pids {
+        while (ProcessExist(pid) && (A_TickCount < deadline))
+            Sleep(20)
+    }
+    Sleep(50)  ; handle release grace
 }
 
 ; Kill AltTabby processes whose exe path starts with dirPath (worktree-safe)
 _Test_KillAltTabbyInDir(dirPath) {
+    pids := []
     for _, proc in _Test_EnumProcesses("AltTabby.exe") {
         try {
             procPath := ProcessGetPath(proc.pid)
-            if (InStr(procPath, dirPath) = 1)
+            if (InStr(procPath, dirPath) = 1) {
                 ProcessClose(proc.pid)
+                pids.Push(proc.pid)
+            }
         }
     }
-    Sleep(200)
+    deadline := A_TickCount + 2000
+    for _, pid in pids {
+        while (ProcessExist(pid) && (A_TickCount < deadline))
+            Sleep(20)
+    }
+    Sleep(50)  ; handle release grace
 }
 
 ; Kill all processes matching a custom exe name (e.g. "AltTabby_exectest.exe")
 _Test_KillProcessesByName(exeName) {
+    pids := []
     for _, proc in _Test_EnumProcesses(exeName) {
         try ProcessClose(proc.pid)
+        pids.Push(proc.pid)
     }
-    Sleep(200)
+    deadline := A_TickCount + 2000
+    for _, pid in pids {
+        while (ProcessExist(pid) && (A_TickCount < deadline))
+            Sleep(20)
+    }
+    Sleep(50)  ; handle release grace
 }
 
 ; --- Process Enumeration via CreateToolhelp32Snapshot ---


### PR DESCRIPTION
## Summary

- **test_utils.ahk (P0)**: 3 shared `ProcessClose` helpers (`_Test_KillAllAltTabby`, `_Test_KillAltTabbyInDir`, `_Test_KillProcessesByName`) now collect PIDs and poll `ProcessExist` with 2s timeout instead of `Sleep(200)`. Every live test uses these.
- **test_live_watcher.ahk (P1)**: GUI readiness poll checks for non-empty store log content, not just `FileExist` — prevents stale file from prior run false-positiving.
- **test_live_pump.ahk (P1)**: Pump kill verification polls `ProcessExist` with 2s timeout instead of `Sleep(100)` + warn-only check.
- **test_unit_file_watcher.ahk (P2/P3)**: Debounce coalescence polls for callback count instead of `Sleep(600)`. Negative assertion tests use poll loops (500ms) with early exit on unexpected callback.

Closes #141

## Test plan

- [x] `.\tests\test.ps1 --live --timing` — all 633 tests pass
- [x] Unit/FileWatcher timing unchanged (~5.9s, no regression from negative assertion polls)
- [ ] 5 consecutive `--live --timing` runs, all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)