### PR TITLE
Static analysis: win64 API + missing DllCall return type checks

### DIFF
--- a/src/gui/gui_capture.ahk
+++ b/src/gui/gui_capture.ahk
@@ -119,7 +119,7 @@ _Capture_Screenshot() {
 
     ; Convert HBITMAP to GDI+ bitmap
     pBitmap := 0
-    gdipResult := DllCall("gdiplus\GdipCreateBitmapFromHBITMAP", "Ptr", hBitmap, "Ptr", 0, "Ptr*", &pBitmap)
+    gdipResult := DllCall("gdiplus\GdipCreateBitmapFromHBITMAP", "Ptr", hBitmap, "Ptr", 0, "Ptr*", &pBitmap, "int")
 
     if (gdipResult != 0 || !pBitmap) {
         DllCall("SelectObject", "Ptr", hMemDC, "Ptr", hOldBmp)

--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -666,7 +666,7 @@ Launcher_AcquireMutex() {
 
     ; Try to create named mutex
     g_LauncherMutex := DllCall("CreateMutex", "ptr", 0, "int", 1, "str", mutexName, "ptr")
-    lastError := DllCall("GetLastError")
+    lastError := DllCall("GetLastError", "uint")
 
     if (lastError = ERROR_ALREADY_EXISTS) {
         ; Mutex already exists - another launcher is running
@@ -695,7 +695,7 @@ _Launcher_AcquireActiveMutex() {
     mutexName := "AltTabby_Active"
 
     g_ActiveMutex := DllCall("CreateMutex", "ptr", 0, "int", 1, "str", mutexName, "ptr")
-    lastError := DllCall("GetLastError")
+    lastError := DllCall("GetLastError", "uint")
 
     if (lastError = ERROR_ALREADY_EXISTS) {
         if (cfg.DiagLauncherLog)

--- a/src/launcher/launcher_splash.ahk
+++ b/src/launcher/launcher_splash.ahk
@@ -587,7 +587,8 @@ _Splash_LoadWebPFrames(webpPath) {
             , "int", stride
             , "int", 0x26200A  ; PixelFormat32bppPARGB
             , "ptr", pixelBuf.Ptr
-            , "ptr*", &pBitmap)
+            , "ptr*", &pBitmap
+            , "int")
 
         if (hr = 0 && pBitmap) {
             g_SplashFrameBuffers.Push(pixelBuf)
@@ -725,7 +726,8 @@ _Splash_DecodeNextFrame() {
         , "int", stride
         , "int", 0x26200A  ; PixelFormat32bppPARGB
         , "ptr", pixelBuf.Ptr
-        , "ptr*", &pBitmap)
+        , "ptr*", &pBitmap
+        , "int")
 
     if (hr != 0 || !pBitmap)
         return false

--- a/src/shared/ipc_pipe.ahk
+++ b/src/shared/ipc_pipe.ahk
@@ -534,7 +534,7 @@ _IPC_ParseLines(stateObj, onMessageFn, hPipe := 0) {
 
 _IPC_PeekAvailable(hPipe) {
     bytesAvail := 0
-    ok := DllCall("PeekNamedPipe", "ptr", hPipe, "ptr", 0, "uint", 0, "uint*", 0, "uint*", &bytesAvail, "uint*", 0)
+    ok := DllCall("PeekNamedPipe", "ptr", hPipe, "ptr", 0, "uint", 0, "uint*", 0, "uint*", &bytesAvail, "uint*", 0, "int")
     if (!ok)
         return -1
     return bytesAvail

--- a/src/shared/theme.ahk
+++ b/src/shared/theme.ahk
@@ -1000,12 +1000,12 @@ _Theme_RegisterOwnerDrawButton(ctrl) {
     btnText := ctrl.Text
 
     ; Check if this is a default button (BS_DEFPUSHBUTTON = 0x01)
-    style := DllCall("GetWindowLong", "Ptr", ctrl.Hwnd, "Int", -16, "Int")
+    style := DllCall("user32\GetWindowLongPtrW", "Ptr", ctrl.Hwnd, "Int", -16, "Ptr")
     isDefault := (style & 0x0F) = 0x01
 
     ; Convert to BS_OWNERDRAW (0x0B) — clears low nibble, sets owner-draw
     style := (style & ~0xF) | 0xB
-    DllCall("SetWindowLong", "Ptr", ctrl.Hwnd, "Int", -16, "Int", style)
+    DllCall("user32\SetWindowLongPtrW", "Ptr", ctrl.Hwnd, "Int", -16, "Ptr", style, "Ptr")
 
     ; Register in tracking map
     gTheme_ButtonMap[ctrl.Hwnd] := {

--- a/src/viewer/viewer.ahk
+++ b/src/viewer/viewer.ahk
@@ -231,8 +231,8 @@ _Viewer_CreateGui() {
     SendMessage(0x1036, 0x00010020, 0x00010020, gViewer_LV.Hwnd)  ; LVS_EX_FULLROWSELECT | LVS_EX_DOUBLEBUFFERED
 
     ; Show selection even when unfocused
-    style := DllCall("GetWindowLong", "Ptr", gViewer_LV.Hwnd, "Int", -16, "Int")
-    DllCall("SetWindowLong", "Ptr", gViewer_LV.Hwnd, "Int", -16, "Int", style | 0x0008)  ; LVS_SHOWSELALWAYS
+    style := DllCall("user32\GetWindowLongPtrW", "Ptr", gViewer_LV.Hwnd, "Int", -16, "Ptr")
+    DllCall("user32\SetWindowLongPtrW", "Ptr", gViewer_LV.Hwnd, "Int", -16, "Ptr", style | 0x0008, "Ptr")  ; LVS_SHOWSELALWAYS
 
     ; === Bottom status bar ===
     gViewer_Status := gViewer_Gui.AddText("x10 y620 w1100 h20", "Ready")

--- a/tests/check_batch_simple.ps1
+++ b/tests/check_batch_simple.ps1
@@ -432,6 +432,11 @@ $DC_TYPE_SET = @{}
 
 $DC_HANDLE_VAR_EXCLUDE = @{ 'hResult' = $true; 'hRes' = $true; 'hPhys' = $true }
 
+$WIN64_API_MAP = @{
+    'GetWindowLong' = 'GetWindowLongPtrW'
+    'SetWindowLong' = 'SetWindowLongPtrW'
+}
+
 function BS_FindDllCallEnd {
     param([string]$text, [int]$openParenIdx)
     $depth = 0; $inStr = $false
@@ -565,6 +570,23 @@ foreach ($file in $allFiles) {
                 Detail = "$varName looks like a handle - use `"Ptr`" not `"$wrongType`""
             }
         }
+
+        # Rule 3: 64-bit API names (e.g. GetWindowLong -> GetWindowLongPtrW)
+        if ($WIN64_API_MAP.ContainsKey($baseName) -and $joinedLine -notmatch 'A_PtrSize') {
+            $replacement = $WIN64_API_MAP[$baseName]
+            $detail = "${baseName}() is 32-bit - use `"$replacement`" on x64"
+            $dcIssues += [PSCustomObject]@{
+                File = $relPath; Line = $startLineNum; Rule = 'win64-api'; Detail = $detail
+            }
+        }
+
+        # Rule 3b: Result captured without explicit return type (default "Int" truncates unsigned/pointer)
+        if (-not $explicitReturn -and $joinedLine -match '\w+\s*:=\s*DllCall') {
+            $detail = "${baseName}() result captured with default `"Int`" return - specify explicit type"
+            $dcIssues += [PSCustomObject]@{
+                File = $relPath; Line = $startLineNum; Rule = 'missing-return-type'; Detail = $detail
+            }
+        }
     }
 }
 
@@ -572,7 +594,7 @@ if ($dcIssues.Count -gt 0) {
     $anyFailed = $true
     [void]$failOutput.AppendLine("")
     [void]$failOutput.AppendLine("  FAIL: $($dcIssues.Count) DllCall type issue(s) found.")
-    [void]$failOutput.AppendLine("  On 64-bit, handles are pointer-sized. Use `"Ptr`" not `"Int`"/`"UInt`".")
+    [void]$failOutput.AppendLine("  DllCall type safety: handle types, 64-bit API names, return type declarations.")
     [void]$failOutput.AppendLine("  Suppress with: ; lint-ignore: dllcall-types")
     $grouped = $dcIssues | Group-Object File
     foreach ($group in $grouped | Sort-Object Name) {


### PR DESCRIPTION
## Summary

- Add two new DllCall static analysis rules to `check_batch_simple.ps1`:
  - **win64-api**: flags `GetWindowLong`/`SetWindowLong` (32-bit APIs that truncate pointer-sized values on x64), with `A_PtrSize` exclusion for dynamic dispatch patterns
  - **missing-return-type**: flags `var := DllCall(...)` without explicit return type (default `"Int"` silently truncates unsigned/pointer values)
- Fix all 10 true positives across 6 production files (type annotations only, no behavior change)

## Test plan

- [x] Static analysis passes with 0 new violations (`check_batch_simple.ps1` clean)
- [x] New rules correctly exclude `A_PtrSize` dynamic dispatch in `gui_animation.ahk` and `gui_overlay.ahk`
- [ ] Full test suite passes (`.\tests\test.ps1 --live`) — pre-existing `check_batch_functions.ps1` failures are unrelated
- [ ] Manual smoke test: Alt-Tab overlay, debug viewer, config editor owner-draw buttons

Closes #186

Generated with [Claude Code](https://claude.com/claude-code)