### PR TITLE
Fix option interaction bugs: stale config, shortcuts, race

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -448,9 +448,24 @@ if (g_AltTabbyMode = "install-to-pf") {
     try {
         state := ReadStateFile(TEMP_INSTALL_PF_STATE)
 
-        ; Call Update_ApplyCore directly instead of Launcher_DoUpdateInstalled —
-        ; "Install to PF" should never overwrite existing PF config with defaults.
-        ; The user's intent is "put my exe there", not "push my config there".
+        ; Check if PF target already has config — ask user whether to keep or replace.
+        ; When source is the running exe (copyMode), user's active settings may differ
+        ; from stale PF config. Let the user decide.
+        overwriteUserData := false
+        targetDir := ""
+        SplitPath(state.target, , &targetDir)
+        if (FileExist(targetDir "\config.ini")) {
+            configResult := ThemeMsgBox(
+                "The target folder already has settings (config.ini).`n`n"
+                "Replace with your current settings?`n`n"
+                "Yes = Copy your current settings to Program Files`n"
+                "No = Keep the existing Program Files settings",
+                APP_NAME " - Configuration",
+                "YesNo Icon?"
+            )
+            overwriteUserData := (configResult = "Yes")
+        }
+
         Update_ApplyCore({
             sourcePath: state.source,
             targetPath: state.target,
@@ -458,7 +473,8 @@ if (g_AltTabbyMode = "install-to-pf") {
             validatePE: false,
             copyMode: true,
             cleanupSourceOnFailure: false,
-            overwriteUserData: false,
+            overwriteUserData: overwriteUserData,
+            ensureShortcuts: true,
             successMessage: "Alt-Tabby has been installed to:`n" state.target
         })
     } catch as e {

--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -729,22 +729,19 @@ _Launcher_KillAllAltTabbyProcesses() {
             }
         }
     } catch {
-        ; Fallback: use taskkill with wildcard patterns
-        ; Note: taskkill doesn't support wildcards in /IM, so we try common patterns
-        currentExeName := ""
-        SplitPath(A_ScriptFullPath, &currentExeName)
-        fallbackPatterns := ["AltTabby.exe", "alttabby.exe", "Alt-Tabby.exe"]
-        if (currentExeName != "") {
-            alreadyCovered := false
-            for p in fallbackPatterns {
-                if (PathsEqual(p, currentExeName)) {
-                    alreadyCovered := true
-                    break
-                }
+        ; Fallback: use taskkill with known exe name patterns
+        ; ProcessUtils_BuildExeNameList covers current exe, config exe, and target exe.
+        ; Add "Alt-Tabby.exe" as extra fallback for common user renames.
+        fallbackPatterns := ProcessUtils_BuildExeNameList()
+        hasAltHyphen := false
+        for p in fallbackPatterns {
+            if (StrCompare(p, "Alt-Tabby.exe") = 0) {
+                hasAltHyphen := true
+                break
             }
-            if (!alreadyCovered)
-                fallbackPatterns.Push(currentExeName)
         }
+        if (!hasAltHyphen)
+            fallbackPatterns.Push("Alt-Tabby.exe")
         for pattern in fallbackPatterns {
             try RunWait('taskkill /F /IM "' pattern '" /FI "PID ne ' myPID '"',, "Hide")
         }

--- a/src/shared/process_utils.ahk
+++ b/src/shared/process_utils.ahk
@@ -68,7 +68,7 @@ ProcessUtils_Basename(path) {
 ;   3. cfg.SetupExePath (installed location, may differ if user renamed)
 ; Used by ProcessUtils_KillAltTabby for force-kill phase.
 
-_ProcessUtils_BuildExeNameList(targetExeName := "") {
+ProcessUtils_BuildExeNameList(targetExeName := "") {
     global cfg
 
     exeNames := []
@@ -183,11 +183,11 @@ _ProcessUtils_IsElevated(pid) {
 }
 
 ; Kill all Alt-Tabby processes except ourselves
-; Iterates over exe names from _ProcessUtils_BuildExeNameList().
+; Iterates over exe names from ProcessUtils_BuildExeNameList().
 ; Parameters:
 ;   targetExeName - Optional extra exe name to include (for updates targeting different name)
 _ProcessUtils_KillAllAltTabbyExceptSelf(targetExeName := "") {
-    for exeName in _ProcessUtils_BuildExeNameList(targetExeName) {
+    for exeName in ProcessUtils_BuildExeNameList(targetExeName) {
         ProcessUtils_KillByNameExceptSelf(exeName)
     }
 }
@@ -238,7 +238,7 @@ ProcessUtils_KillAltTabby(opts := "") {
     if (force) {
         _ProcessUtils_KillAllAltTabbyExceptSelf(targetExeName)
         if (offerElevation) {
-            for exeName in _ProcessUtils_BuildExeNameList(targetExeName) {
+            for exeName in ProcessUtils_BuildExeNameList(targetExeName) {
                 _PU_OfferElevatedKill(exeName)
             }
         }

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -806,7 +806,14 @@ _Update_FindExeDownloadUrl(jsonResponse) {
 
 ; Download update and apply it
 Update_DownloadAndApply(downloadUrl, newVersion) {
-    global cfg
+    global cfg, g_AdminToggleInProgress, APP_NAME
+
+    ; Guard: block if admin mode toggle is in progress (prevents race with UAC elevation)
+    if (IsSet(g_AdminToggleInProgress) && g_AdminToggleInProgress) {
+        ThemeMsgBox("An admin mode change is in progress. Please wait for it to complete before updating.", APP_NAME, "Icon!")
+        return
+    }
+
     ; Determine paths
     currentExe := A_ScriptFullPath
     exeDir := ""
@@ -929,6 +936,7 @@ Update_NeedsElevation(targetDir) {
 ;   cleanupSourceOnFailure - Delete source file if update fails
 ;   relaunchAfter - After success: show TrayTip, cleanup .old, relaunch+exit (default: true)
 ;   overwriteUserData - Copy config/blacklist even if target already has them (default: false)
+;   ensureShortcuts - Create Start Menu + Startup shortcuts if they don't exist (default: false)
 ;   killPids - Optional {gui:, pump:} PIDs for graceful shutdown before force-kill
 
 Update_ApplyCore(opts) {
@@ -943,6 +951,7 @@ Update_ApplyCore(opts) {
     cleanupSourceOnFailure := opts.HasOwnProp("cleanupSourceOnFailure") ? opts.cleanupSourceOnFailure : false
     relaunchAfter := opts.HasOwnProp("relaunchAfter") ? opts.relaunchAfter : true
     overwriteUserData := opts.HasOwnProp("overwriteUserData") ? opts.overwriteUserData : false
+    ensureShortcuts := opts.HasOwnProp("ensureShortcuts") ? opts.ensureShortcuts : false
     killPids := opts.HasOwnProp("killPids") ? opts.killPids : ""
 
     lockFile := ""
@@ -1078,6 +1087,15 @@ Update_ApplyCore(opts) {
         ; Recreate shortcuts to point to updated exe (Bug 5 fix)
         ; This ensures shortcuts work after exe rename + auto-update
         RecreateShortcuts()
+
+        ; When installing to PF and no shortcuts exist (e.g., wizard was skipped),
+        ; create them now. RecreateShortcuts only updates existing shortcuts.
+        if (ensureShortcuts) {
+            if (!FileExist(Shortcut_GetStartMenuPath()))
+                CreateShortcutForCurrentMode(Shortcut_GetStartMenuPath())
+            if (!FileExist(Shortcut_GetStartupPath()))
+                CreateShortcutForCurrentMode(Shortcut_GetStartupPath())
+        }
 
         ; Success — relaunch unless caller handles it (e.g., wizard)
         if (relaunchAfter) {

--- a/tests/check_batch_patterns.ps1
+++ b/tests/check_batch_patterns.ps1
@@ -254,8 +254,8 @@ $CHECKS = @(
     @{
         Id       = "exe_name_dedup"
         File     = "shared\process_utils.ahk"
-        Desc     = "_ProcessUtils_BuildExeNameList uses StrLower + seenNames dedup"
-        Patterns = @("_ProcessUtils_BuildExeNameList(", "StrLower(")
+        Desc     = "ProcessUtils_BuildExeNameList uses StrLower + seenNames dedup"
+        Patterns = @("ProcessUtils_BuildExeNameList(", "StrLower(")
         AnyOf    = @("seenNames.Has(", "seenNames[")
     },
     @{

--- a/tests/run_tests.ahk
+++ b/tests/run_tests.ahk
@@ -87,6 +87,9 @@ global g_BlacklistEditorPID := 0
 ; --- Admin mode cache (from launcher_tray.ahk, used by IsAdminModeFullyActive in setup_utils.ahk) ---
 global g_CachedAdminTaskActive := false
 
+; --- Admin toggle state (from launcher_tray.ahk, guarded by Update_DownloadAndApply in setup_utils.ahk) ---
+global g_AdminToggleInProgress := false
+
 ; --- Theme palette (from theme.ahk, used by launcher_about.ahk) ---
 global gTheme_Palette := {}
 
@@ -287,6 +290,11 @@ ThemeMsgBox(params*) {
 
 ; Setup utility mock (setup_utils.ahk)
 RecreateShortcuts(params*) {
+}
+
+; Shortcut creation mock (launcher_shortcuts.ahk, called by setup_utils.ahk ensureShortcuts)
+CreateShortcutForCurrentMode(params*) {
+    return true
 }
 
 ; Process pump mocks (window_list.ahk)


### PR DESCRIPTION
## Summary

- Ask user to keep/replace config when installing to PF with existing config.ini (prevents silent loss of customized settings)
- Add `ensureShortcuts` option to `Update_ApplyCore` — creates Start Menu + Startup shortcuts on PF install when wizard was skipped
- Guard `Update_DownloadAndApply` against concurrent admin mode toggle (`g_AdminToggleInProgress` check)
- DRY: Make `ProcessUtils_BuildExeNameList` public and use it in WMI kill fallback instead of hardcoded exe patterns

Closes #171

## Test plan

- [ ] Run from Desktop with customized config → tray "Install to PF" with existing stale PF config → verify dialog appears asking keep/replace
- [ ] Skip wizard → later tray "Install to PF" → verify Start Menu and Startup shortcuts are created
- [ ] Click "Run as Administrator" (UAC appears) → try to install update → verify blocked with message
- [ ] Full test suite passes (902/902 tests, all static analysis checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)