### PR TITLE
Add path-tracing query tools and /trace skill

### DIFF
--- a/.claude/skills/trace/SKILL.md
+++ b/.claude/skills/trace/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: trace
+description: Spawn agent to trace code flow via query tools — answer only, no context cost
+user-invocable: true
+disable-model-invocation: false
+context: fork
+agent: Explore
+argument-hint: "<question about code flow>"
+---
+Trace the following code flow through the Alt-Tabby codebase:
+"$ARGUMENTS"
+
+## Available Query Tools
+
+Run via `powershell -File tools/<name>`. These are the primary research tools — always prefer them over reading files directly.
+
+### CALL CHAIN (primary tool for tracing)
+```
+query_callchain.ps1 <funcName> [-Depth N] [-Reverse]
+```
+Forward: shows what `<funcName>` calls, to N levels deep (default 2).
+Reverse: shows what calls `<funcName>`, to N levels up.
+Example: `powershell -File tools/query_callchain.ps1 GUI_Repaint -Depth 3`
+
+### FUNCTION BODY
+```
+query_function.ps1 <funcName>
+```
+Extracts full function body with line numbers. Use when you need to understand WHAT a function does, not just what it calls.
+Example: `powershell -File tools/query_function.ps1 GUI_TransitionTo`
+
+### GLOBAL OWNERSHIP
+```
+query_global_ownership.ps1 <globalName>
+```
+Shows who declares, writes (with mutation count), and reads a global.
+Example: `powershell -File tools/query_global_ownership.ps1 gGUI_State`
+
+### GLOBAL MUTATIONS (detailed)
+```
+query_mutations.ps1 <globalName> [-Brief]
+```
+Shows every function that mutates a global, with guards (Critical sections, if-conditions) and literal values assigned. More detailed than ownership.
+Example: `powershell -File tools/query_mutations.ps1 gGUI_State`
+
+### IMPACT / BLAST RADIUS
+```
+query_impact.ps1 <funcName> [-Deep]
+```
+Shows callers, globals written, downstream readers of those globals.
+`-Deep` adds transitive callers (callers of callers).
+Example: `powershell -File tools/query_impact.ps1 GUI_Repaint -Deep`
+
+### FILE INTERFACE
+```
+query_interface.ps1 <filename>
+```
+Public functions + globals for a file (like `help(module)`). Accepts filename with or without `.ahk` extension.
+Example: `powershell -File tools/query_interface.ps1 gui_paint`
+
+### INCLUDE CHAIN
+```
+query_includes.ps1 [filename]
+```
+No args: full include tree from entry points.
+With filename: who includes this file, what it includes, transitive entry points.
+Example: `powershell -File tools/query_includes.ps1 gui_state.ahk`
+
+### FUNCTION VISIBILITY
+```
+query_function_visibility.ps1 <funcName>
+```
+Where defined, public/private, all callers across all files.
+Example: `powershell -File tools/query_function_visibility.ps1 _GUI_FreezeDisplayList`
+
+### CONFIG
+```
+query_config.ps1 [keyword | -Section <name> | -Usage <propertyName>]
+```
+No args: section/group index. Keyword: fuzzy search. `-Usage`: which files read `cfg.X`.
+Example: `powershell -File tools/query_config.ps1 -Usage ThemeMode`
+
+### IPC MESSAGES
+```
+query_ipc.ps1 [message]
+```
+No args: list all `IPC_MSG_*` constants. With message: who sends/handles it.
+Example: `powershell -File tools/query_ipc.ps1 snapshot`
+
+### STATE MACHINE
+```
+query_state.ps1 [state] [event]
+```
+No args: index of all states/events. With args: specific dispatch branch.
+Hardcoded to `GUI_OnInterceptorEvent` in `gui_state.ahk`.
+Example: `powershell -File tools/query_state.ps1 ACTIVE TAB_STEP`
+
+### TIMERS
+```
+query_timers.ps1 [keyword]
+```
+No args: full SetTimer inventory. With keyword: fuzzy filter.
+Example: `powershell -File tools/query_timers.ps1 heartbeat`
+
+### WINDOWS MESSAGES
+```
+query_messages.ps1 [query]
+```
+No args: list all `WM_` handlers. With query: hex, `WM_` name, or handler function.
+Example: `powershell -File tools/query_messages.ps1 WM_CTLCOLORSTATIC`
+
+## Research Instructions
+
+1. **ALWAYS prefer query tools over reading files directly** — they return semantic answers and cost far less context
+2. **Start with `query_callchain.ps1`** as the primary tracing tool
+3. Use `query_function.ps1` ONLY when call chain output doesn't explain what a step does
+4. Use `query_global_ownership.ps1` or `query_mutations.ps1` when the question involves data flow through globals
+5. Use `query_impact.ps1` when the question is about what a change would affect
+6. Use `query_interface.ps1` to understand a module's API surface before diving into specifics
+
+## Response Format
+
+Return ONLY a synthesized answer in this exact format:
+
+## Summary
+One sentence: what the flow does end-to-end.
+
+## Path
+1. FunctionName (file.ahk:line) — what this step does
+2. FunctionName (file.ahk:line) — what this step does
+...
+
+## Key State
+- globalName (owner: file) — role in this flow
+- globalName (owner: file) — role in this flow
+
+Maximum 30 lines total. No raw tool output. No reasoning about your research process.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,11 @@ Query tools live in `tools/`. Prefer these over reading full files or grepping:
 - `query_function.ps1 <funcName>` — extract full function body without loading the entire file
 - `query_interface.ps1 <filename>` — public functions + globals for a file (like help(module))
 - `query_config.ps1` — no args: shows section/group index. With keyword: fuzzy search. `-Section <name>`: list section. `-Usage <key>`: which files consume a config value
-- `query_ipc.ps1 <msgType>` — who sends/handles an IPC message (or no args: list all types)
-- `query_timers.ps1` — SetTimer inventory grouped by file (or with keyword: fuzzy search by callback/file)
+- `query_callchain.ps1 <funcName>` — call graph from a function: what it calls (or `-Reverse` for callers), to `-Depth N` levels. Primary tool for tracing code paths
+
+Additional domain-specific query tools (ipc, timers, impact, mutations, includes, messages, state) exist in `tools/` — run `ls tools/query_*.ps1` to discover when needed.
+
+For deep multi-module flow tracing, use `/trace <question>` — spawns an agent in separate context that uses all query tools and returns only the semantic answer.
 
 These return semantic answers, not raw text. The work runs in PowerShell — only the answer enters context.
 

--- a/tests/check_skill_frontmatter.ps1
+++ b/tests/check_skill_frontmatter.ps1
@@ -29,6 +29,7 @@ $sw = [System.Diagnostics.Stopwatch]::StartNew()
 $AutoDiscoverWhitelist = @(
     "explain"
     "investigate"
+    "trace"
 )
 
 # === Resolve skills directory ===

--- a/tools/query_callchain.ps1
+++ b/tools/query_callchain.ps1
@@ -1,0 +1,328 @@
+# query_callchain.ps1 - Call graph traversal from a function
+#
+# Shows what a function calls (forward) or what calls it (reverse),
+# to a configurable depth. Replaces the pattern of chaining 4-6
+# query_function.ps1 calls to manually trace a code path.
+#
+# Detects both direct calls and indirect references:
+#   FuncName()              Direct call
+#   SetTimer(FuncName, ...) Timer callback
+#   OnMessage(0x..., Fn)    Message handler
+#   OnEvent("...", Fn)      Event handler
+#   .OnEvent("...", Fn)     GUI event handler
+#
+# Usage:
+#   powershell -File tools/query_callchain.ps1 <funcName>
+#   powershell -File tools/query_callchain.ps1 GUI_Repaint -Depth 3
+#   powershell -File tools/query_callchain.ps1 GUI_Repaint -Reverse
+#   powershell -File tools/query_callchain.ps1 GUI_Repaint -Reverse -Depth 1
+
+param(
+    [Parameter(Position=0)][string]$FuncName,
+    [int]$Depth = 2,
+    [switch]$Reverse,
+    [string]$SourceDir
+)
+
+$ErrorActionPreference = 'Stop'
+$totalSw = [System.Diagnostics.Stopwatch]::StartNew()
+
+. "$PSScriptRoot\_query_helpers.ps1"
+
+if (-not $FuncName) {
+    Write-Host "  Usage: query_callchain.ps1 <funcName> [-Depth N] [-Reverse]" -ForegroundColor Yellow
+    Write-Host "  Examples:" -ForegroundColor DarkGray
+    Write-Host "    query_callchain.ps1 GUI_Repaint              Forward calls (depth 2)" -ForegroundColor DarkGray
+    Write-Host "    query_callchain.ps1 GUI_Repaint -Depth 3     Forward calls (depth 3)" -ForegroundColor DarkGray
+    Write-Host "    query_callchain.ps1 GUI_Repaint -Reverse     Who calls this function" -ForegroundColor DarkGray
+    exit 1
+}
+
+# === Resolve paths ===
+if (-not $SourceDir) {
+    $SourceDir = (Resolve-Path "$PSScriptRoot\..\src").Path
+}
+if (-not (Test-Path $SourceDir)) {
+    Write-Host "  ERROR: Source directory not found: $SourceDir" -ForegroundColor Red
+    exit 1
+}
+$projectRoot = (Resolve-Path "$SourceDir\..").Path
+
+# === Collect source files (exclude lib/) ===
+$srcFiles = Get-AhkSourceFiles $SourceDir
+
+# ============================================================
+# Pass 1: Build function registry
+# ============================================================
+$pass1Sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+# funcRegistry: lowercase name -> @{ Name; File; RelPath; Line }
+$funcRegistry = @{}
+# fileCache: filePath -> string[] (lazy-split lines)
+$fileCache = @{}
+
+foreach ($file in $srcFiles) {
+    $text = [System.IO.File]::ReadAllText($file.FullName)
+    $lines = Split-Lines $text
+    $fileCache[$file.FullName] = $lines
+    $relPath = $file.FullName.Replace("$projectRoot\", '')
+
+    $depth = 0
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $cleaned = Clean-Line $lines[$i]
+        if ($cleaned -eq '') { continue }
+
+        # Function definition at file scope (depth 0)
+        if ($depth -eq 0) {
+            $m = $script:_rxFuncDef.Match($cleaned)
+            if ($m.Success) {
+                $fname = $m.Groups[1].Value
+                $fkey = $fname.ToLower()
+                if (-not $AHK_KEYWORDS_SET.Contains($fkey) -and $cleaned.Contains('{')) {
+                    if (-not $funcRegistry.ContainsKey($fkey)) {
+                        $funcRegistry[$fkey] = @{
+                            Name    = $fname
+                            File    = $file.FullName
+                            RelPath = $relPath
+                            Line    = ($i + 1)
+                        }
+                    }
+                }
+            }
+        }
+
+        $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
+        if ($depth -lt 0) { $depth = 0 }
+    }
+}
+
+# Build lookup set for fast matching
+$funcNameSet = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+foreach ($key in $funcRegistry.Keys) {
+    [void]$funcNameSet.Add($key)
+}
+
+$pass1Sw.Stop()
+
+# Check root function exists
+$rootKey = $FuncName.ToLower()
+if (-not $funcRegistry.ContainsKey($rootKey)) {
+    Write-Host "  Function not found: $FuncName" -ForegroundColor Red
+
+    # Suggest close matches
+    $suggestions = @()
+    foreach ($key in $funcRegistry.Keys) {
+        if ($key.Contains($rootKey) -or $rootKey.Contains($key)) {
+            $suggestions += $funcRegistry[$key].Name
+        }
+    }
+    if ($suggestions.Count -gt 0 -and $suggestions.Count -le 10) {
+        Write-Host "  Did you mean:" -ForegroundColor Yellow
+        foreach ($s in ($suggestions | Sort-Object)) {
+            Write-Host "    $s" -ForegroundColor DarkGray
+        }
+    }
+    exit 1
+}
+
+# ============================================================
+# Pass 2: Build call graph (adjacency list)
+# ============================================================
+$pass2Sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+# callGraph: lowercase caller -> ArrayList of lowercase callee names
+$callGraph = @{}
+
+# Reference pattern: function name followed by ( — catches direct calls
+$rxCallRef = [regex]::new('(?<![.\w])([a-zA-Z_]\w+)(?=\s*\()', 'Compiled')
+# Callback patterns: function names passed as references (no trailing parenthesis)
+# SetTimer(FuncRef, ...), OnMessage(msg, FuncRef), .OnEvent("ev", FuncRef)
+$hasCallbackKeyword = $false
+
+foreach ($file in $srcFiles) {
+    $lines = $fileCache[$file.FullName]
+
+    $depth = 0
+    $inFunc = $false
+    $funcDepth = -1
+    $curFuncKey = ""
+    $seen = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $cleaned = Clean-Line $lines[$i]
+        if ($cleaned -eq '') { continue }
+
+        # Track function boundaries
+        if (-not $inFunc -and $depth -eq 0) {
+            $m = $script:_rxFuncDef.Match($cleaned)
+            if ($m.Success) {
+                $fname = $m.Groups[1].Value
+                $fkey = $fname.ToLower()
+                if (-not $AHK_KEYWORDS_SET.Contains($fkey) -and $cleaned.Contains('{')) {
+                    $inFunc = $true
+                    $funcDepth = $depth
+                    $curFuncKey = $fkey
+                    $seen.Clear()
+
+                    if (-not $callGraph.ContainsKey($curFuncKey)) {
+                        $callGraph[$curFuncKey] = [System.Collections.ArrayList]::new()
+                    }
+                }
+            }
+        }
+
+        $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
+        if ($depth -lt 0) { $depth = 0 }
+
+        if ($inFunc -and $depth -le $funcDepth) {
+            $inFunc = $false
+            $funcDepth = -1
+        }
+
+        # Only scan inside function bodies
+        if (-not $inFunc) { continue }
+
+        # Find direct calls: FuncName(
+        $callMatches = $rxCallRef.Matches($cleaned)
+        foreach ($cm in $callMatches) {
+            $calledName = $cm.Groups[1].Value
+            $calledKey = $calledName.ToLower()
+
+            # Skip self, keywords, builtins, unknown functions
+            if ($calledKey -eq $curFuncKey) { continue }
+            if ($AHK_KEYWORDS_SET.Contains($calledKey)) { continue }
+            if ($AHK_BUILTINS_SET.Contains($calledKey)) { continue }
+            if (-not $funcNameSet.Contains($calledKey)) { continue }
+            if ($seen.Contains($calledKey)) { continue }
+
+            [void]$seen.Add($calledKey)
+            [void]$callGraph[$curFuncKey].Add($calledKey)
+        }
+
+        # Callback references: on lines with SetTimer/OnMessage/OnEvent, also
+        # match word tokens that are known functions without trailing (
+        # This catches function refs like SetTimer(MyFunc, 1000) and OnMessage(0x312, _Handler)
+        $hasCallbackKeyword = $cleaned.Contains('SetTimer') -or $cleaned.Contains('OnMessage') -or $cleaned.Contains('OnEvent')
+        if ($hasCallbackKeyword) {
+            $wordMatches = $script:_rxWord.Matches($cleaned)
+            foreach ($wm in $wordMatches) {
+                $calledKey = $wm.Value.ToLower()
+                if ($calledKey -eq $curFuncKey) { continue }
+                if ($AHK_KEYWORDS_SET.Contains($calledKey)) { continue }
+                if (-not $funcNameSet.Contains($calledKey)) { continue }
+                if ($seen.Contains($calledKey)) { continue }
+                [void]$seen.Add($calledKey)
+                [void]$callGraph[$curFuncKey].Add($calledKey)
+            }
+        }
+    }
+}
+
+$pass2Sw.Stop()
+
+# Build reverse graph if needed
+$reverseGraph = @{}
+if ($Reverse) {
+    foreach ($callerKey in $callGraph.Keys) {
+        foreach ($calleeKey in $callGraph[$callerKey]) {
+            if (-not $reverseGraph.ContainsKey($calleeKey)) {
+                $reverseGraph[$calleeKey] = [System.Collections.ArrayList]::new()
+            }
+            if (-not $reverseGraph[$calleeKey].Contains($callerKey)) {
+                [void]$reverseGraph[$calleeKey].Add($callerKey)
+            }
+        }
+    }
+}
+
+# ============================================================
+# Pass 3: BFS traversal from root
+# ============================================================
+$graph = if ($Reverse) { $reverseGraph } else { $callGraph }
+$rootDef = $funcRegistry[$rootKey]
+
+# BFS with depth tracking
+$visited = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+[void]$visited.Add($rootKey)
+
+# Tree structure: list of @{ Key; Depth; IsAlreadyShown }
+$treeNodes = [System.Collections.ArrayList]::new()
+
+# Queue: @{ Key; Depth }
+$queue = [System.Collections.Queue]::new()
+
+# Seed with root's children
+if ($graph.ContainsKey($rootKey)) {
+    foreach ($childKey in ($graph[$rootKey] | Sort-Object)) {
+        $queue.Enqueue(@{ Key = $childKey; Depth = 0 })
+    }
+}
+
+$uniqueCount = 0
+$maxDepthReached = 0
+
+while ($queue.Count -gt 0) {
+    $item = $queue.Dequeue()
+    $key = $item.Key
+    $d = $item.Depth
+
+    if ($visited.Contains($key)) {
+        [void]$treeNodes.Add(@{ Key = $key; Depth = $d; IsAlreadyShown = $true })
+        continue
+    }
+
+    [void]$visited.Add($key)
+    $uniqueCount++
+    if ($d -gt $maxDepthReached) { $maxDepthReached = $d }
+    [void]$treeNodes.Add(@{ Key = $key; Depth = $d; IsAlreadyShown = $false })
+
+    # Enqueue children if not at max depth
+    if ($d -lt $Depth -and $graph.ContainsKey($key)) {
+        foreach ($childKey in ($graph[$key] | Sort-Object)) {
+            $queue.Enqueue(@{ Key = $childKey; Depth = ($d + 1) })
+        }
+    }
+}
+
+$totalSw.Stop()
+
+# ============================================================
+# Output
+# ============================================================
+Write-Host ""
+Write-Host "  $($rootDef.Name)  ($($rootDef.RelPath):$($rootDef.Line))" -ForegroundColor White
+$dirLabel = if ($Reverse) { "called by" } else { "calls" }
+Write-Host "    ${dirLabel}:" -ForegroundColor DarkGray
+
+if ($treeNodes.Count -eq 0) {
+    $noResultMsg = if ($Reverse) { "(no callers found)" } else { "(no calls to project functions)" }
+    Write-Host "      $noResultMsg" -ForegroundColor DarkGray
+} else {
+    foreach ($node in $treeNodes) {
+        $indent = "      " + ("  " * $node.Depth)
+        $def = $funcRegistry[$node.Key]
+        $name = $def.Name
+        $loc = "$($def.RelPath):$($def.Line)"
+
+        if ($node.IsAlreadyShown) {
+            $label = if ($node.Key -eq $rootKey) { "(recursive)" } else { "(already shown)" }
+            Write-Host "${indent}${name}" -ForegroundColor DarkGray -NoNewline
+            Write-Host "  $label" -ForegroundColor DarkGray
+        } else {
+            # Pad name to align locations
+            $padded = $name.PadRight(28)
+            Write-Host "${indent}${padded}" -ForegroundColor White -NoNewline
+            Write-Host " $loc" -ForegroundColor Cyan
+        }
+    }
+}
+
+Write-Host ""
+$depthLabel = $maxDepthReached + 1
+Write-Host "  $depthLabel level(s), $uniqueCount unique function(s)" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "  Completed in $($totalSw.ElapsedMilliseconds)ms (pass1: $($pass1Sw.ElapsedMilliseconds)ms, pass2: $($pass2Sw.ElapsedMilliseconds)ms)" -ForegroundColor Cyan

--- a/tools/query_impact.ps1
+++ b/tools/query_impact.ps1
@@ -1,0 +1,508 @@
+# query_impact.ps1 - Blast radius analysis for a function
+#
+# Shows everything that could be affected by changing a function:
+# callers, globals it writes, who reads those globals, and optionally
+# transitive callers. Combines what would require chaining
+# query_function_visibility + query_global_ownership.
+#
+# Usage:
+#   powershell -File tools/query_impact.ps1 <funcName>
+#   powershell -File tools/query_impact.ps1 GUI_Repaint -Deep
+
+param(
+    [Parameter(Position=0)][string]$FuncName,
+    [switch]$Deep,
+    [string]$SourceDir
+)
+
+$ErrorActionPreference = 'Stop'
+$totalSw = [System.Diagnostics.Stopwatch]::StartNew()
+
+. "$PSScriptRoot\_query_helpers.ps1"
+
+if (-not $FuncName) {
+    Write-Host "  Usage: query_impact.ps1 <funcName> [-Deep]" -ForegroundColor Yellow
+    Write-Host "  Examples:" -ForegroundColor DarkGray
+    Write-Host "    query_impact.ps1 GUI_Repaint          Callers + globals written + readers" -ForegroundColor DarkGray
+    Write-Host "    query_impact.ps1 GUI_Repaint -Deep    Also show transitive callers" -ForegroundColor DarkGray
+    exit 1
+}
+
+# === Resolve paths ===
+if (-not $SourceDir) {
+    $SourceDir = (Resolve-Path "$PSScriptRoot\..\src").Path
+}
+if (-not (Test-Path $SourceDir)) {
+    Write-Host "  ERROR: Source directory not found: $SourceDir" -ForegroundColor Red
+    exit 1
+}
+$projectRoot = (Resolve-Path "$SourceDir\..").Path
+
+# === Collect source files (exclude lib/) ===
+$srcFiles = Get-AhkSourceFiles $SourceDir
+
+# ============================================================
+# Step 1: Locate function definition + extract body
+# ============================================================
+$funcDef = $null
+$funcBody = @()
+$funcBodyStartIdx = -1
+$funcFile = $null
+
+# Also build function registry + file-scope globals for later steps
+$funcRegistry = @{}
+$globalDecl = @{}
+$fileCache = @{}
+
+$MUTATING_METHODS = 'Push|Pop|Delete|InsertAt|RemoveAt|Set|Clear'
+
+foreach ($file in $srcFiles) {
+    $text = [System.IO.File]::ReadAllText($file.FullName)
+    $lines = Split-Lines $text
+    $fileCache[$file.FullName] = $lines
+    $relPath = $file.FullName.Replace("$projectRoot\", '')
+
+    $depth = 0
+    $inFunc = $false
+    $funcDepth = -1
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $cleaned = Clean-Line $lines[$i]
+        if ($cleaned -eq '') { continue }
+
+        # Collect file-scope globals
+        if (-not $inFunc -and $cleaned -match '^\s*global\s+(.+)') {
+            $declPart = $Matches[1]
+            $stripped = Strip-Nested $declPart
+            foreach ($part in $stripped -split ',') {
+                $trimmed = $part.Trim()
+                if ($trimmed -match '^(\w+)') {
+                    $gName = $Matches[1]
+                    if ($gName.Length -ge 2 -and -not $AHK_BUILTINS_SET.Contains($gName)) {
+                        if (-not $globalDecl.ContainsKey($gName)) {
+                            $globalDecl[$gName] = @{
+                                File    = $file.FullName
+                                RelPath = $relPath
+                                Line    = ($i + 1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        # Function definition at file scope
+        if (-not $inFunc) {
+            $m = $script:_rxFuncDef.Match($cleaned)
+            if ($m.Success) {
+                $fname = $m.Groups[1].Value
+                $fkey = $fname.ToLower()
+                if (-not $AHK_KEYWORDS_SET.Contains($fkey) -and $cleaned.Contains('{')) {
+                    $inFunc = $true
+                    $funcDepth = $depth
+
+                    if (-not $funcRegistry.ContainsKey($fkey)) {
+                        $funcRegistry[$fkey] = @{
+                            Name    = $fname
+                            File    = $file.FullName
+                            RelPath = $relPath
+                            Line    = ($i + 1)
+                        }
+                    }
+
+                    # If this is our target function, start capturing body
+                    if ($fkey -eq $FuncName.ToLower() -and -not $funcDef) {
+                        $funcDef = $funcRegistry[$fkey]
+                        $funcFile = $file.FullName
+                        $funcBodyStartIdx = $i
+                    }
+                }
+            }
+        }
+
+        $braceOpen = $cleaned.Length - $cleaned.Replace('{','').Length
+        $braceClose = $cleaned.Length - $cleaned.Replace('}','').Length
+        $depth += $braceOpen - $braceClose
+        if ($depth -lt 0) { $depth = 0 }
+
+        # Capture function body lines
+        if ($funcBodyStartIdx -ge 0 -and $i -ge $funcBodyStartIdx -and $funcBody.Count -eq 0) {
+            # We're inside the target function — keep going until depth drops
+        }
+
+        if ($inFunc -and $depth -le $funcDepth) {
+            # If this was our target function, capture body
+            if ($funcBodyStartIdx -ge 0 -and $funcBody.Count -eq 0 -and $file.FullName -eq $funcFile) {
+                for ($bi = $funcBodyStartIdx; $bi -le $i; $bi++) {
+                    $funcBody += $lines[$bi]
+                }
+            }
+            $inFunc = $false
+            $funcDepth = -1
+        }
+    }
+
+    # Handle EOF without closing brace for target function
+    if ($funcBodyStartIdx -ge 0 -and $funcBody.Count -eq 0 -and $file.FullName -eq $funcFile) {
+        for ($bi = $funcBodyStartIdx; $bi -lt $lines.Count; $bi++) {
+            $funcBody += $lines[$bi]
+        }
+    }
+}
+
+if (-not $funcDef) {
+    Write-Host "  Function not found: $FuncName" -ForegroundColor Red
+    # Suggest close matches
+    $suggestions = @()
+    $searchKey = $FuncName.ToLower()
+    foreach ($key in $funcRegistry.Keys) {
+        if ($key.Contains($searchKey) -or $searchKey.Contains($key)) {
+            $suggestions += $funcRegistry[$key].Name
+        }
+    }
+    if ($suggestions.Count -gt 0 -and $suggestions.Count -le 10) {
+        Write-Host "  Did you mean:" -ForegroundColor Yellow
+        foreach ($s in ($suggestions | Sort-Object)) {
+            Write-Host "    $s" -ForegroundColor DarkGray
+        }
+    }
+    exit 1
+}
+
+# Build lookup sets
+$funcNameSet = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+foreach ($key in $funcRegistry.Keys) { [void]$funcNameSet.Add($key) }
+
+$globalSet = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+foreach ($name in $globalDecl.Keys) { [void]$globalSet.Add($name) }
+
+# ============================================================
+# Step 2: Find direct callers
+# ============================================================
+$callers = [System.Collections.ArrayList]::new()
+$escaped = [regex]::Escape($funcDef.Name)
+$rxRef = [regex]::new("(?<![.\w])$escaped(?=\s*[\(,\)\s\.\[]|`$)", 'Compiled, IgnoreCase')
+
+foreach ($file in $srcFiles) {
+    $text = [System.IO.File]::ReadAllText($file.FullName)
+    if ($text.IndexOf($funcDef.Name, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
+
+    $lines = $fileCache[$file.FullName]
+    $relPath = $file.FullName.Replace("$projectRoot\", '')
+    $bounds = Build-FuncBoundaryMap $lines
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        # Skip the definition line itself
+        if ($file.FullName -eq $funcDef.File -and ($i + 1) -eq $funcDef.Line) { continue }
+
+        $cleaned = Clean-Line $lines[$i]
+        if ($cleaned -eq '') { continue }
+
+        if ($rxRef.IsMatch($cleaned)) {
+            $enclosing = Find-EnclosingFunction $bounds $i
+            [void]$callers.Add(@{
+                RelPath = $relPath
+                Line    = ($i + 1)
+                Func    = $enclosing
+            })
+        }
+    }
+}
+
+# ============================================================
+# Step 3: Find globals written by this function
+# ============================================================
+$globalsWritten = [System.Collections.ArrayList]::new()
+$globalsWrittenSet = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+
+# First find which globals are declared in this function's scope
+$funcGlobalDecls = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+foreach ($bodyLine in $funcBody) {
+    $cleaned = Clean-Line $bodyLine
+    if ($cleaned -match '^\s*global\s+(.+)') {
+        $declPart = $Matches[1]
+        $stripped = Strip-Nested $declPart
+        foreach ($part in $stripped -split ',') {
+            $trimmed = $part.Trim()
+            if ($trimmed -match '^(\w+)') {
+                $gName = $Matches[1]
+                if ($globalSet.Contains($gName)) {
+                    [void]$funcGlobalDecls.Add($gName)
+                }
+            }
+        }
+    }
+}
+
+# Now scan for mutations of those globals
+foreach ($gName in $funcGlobalDecls) {
+    $e = [regex]::Escape($gName)
+    $mutPatterns = @(
+        [regex]::new("(?<![.\w])$e\s*[:+\-\*\/\.]+\="),
+        [regex]::new("(?<![.\w])$e\s*(\+\+|--)"),
+        [regex]::new("(?<![.\w])$e\[.+?\]\s*[:+\-\*\/\.]+\="),
+        [regex]::new("\b$e\.($MUTATING_METHODS)\s*\("),
+        [regex]::new("\b$e\.\w+\s*[:+\-\*\/\.]+\=")
+    )
+
+    foreach ($bodyLine in $funcBody) {
+        $cleaned = Clean-Line $bodyLine
+        if ($cleaned -eq '') { continue }
+
+        $isMutation = $mutPatterns[0].IsMatch($cleaned) -or
+                      $mutPatterns[1].IsMatch($cleaned) -or
+                      $mutPatterns[2].IsMatch($cleaned) -or
+                      $mutPatterns[3].IsMatch($cleaned) -or
+                      $mutPatterns[4].IsMatch($cleaned)
+
+        if ($isMutation -and -not $globalsWrittenSet.Contains($gName)) {
+            [void]$globalsWrittenSet.Add($gName)
+            [void]$globalsWritten.Add(@{
+                Name    = $gName
+                Decl    = $globalDecl[$gName]
+            })
+            break  # found at least one mutation, move to next global
+        }
+    }
+}
+
+# ============================================================
+# Step 4: Find downstream readers of written globals
+# ============================================================
+$downstreamReaders = @{}  # globalName -> ArrayList of @{ RelPath; Func }
+
+foreach ($gw in $globalsWritten) {
+    $gName = $gw.Name
+    $readers = [System.Collections.ArrayList]::new()
+    $seenReaders = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($file in $srcFiles) {
+        $text = [System.IO.File]::ReadAllText($file.FullName)
+        if ($text.IndexOf($gName, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
+
+        $lines = $fileCache[$file.FullName]
+        $relPath = $file.FullName.Replace("$projectRoot\", '')
+        $bounds = Build-FuncBoundaryMap $lines
+
+        # Check if any function in this file declares global <gName>
+        $inFunc = $false
+        $funcDepth = -1
+        $curFunc = ""
+        $curFuncDeclaresGlobal = $false
+        $depth = 0
+
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            $cleaned = Clean-Line $lines[$i]
+            if ($cleaned -eq '') { continue }
+
+            if (-not $inFunc) {
+                $fm = $script:_rxFuncDef.Match($cleaned)
+                if ($fm.Success) {
+                    $fn = $fm.Groups[1].Value
+                    if (-not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
+                        $inFunc = $true
+                        $funcDepth = $depth
+                        $curFunc = $fn
+                        $curFuncDeclaresGlobal = $false
+                    }
+                }
+            }
+
+            $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
+            if ($depth -lt 0) { $depth = 0 }
+
+            if ($inFunc -and $depth -le $funcDepth) {
+                $inFunc = $false
+                $funcDepth = -1
+            }
+
+            if (-not $inFunc) { continue }
+
+            # Check for global declaration inside function
+            if ($cleaned -match '^\s*global\s+' -and $cleaned -match "(?<!\w)$([regex]::Escape($gName))(?!\w)") {
+                $curFuncDeclaresGlobal = $true
+            }
+
+            # Check for read reference (non-mutation, non-declaration line)
+            if ($curFuncDeclaresGlobal -and $cleaned -match "(?<![.\w])$([regex]::Escape($gName))(?!\w)") {
+                $isGlobalDeclLine = $cleaned -match '^\s*global\s+'
+                if (-not $isGlobalDeclLine) {
+                    $readerKey = "${relPath}:${curFunc}"
+                    if (-not $seenReaders.Contains($readerKey)) {
+                        [void]$seenReaders.Add($readerKey)
+                        [void]$readers.Add(@{
+                            RelPath = $relPath
+                            Func    = $curFunc
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    if ($readers.Count -gt 0) {
+        $downstreamReaders[$gName] = $readers
+    }
+}
+
+# ============================================================
+# Step 5 (if -Deep): Transitive callers
+# ============================================================
+$transCallers = [System.Collections.ArrayList]::new()
+
+if ($Deep -and $callers.Count -gt 0) {
+    # For each direct caller, find THEIR callers
+    $directCallerFuncs = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($c in $callers) {
+        if ($c.Func -ne "(file scope)") {
+            [void]$directCallerFuncs.Add($c.Func)
+        }
+    }
+
+    $transCount = 0
+    foreach ($callerFuncName in $directCallerFuncs) {
+        if (-not $funcRegistry.ContainsKey($callerFuncName.ToLower())) { continue }
+        $callerDef = $funcRegistry[$callerFuncName.ToLower()]
+        $escapedCaller = [regex]::Escape($callerDef.Name)
+        $rxCallerRef = [regex]::new("(?<![.\w])$escapedCaller(?=\s*[\(,\)\s\.\[]|`$)", 'IgnoreCase')
+
+        foreach ($file in $srcFiles) {
+            $text = [System.IO.File]::ReadAllText($file.FullName)
+            if ($text.IndexOf($callerDef.Name, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
+
+            $lines = $fileCache[$file.FullName]
+            $relPath = $file.FullName.Replace("$projectRoot\", '')
+            $bounds = Build-FuncBoundaryMap $lines
+
+            for ($i = 0; $i -lt $lines.Count; $i++) {
+                if ($file.FullName -eq $callerDef.File -and ($i + 1) -eq $callerDef.Line) { continue }
+
+                $cleaned = Clean-Line $lines[$i]
+                if ($cleaned -eq '') { continue }
+
+                if ($rxCallerRef.IsMatch($cleaned)) {
+                    $enclosing = Find-EnclosingFunction $bounds $i
+                    [void]$transCallers.Add(@{
+                        DirectCaller  = $callerDef.Name
+                        DirectCallerRel = $callerDef.RelPath
+                        TransCaller   = $enclosing
+                        TransCallerRel = $relPath
+                        Line          = ($i + 1)
+                    })
+                    $transCount++
+                    if ($transCount -ge 20) { break }
+                }
+            }
+            if ($transCount -ge 20) { break }
+        }
+        if ($transCount -ge 20) { break }
+    }
+}
+
+$totalSw.Stop()
+
+# ============================================================
+# Output
+# ============================================================
+Write-Host ""
+Write-Host "  $($funcDef.Name)  ($($funcDef.RelPath):$($funcDef.Line))" -ForegroundColor White
+
+# Callers
+Write-Host ""
+if ($callers.Count -gt 0) {
+    Write-Host "  callers ($($callers.Count)):" -ForegroundColor Green
+    # Group by file
+    $callersByFile = @{}
+    foreach ($c in $callers) {
+        if (-not $callersByFile.ContainsKey($c.RelPath)) {
+            $callersByFile[$c.RelPath] = [System.Collections.ArrayList]::new()
+        }
+        [void]$callersByFile[$c.RelPath].Add($c)
+    }
+    foreach ($fileRel in ($callersByFile.Keys | Sort-Object)) {
+        $fileParts = @()
+        foreach ($c in $callersByFile[$fileRel]) {
+            $fileParts += "$($c.Func) :$($c.Line)"
+        }
+        $basename = [System.IO.Path]::GetFileName($fileRel)
+        Write-Host "    $($basename.PadRight(22)) $($fileParts -join ', ')" -ForegroundColor DarkGray
+    }
+} else {
+    Write-Host "  callers: no external callers (possibly entry point or callback)" -ForegroundColor DarkGray
+}
+
+# Globals written
+Write-Host ""
+if ($globalsWritten.Count -gt 0) {
+    Write-Host "  globals written ($($globalsWritten.Count)):" -ForegroundColor Green
+    foreach ($gw in ($globalsWritten | Sort-Object { $_.Name })) {
+        $decl = $gw.Decl
+        Write-Host "    $($gw.Name.PadRight(30)) declared $($decl.RelPath):$($decl.Line)" -ForegroundColor DarkGray
+    }
+} else {
+    Write-Host "  globals written: no global side effects" -ForegroundColor DarkGray
+}
+
+# Downstream readers
+if ($downstreamReaders.Count -gt 0) {
+    Write-Host ""
+    Write-Host "  downstream readers of written globals:" -ForegroundColor Green
+    foreach ($gName in ($downstreamReaders.Keys | Sort-Object)) {
+        $readers = $downstreamReaders[$gName]
+        # Group by file basename
+        $byFile = @{}
+        foreach ($r in $readers) {
+            $basename = [System.IO.Path]::GetFileName($r.RelPath)
+            $base = [System.IO.Path]::GetFileNameWithoutExtension($r.RelPath)
+            if (-not $byFile.ContainsKey($base)) { $byFile[$base] = 0 }
+            $byFile[$base]++
+        }
+        $fileSummary = @()
+        foreach ($base in ($byFile.Keys | Sort-Object)) {
+            $count = $byFile[$base]
+            $fileSummary += "$base ($count fn)"
+        }
+        Write-Host "    $($gName.PadRight(30)) $($fileSummary -join ', ')" -ForegroundColor DarkGray
+    }
+}
+
+# Transitive callers
+if ($Deep -and $transCallers.Count -gt 0) {
+    Write-Host ""
+    Write-Host "  transitive callers (depth 2):" -ForegroundColor Green
+    foreach ($tc in $transCallers) {
+        $tcRel = [System.IO.Path]::GetFileName($tc.TransCallerRel)
+        Write-Host "    $($tc.DirectCaller) <- $($tc.TransCaller) ($tcRel`:$($tc.Line))" -ForegroundColor DarkGray
+    }
+    if ($transCallers.Count -ge 20) {
+        Write-Host "    ... and more (capped at 20)" -ForegroundColor DarkGray
+    }
+}
+
+# Blast radius summary
+$affectedFiles = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+$affectedFuncs = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+
+foreach ($c in $callers) {
+    [void]$affectedFiles.Add($c.RelPath)
+    [void]$affectedFuncs.Add($c.Func)
+}
+foreach ($gName in $downstreamReaders.Keys) {
+    foreach ($r in $downstreamReaders[$gName]) {
+        [void]$affectedFiles.Add($r.RelPath)
+        [void]$affectedFuncs.Add($r.Func)
+    }
+}
+
+Write-Host ""
+Write-Host "  blast radius: $($affectedFiles.Count) file(s), $($affectedFuncs.Count) function(s)" -ForegroundColor White
+Write-Host ""
+Write-Host "  Completed in $($totalSw.ElapsedMilliseconds)ms" -ForegroundColor Cyan

--- a/tools/query_mutations.ps1
+++ b/tools/query_mutations.ps1
@@ -1,0 +1,367 @@
+# query_mutations.ps1 - Detailed global mutation analysis
+#
+# Given a global variable name, shows every function that mutates it,
+# with the conditions/guards around the mutation (Critical sections,
+# if-guards, state checks). This is the "who can change this and when"
+# question that query_global_ownership answers at file level but not
+# at code-path level.
+#
+# Usage:
+#   powershell -File tools/query_mutations.ps1 <globalName>
+#   powershell -File tools/query_mutations.ps1 gGUI_State -Brief
+
+param(
+    [Parameter(Position=0)][string]$GlobalName,
+    [switch]$Brief,
+    [string]$SourceDir
+)
+
+$ErrorActionPreference = 'Stop'
+$totalSw = [System.Diagnostics.Stopwatch]::StartNew()
+
+. "$PSScriptRoot\_query_helpers.ps1"
+
+if (-not $GlobalName) {
+    Write-Host "  Usage: query_mutations.ps1 <globalName> [-Brief]" -ForegroundColor Yellow
+    Write-Host "  Examples:" -ForegroundColor DarkGray
+    Write-Host "    query_mutations.ps1 gGUI_State          Full mutation analysis with guards" -ForegroundColor DarkGray
+    Write-Host "    query_mutations.ps1 gGUI_State -Brief   Compact summary" -ForegroundColor DarkGray
+    exit 1
+}
+
+# === Resolve paths ===
+if (-not $SourceDir) {
+    $SourceDir = (Resolve-Path "$PSScriptRoot\..\src").Path
+}
+if (-not (Test-Path $SourceDir)) {
+    Write-Host "  ERROR: Source directory not found: $SourceDir" -ForegroundColor Red
+    exit 1
+}
+$projectRoot = (Resolve-Path "$SourceDir\..").Path
+
+# === Collect source files (exclude lib/) ===
+$srcFiles = Get-AhkSourceFiles $SourceDir
+
+$MUTATING_METHODS = 'Push|Pop|Delete|InsertAt|RemoveAt|Set|Clear'
+
+# ============================================================
+# Step 1: Find the file-scope global declaration
+# ============================================================
+$declaration = $null
+$fileCache = @{}
+
+foreach ($file in $srcFiles) {
+    $text = [System.IO.File]::ReadAllText($file.FullName)
+    if ($text.IndexOf($GlobalName, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
+
+    $lines = Split-Lines $text
+    $fileCache[$file.FullName] = $lines
+    $relPath = $file.FullName.Replace("$projectRoot\", '')
+
+    $depth = 0
+    $inFunc = $false
+    $funcDepth = -1
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $cleaned = Clean-Line $lines[$i]
+        if ($cleaned -eq '') { continue }
+
+        if (-not $inFunc) {
+            $m = $script:_rxFuncDef.Match($cleaned)
+            if ($m.Success) {
+                $fn = $m.Groups[1].Value
+                if (-not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
+                    $inFunc = $true
+                    $funcDepth = $depth
+                }
+            }
+        }
+
+        $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
+        if ($depth -lt 0) { $depth = 0 }
+
+        if ($inFunc -and $depth -le $funcDepth) {
+            $inFunc = $false
+            $funcDepth = -1
+        }
+
+        # File-scope global declaration
+        if (-not $inFunc -and -not $declaration -and $cleaned -match '^\s*global\s+') {
+            $stripped = Strip-Nested $cleaned
+            if ($stripped -match "(?<!\w)$([regex]::Escape($GlobalName))(?!\w)") {
+                $declaration = @{
+                    File    = $file.FullName
+                    RelPath = $relPath
+                    Line    = ($i + 1)
+                }
+            }
+        }
+    }
+
+    if ($declaration) { break }
+}
+
+if (-not $declaration) {
+    Write-Host "  Unknown global: $GlobalName" -ForegroundColor Red
+    # Suggest close matches
+    $searchKey = $GlobalName.ToLower()
+    $suggestions = @()
+    foreach ($file in $srcFiles) {
+        if (-not $fileCache.ContainsKey($file.FullName)) {
+            $text = [System.IO.File]::ReadAllText($file.FullName)
+            if ($text.IndexOf('global ', [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
+            $fileCache[$file.FullName] = Split-Lines $text
+        }
+        $lines = $fileCache[$file.FullName]
+        foreach ($line in $lines) {
+            if ($line -match '^\s*global\s+') {
+                $wordMatches = $script:_rxWord.Matches($line)
+                foreach ($wm in $wordMatches) {
+                    $w = $wm.Value
+                    if ($w -ieq 'global') { continue }
+                    if ($w.ToLower().Contains($searchKey) -or $searchKey.Contains($w.ToLower())) {
+                        $suggestions += $w
+                    }
+                }
+            }
+        }
+    }
+    $suggestions = $suggestions | Sort-Object -Unique | Select-Object -First 10
+    if ($suggestions.Count -gt 0) {
+        Write-Host "  Did you mean:" -ForegroundColor Yellow
+        foreach ($s in $suggestions) {
+            Write-Host "    $s" -ForegroundColor DarkGray
+        }
+    }
+    exit 1
+}
+
+# ============================================================
+# Step 2: Find all mutations with context
+# ============================================================
+$e = [regex]::Escape($GlobalName)
+$mutPatterns = @(
+    [regex]::new("(?<![.\w])$e\s*[:+\-\*\/\.]+\="),
+    [regex]::new("(?<![.\w])$e\s*(\+\+|--)"),
+    [regex]::new("(?<![.\w])$e\[.+?\]\s*[:+\-\*\/\.]+\="),
+    [regex]::new("\b$e\.($MUTATING_METHODS)\s*\("),
+    [regex]::new("\b$e\.\w+\s*[:+\-\*\/\.]+\=")
+)
+
+# Literal value regex for simple assignments
+$rxLiteralAssign = [regex]::new("(?<![.\w])$e\s*:=\s*(.+)")
+
+# Mutations: @{ File; RelPath; Line; Code; Func; Guards[]; LiteralValue }
+$mutations = [System.Collections.ArrayList]::new()
+$literalValues = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+
+foreach ($file in $srcFiles) {
+    $text = [System.IO.File]::ReadAllText($file.FullName)
+    if ($text.IndexOf($GlobalName, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
+
+    if (-not $fileCache.ContainsKey($file.FullName)) {
+        $fileCache[$file.FullName] = Split-Lines $text
+    }
+    $lines = $fileCache[$file.FullName]
+    $relPath = $file.FullName.Replace("$projectRoot\", '')
+
+    $depth = 0
+    $inFunc = $false
+    $funcDepth = -1
+    $funcName = ""
+    $funcStartIdx = -1
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $cleaned = Clean-Line $lines[$i]
+        if ($cleaned -eq '') { continue }
+
+        if (-not $inFunc) {
+            $m = $script:_rxFuncDef.Match($cleaned)
+            if ($m.Success) {
+                $fn = $m.Groups[1].Value
+                if (-not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
+                    $inFunc = $true
+                    $funcDepth = $depth
+                    $funcName = $fn
+                    $funcStartIdx = $i
+                }
+            }
+        }
+
+        $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
+        if ($depth -lt 0) { $depth = 0 }
+
+        if ($inFunc -and $depth -le $funcDepth) {
+            $inFunc = $false
+            $funcDepth = -1
+        }
+
+        if (-not $inFunc) { continue }
+
+        # Test for mutation
+        $isMutation = $mutPatterns[0].IsMatch($cleaned) -or
+                      $mutPatterns[1].IsMatch($cleaned) -or
+                      $mutPatterns[2].IsMatch($cleaned) -or
+                      $mutPatterns[3].IsMatch($cleaned) -or
+                      $mutPatterns[4].IsMatch($cleaned)
+
+        if (-not $isMutation) { continue }
+
+        # Extract guards by walking backwards from mutation line
+        $guards = [System.Collections.ArrayList]::new()
+        $hasCritical = $false
+
+        # Walk backwards within the function to find guards
+        $guardBraceDepth = 0
+        $guardsFound = 0
+        for ($gi = $i - 1; $gi -ge $funcStartIdx -and $guardsFound -lt 3; $gi--) {
+            $gCleaned = Clean-Line $lines[$gi]
+            if ($gCleaned -eq '') { continue }
+
+            # Track brace depth going backwards
+            $gBraceClose = $gCleaned.Length - $gCleaned.Replace('}','').Length
+            $gBraceOpen = $gCleaned.Length - $gCleaned.Replace('{','').Length
+            $guardBraceDepth += $gBraceClose - $gBraceOpen
+
+            # Check for Critical "On"
+            if (-not $hasCritical -and $gCleaned -match 'Critical\s+["'']On["'']') {
+                $hasCritical = $true
+            }
+
+            # When we cross a brace boundary going up, look for if/while condition
+            if ($guardBraceDepth -gt 0 -and ($gCleaned -match '^\s*(if|while|else\s+if)\s*\((.+)\)\s*\{?\s*$')) {
+                $condition = $Matches[2].Trim()
+                # Truncate long conditions
+                if ($condition.Length -gt 60) { $condition = $condition.Substring(0, 57) + "..." }
+                [void]$guards.Add($condition)
+                $guardsFound++
+                $guardBraceDepth--
+            }
+        }
+
+        if ($hasCritical) {
+            [void]$guards.Insert(0, 'Critical "On"')
+        }
+
+        # Extract literal value from raw line (not cleaned, since Clean-Line strips strings)
+        $literalValue = $null
+        $rawTrimmed = $lines[$i].Trim()
+        $litMatch = $rxLiteralAssign.Match($rawTrimmed)
+        if ($litMatch.Success) {
+            $rhs = $litMatch.Groups[1].Value.Trim()
+            # Check if it's a literal (string, number, true/false)
+            if ($rhs -match '^"([^"]*)"$') {
+                $literalValue = '"' + $Matches[1] + '"'
+                [void]$literalValues.Add($Matches[1])
+            } elseif ($rhs -match "^'([^']*)'$") {
+                $literalValue = "'" + $Matches[1] + "'"
+                [void]$literalValues.Add($Matches[1])
+            } elseif ($rhs -match '^-?\d+(\.\d+)?$') {
+                $literalValue = $rhs
+                [void]$literalValues.Add($rhs)
+            } elseif ($rhs -ieq 'true' -or $rhs -ieq 'false') {
+                $literalValue = $rhs.ToLower()
+                [void]$literalValues.Add($rhs.ToLower())
+            } elseif ($rhs -match '^[A-Z_]+$' -and $rhs.Length -le 30) {
+                # Likely a constant
+                $literalValue = $rhs
+            } else {
+                $literalValue = '(dynamic)'
+            }
+        }
+
+        [void]$mutations.Add(@{
+            File         = $file.FullName
+            RelPath      = $relPath
+            Line         = ($i + 1)
+            Code         = $lines[$i].Trim()
+            Func         = $funcName
+            Guards       = $guards
+            LiteralValue = $literalValue
+        })
+    }
+}
+
+$totalSw.Stop()
+
+# ============================================================
+# Output
+# ============================================================
+Write-Host ""
+Write-Host "  $GlobalName" -ForegroundColor White
+Write-Host ""
+Write-Host "  declared: $($declaration.RelPath):$($declaration.Line)" -ForegroundColor Cyan
+
+if ($mutations.Count -eq 0) {
+    Write-Host ""
+    Write-Host "  no mutations found (read-only global or set only at declaration)" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "  Completed in $($totalSw.ElapsedMilliseconds)ms" -ForegroundColor Cyan
+    exit 0
+}
+
+Write-Host ""
+
+if ($Brief) {
+    # Brief mode
+    Write-Host "  mutations ($($mutations.Count)):" -ForegroundColor Green
+    foreach ($m in $mutations) {
+        $basename = [System.IO.Path]::GetFileName($m.RelPath)
+        $tags = @()
+        $hasCrit = $false
+        $hasGuard = $false
+        foreach ($g in $m.Guards) {
+            if ($g -eq 'Critical "On"') { $hasCrit = $true }
+            else { $hasGuard = $true }
+        }
+        if ($hasCrit) { $tags += "Critical" }
+        if ($hasGuard) { $tags += "guarded" }
+        $tagStr = if ($tags.Count -gt 0) { "  [$($tags -join ', ')]" } else { "" }
+        Write-Host "    $($m.Func.PadRight(24)) $basename`:$($m.Line)$tagStr" -ForegroundColor DarkGray
+    }
+} else {
+    # Full mode
+    Write-Host "  mutations ($($mutations.Count)):" -ForegroundColor Green
+
+    # Group by function for cleaner output
+    $byFunc = [ordered]@{}
+    foreach ($m in $mutations) {
+        $funcKey = "$($m.Func)|$($m.RelPath)"
+        if (-not $byFunc.Contains($funcKey)) {
+            $byFunc[$funcKey] = [System.Collections.ArrayList]::new()
+        }
+        [void]$byFunc[$funcKey].Add($m)
+    }
+
+    foreach ($entry in $byFunc.GetEnumerator()) {
+        $muts = $entry.Value
+        $first = $muts[0]
+        $basename = [System.IO.Path]::GetFileName($first.RelPath)
+
+        Write-Host ""
+        Write-Host "    $($first.Func)()  " -ForegroundColor White -NoNewline
+        Write-Host "$basename`:$($first.Line)" -ForegroundColor Cyan
+
+        foreach ($m in $muts) {
+            Write-Host "      $($m.Code)" -ForegroundColor DarkGray
+        }
+
+        # Show guards from the first mutation (typically all mutations in same function have same guards)
+        if ($first.Guards.Count -gt 0) {
+            $guardStr = $first.Guards -join ', '
+            Write-Host "      guards: $guardStr" -ForegroundColor Yellow
+        }
+    }
+}
+
+# Values assigned
+if ($literalValues.Count -gt 0) {
+    Write-Host ""
+    $sortedValues = $literalValues | Sort-Object
+    $valueStr = ($sortedValues | ForEach-Object { "`"$_`"" }) -join ', '
+    Write-Host "  values assigned: $valueStr" -ForegroundColor DarkGray
+}
+
+Write-Host ""
+Write-Host "  Completed in $($totalSw.ElapsedMilliseconds)ms" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- New query tools for tracing code flow without chaining point-lookups: `query_callchain` (call graph traversal), `query_impact` (blast radius analysis), `query_mutations` (global mutation detail with guards and literal values)
- `/trace` skill spawns a forked Explore agent with the full query tool catalog, returning only the synthesized answer at zero context cost
- CLAUDE.md updated: callchain promoted to always-loaded, domain-specific tools moved to discoverable tier

Closes #154

## Test plan
- [ ] Run `tools/query_callchain.ps1` with forward/reverse traversal on known functions
- [ ] Run `tools/query_impact.ps1` on a global with known callers/readers
- [ ] Run `tools/query_mutations.ps1` on a frequently-mutated global
- [ ] Verify `/trace` skill invocation returns synthesized answer
- [ ] Confirm pre-gate passes: `.\tests\test.ps1 --live`

🤖 Generated with [Claude Code](https://claude.com/claude-code)