### PR TITLE
Fix test reliability anti-patterns (7 timing flakes)

### DIFF
--- a/tests/gui_tests_data.ahk
+++ b/tests/gui_tests_data.ahk
@@ -604,7 +604,7 @@ RunGUITests_Data() {
     gWS_Store[1000] := {present: true, iconHicon: 50001}
     GUI_KickPreCache()
     ; Timer should NOT have been set; verify by calling tick manually after brief wait
-    Sleep(60)
+    Sleep(150)  ; 3x the -50ms timer period for reliable negative assertion
     GUI_AssertEq(gMock_PreCachedIcons.Count, 0, "KickPreCache ACTIVE: timer not set, no icons cached")
 
     ; ============================================================

--- a/tests/test_live_execution.ahk
+++ b/tests/test_live_execution.ahk
@@ -187,8 +187,11 @@ RunLiveTests_Execution() {
                 TestErrors++
             }
 
-            ; Kill the test process
+            ; Kill the test process and wait for death
             try ProcessClose(recreatePid)
+            closeDeadline := A_TickCount + 2000
+            while (ProcessExist(recreatePid) && (A_TickCount < closeDeadline))
+                Sleep(20)
         } else {
             Log("FAIL: Could not launch compiled exe for recreation test")
             TestErrors++

--- a/tests/test_live_pump.ahk
+++ b/tests/test_live_pump.ahk
@@ -349,11 +349,8 @@ RunLiveTests_Pump() {
 _Pump_Cleanup() {
     global PUMP_EXE_NAME, PUMP_HWND_FILE, PUMP_LOG_PREFIX
 
-    ; Kill processes by name (only pump copies, not other AltTabby.exe)
-    for _, proc in _Test_EnumProcesses(PUMP_EXE_NAME) {
-        try ProcessClose(proc.pid)
-    }
-    Sleep(50)
+    ; Kill processes by name with poll for death (only pump copies, not other AltTabby.exe)
+    _Test_KillProcessesByName(PUMP_EXE_NAME)
 
     try FileDelete(PUMP_HWND_FILE)
 

--- a/tests/test_live_watcher.ahk
+++ b/tests/test_live_watcher.ahk
@@ -303,11 +303,8 @@ RunLiveTests_Watcher() {
 _Watcher_Cleanup() {
     global WATCHER_EXE_NAME, WATCHER_HWND_FILE, WATCHER_LOG_PREFIX
 
-    ; Kill processes by name (only watcher copies, not other AltTabby.exe)
-    for _, proc in _Test_EnumProcesses(WATCHER_EXE_NAME) {
-        try ProcessClose(proc.pid)
-    }
-    Sleep(50)
+    ; Kill processes by name with poll for death (only watcher copies, not other AltTabby.exe)
+    _Test_KillProcessesByName(WATCHER_EXE_NAME)
 
     try FileDelete(WATCHER_HWND_FILE)
 

--- a/tests/test_unit_core_config.ahk
+++ b/tests/test_unit_core_config.ahk
@@ -600,8 +600,30 @@ RunUnitTests_CoreConfig() {
         errFiles.Push(errFile)
     }
 
-    ; Single wait for all to initialize (750ms total instead of 4x750ms)
-    Sleep(750)
+    ; Poll for all processes to have started (or died with errors)
+    initStart := A_TickCount
+    while ((A_TickCount - initStart) < 3000) {
+        allReady := true
+        for idx, ep in entryPoints {
+            pid := pids[idx]
+            if (!pid)
+                continue
+            ; Process still running = initialized OK; process dead = check error file
+            if (ProcessExist(pid))
+                continue
+            ; Dead process — error file should exist if there was output
+            errFile := errFiles[idx]
+            if (errFile != "" && !FileExist(errFile)) {
+                allReady := false
+                break
+            }
+        }
+        if (allReady)
+            break
+        Sleep(50)
+    }
+    ; Additional grace for processes still running to finish init
+    Sleep(200)
 
     ; Collect results from all entry points
     for idx, ep in entryPoints {
@@ -619,6 +641,9 @@ RunUnitTests_CoreConfig() {
             stillRunning := false  ; We just killed it
         } else if (stillRunning) {
             ProcessClose(pid)
+            closeDeadline := A_TickCount + 2000
+            while (ProcessExist(pid) && (A_TickCount < closeDeadline))
+                Sleep(20)
         }
 
         ; Read error output

--- a/tests/test_unit_file_watcher.ahk
+++ b/tests/test_unit_file_watcher.ahk
@@ -99,7 +99,13 @@ RunUnitTests_FileWatcher() {
                 break
             Sleep(50)
         }
-        Sleep(300)  ; catch any spurious second callback
+        ; Poll for stable count (600ms confirms absence, exits early if spurious fires)
+        graceStart := A_TickCount
+        while ((A_TickCount - graceStart) < 600) {
+            if (callbackCount3 > 1)
+                break
+            Sleep(50)
+        }
 
         if (callbackCount3 = 1) {
             Log("PASS: FileWatch debounce coalesced 5 rapid writes into 1 callback")


### PR DESCRIPTION
## Summary

- Replace async `ProcessClose` + blind `Sleep(50)` in pump/watcher cleanup with `_Test_KillProcessesByName()` which polls for process death
- Replace blind `Sleep(750)` for parallel entry point init with polling loop (3s deadline)
- Add 2s death-poll after `ProcessClose` in config and execution tests before reading output files
- Replace blind `Sleep(300)` debounce check with 600ms poll that exits early on spurious callback
- Increase negative assertion sleep from 60ms to 150ms (3x timer period) for `KickPreCache` test

7 fixes across 6 test files. No production code changes.

Closes #183

## Test plan

- [ ] `.\tests\test.ps1 --live` passes (blocked by pre-existing static analysis failures on main — changes are test-only)
- [ ] Verify pump/watcher cleanup doesn't leave stale processes
- [ ] Verify config entry point test doesn't flake on slow machines

Generated with [Claude Code](https://claude.com/claude-code)