### PR TITLE
Fix stale references in 9 review skills and ahk-patterns.md

### DIFF
--- a/.claude/rules/ahk-patterns.md
+++ b/.claude/rules/ahk-patterns.md
@@ -77,7 +77,7 @@ Use tick-based timing instead of static counters that can leak state if timer is
 
 In frequently-called functions (paint, input, per-window loops):
 - **Buffers**: Use `static` for DllCall marshal buffers repopulated via NumPut before use
-- **GDI+ objects**: Cache brushes/pens/fonts (see `Gdip_GetCachedBrush`, `gGdip_Res`), never create+destroy per-call
+- **D2D objects**: Cache brushes/fonts (see `D2D_GetCachedBrush`, `gD2D_Res`), never create+destroy per-call
 - **Regex**: Pre-compile patterns at load time, not per-match (see `Blacklist_Reload`)
 - **Loop constants**: Hoist `Round(N * scale)` before loops, not per-iteration
 

--- a/.claude/skills/review-blocking/SKILL.md
+++ b/.claude/skills/review-blocking/SKILL.md
@@ -41,9 +41,9 @@ Produce a categorized function list:
 
 | Function | File | Tier | Reason |
 |----------|------|------|--------|
-| `_WEH_OnFocusChange` | `winevent_hook.ahk` | 1 | WinEvent callback + Critical |
+| `_WEH_WinEventProc` | `winevent_hook.ahk` | 1 | WinEvent callback + Critical |
 | `GUI_Repaint` | `gui_paint.ahk` | 1 | Timer callback |
-| `_BL_MatchPattern` | `blacklist.ahk` | 3 | Called by `Blacklist_IsWindowEligible` (Tier 2) |
+| `Blacklist_IsMatch` | `blacklist.ahk` | 3 | Called by `Blacklist_IsWindowEligible` (Tier 2) |
 
 ### Scope
 
@@ -138,7 +138,7 @@ For each file, list all findings across its functions:
 
 | Function | Finding | Line(s) | Est. Saving | Complexity | Fix |
 |----------|---------|---------|-------------|------------|-----|
-| `_WEH_OnFocusChange` | Redundant `WinGetTitle` call | 88 | ~50μs | Trivial | Cache in local |
+| `_WEH_WinEventProc` | Redundant `WinGetTitle` call | 88 | ~50μs | Trivial | Cache in local |
 
 ### `gui_paint.ahk`
 

--- a/.claude/skills/review-criticals/SKILL.md
+++ b/.claude/skills/review-criticals/SKILL.md
@@ -20,7 +20,7 @@ Find every `Critical "On"` / `Critical "Off"` pair in `src/core/` and `src/gui/`
 
 | Function | File:Lines | Protected Code Summary | Hold Duration | Shared State Touched |
 |----------|-----------|----------------------|---------------|---------------------|
-| `_WEH_OnFocusChange` | `winevent_hook.ahk:40-85` | Check eligibility, upsert window, update MRU | Medium (~50-200μs) | `gWL_*` store globals, `gMRU_*` |
+| `_WEH_WinEventProc` | `winevent_hook.ahk:196+` | Check eligibility, upsert window, update MRU | Medium (~50-200μs) | `gWS_*` store globals |
 
 **Hold Duration estimates:**
 - **Trivial** (~1-5μs): Single assignment, counter increment, flag set
@@ -103,8 +103,8 @@ For each candidate:
 
 | # | Function | File:Lines | Hold Duration | Shared State | Classification |
 |---|----------|-----------|---------------|-------------|----------------|
-| 1 | `_WEH_OnFocusChange` | `winevent_hook.ahk:40-85` | Medium | `gWL_*`, `gMRU_*` | Still necessary |
-| 2 | `_KS_ProcessState` | `komorebi_state.ahk:120-180` | Long | `gKS_Cache`, `gWL_*` | Narrowable |
+| 1 | `_WEH_WinEventProc` | `winevent_hook.ahk:196+` | Medium | `gWS_*` | Still necessary |
+| 2 | `KSub_CacheFocusedHwnds` | `komorebi_state.ahk` | Long | `gKS_Cache`, `gWS_*` | Narrowable |
 | 3 | `_OldHelper` | `some_file.ahk:30-35` | Trivial | `gFoo` (no longer shared) | Stale |
 
 Total: N Critical sections. X still necessary, Y narrowable, Z stale, W unverifiable.
@@ -113,7 +113,7 @@ Total: N Critical sections. X still necessary, Y narrowable, Z stale, W unverifi
 
 | Function | File:Lines | Current Scope | Proposed Scope | Lines Moved Out | Est. Time Saved | Risk |
 |----------|-----------|--------------|---------------|----------------|----------------|------|
-| `_KS_ProcessState` | `komorebi_state.ahk:120-180` | 60 lines | 15 lines | JSON parse (before), log write (after) | ~100μs | Low — moved work is purely local |
+| `KSub_CacheFocusedHwnds` | `komorebi_state.ahk` | 60 lines | 15 lines | JSON parse (before), log write (after) | ~100μs | Low — moved work is purely local |
 
 **Section 3 — Stale holds (recommended removal):**
 

--- a/.claude/skills/review-d3d/SKILL.md
+++ b/.claude/skills/review-d3d/SKILL.md
@@ -131,10 +131,10 @@ Split by concern (run in parallel):
 
 ### Tools
 
-- `query_function.ps1 Shader_PreRender` — extract the full per-frame function body
+- `query_function.ps1 Shader_PreRender` — extract the full per-frame function body (if query_function.ps1 can't parse it, read `src/lib/d2d_shader.ahk` directly at line ~1055)
 - `query_function.ps1 Shader_Init` — extract init code
 - `query_interface.ps1 d2d_shader` — full public API
-- `query_global_ownership.ps1 gShader_*` — who owns shader globals
+- `query_interface.ps1 d2d_shader` — shader globals and public API (note: `query_global_ownership.ps1` excludes `src/lib/`)
 
 ## Assessment Format
 

--- a/.claude/skills/review-professionalism/SKILL.md
+++ b/.claude/skills/review-professionalism/SKILL.md
@@ -80,7 +80,7 @@ Group by user-facing area:
 
 | Area | File | Lines | Issue | User Impact | Fix |
 |------|------|-------|-------|------------|-----|
-| Wizard | `wizard.ahk` | 88 | "Click OK to continue" — no explanation of what happens next | Confusing first-run | Rewrite to "This will install Alt-Tabby to Program Files and create a startup task." |
+| Wizard | `launcher_wizard.ahk` | 88 | "Click OK to continue" — no explanation of what happens next | Confusing first-run | Rewrite to "This will install Alt-Tabby to Program Files and create a startup task." |
 | Tray menu | `launcher.ahk` | 42 | Menu item "Debug Viewer" — technical jargon | Intimidating to non-technical users | Rename to "Window Inspector" or similar |
 | Config editor | `config_editor.ahk` | 200 | Setting description uses ms units without explanation | User doesn't know what 150ms means | Add "(lower = faster response)" hint |
 

--- a/.claude/skills/review-reentrancy/SKILL.md
+++ b/.claude/skills/review-reentrancy/SKILL.md
@@ -123,7 +123,7 @@ Scan these files for `ComCall(`, `ComObj`, vtable dispatch patterns, and `DllCal
 - `src/gui/gui_gdip.ahk` — D2D resource calls (CreateBrush, DrawText, DrawImage, etc.)
 
 **Secondary (show/hide transitions):**
-- `src/gui/gui_antiflash.ahk` — DWM cloaking, SetWindowPos, ShowWindow
+- `src/shared/gui_antiflash.ahk` — DWM cloaking, SetWindowPos, ShowWindow
 - `src/gui/gui_state.ahk` — state transitions that trigger show/hide
 - `src/gui/gui_overlay.ahk` — `D2D_HandleDeviceLoss` (full pipeline recreation)
 

--- a/.claude/skills/review-resource-leaks/SKILL.md
+++ b/.claude/skills/review-resource-leaks/SKILL.md
@@ -12,7 +12,7 @@ Enter planning mode. Systematically audit the codebase for resource leaks and un
 
 GDI+ objects (brushes, pens, fonts, bitmaps, graphics) that are created but never deleted. Each leaked object consumes a GDI handle — Windows limits these per-process (~10,000). Over time, leaks cause rendering failures or crashes.
 
-**Known safe pattern**: `Gdip_GetCachedBrush` and `gGdip_Res` cache objects intentionally — these are NOT leaks. The concern is `Gdip_CreateBrush*` / `Gdip_CreatePen` / `Gdip_CreateFont` calls whose return values are never passed to a corresponding `Gdip_Delete*`.
+**Known safe pattern**: `D2D_GetCachedBrush` and `gD2D_Res` cache objects intentionally — these are NOT leaks. The rendering pipeline uses D2D now — look for D2D resource create/release patterns and any remaining GDI+ usage in `src/lib/`.
 
 Look for:
 - Create without matching delete in the same scope or cleanup path
@@ -62,7 +62,7 @@ Data structures that grow over time without pruning:
 
 ## Known Safe Patterns (Do NOT Flag)
 
-- `gGdip_Res` brush/pen/font cache — intentional lifetime cache, cleaned up on exit
+- `gD2D_Res` brush/font cache — intentional lifetime cache, cleaned up on exit
 - `static` buffers in hot-path functions — intentional reuse per `ahk-patterns.md`
 - Flight recorder ring buffer — pre-allocated, fixed size, overwrites oldest entries
 - Stats `.bak` sentinel files — intentional crash-safety pattern
@@ -71,7 +71,7 @@ Data structures that grow over time without pruning:
 
 Split by resource type for independent parallel exploration:
 
-- **GDI+** — `src/gui/gui_paint.ahk`, `src/gui/gui_overlay.ahk`, any file using `Gdip_*`
+- **D2D / GDI+** — `src/gui/gui_paint.ahk`, `src/gui/gui_overlay.ahk`, `src/gui/gui_gdip.ahk`, any file using `D2D_*` functions. Some `Gdip_*` may remain in `src/lib/` but the paint pipeline is D2D now
 - **Win32 handles** — `src/core/` producers, `src/shared/ipc_pipe.ahk`, DllCall-heavy files. Use `query_function_visibility.ps1` to trace cleanup call chains — verify every Create/Open has a corresponding Close/Delete reachable from all callers.
 - **Timers** — use `query_timers.ps1` to inventory all timers, then check each for proper cleanup
 - **Pipe IPC** — `src/shared/ipc_pipe.ahk`, `src/pump/` files
@@ -96,7 +96,7 @@ Group by severity (per-paint > per-event > per-session > theoretical):
 
 | File | Lines | Resource Type | Leak Description | Impact | Fix |
 |------|-------|--------------|-----------------|--------|-----|
-| `file.ahk` | 42–58 | GDI+ Brush | `Gdip_CreateSolidBrush` in paint loop, never deleted | ~60 handles/sec | Use `Gdip_GetCachedBrush` or `static` |
+| `file.ahk` | 42–58 | D2D Brush | D2D brush created in paint loop, never released | ~60 handles/sec | Use `D2D_GetCachedBrush` or `static` |
 
 For CPU churn findings, use a separate table:
 

--- a/.claude/skills/review-reviews/SKILL.md
+++ b/.claude/skills/review-reviews/SKILL.md
@@ -95,11 +95,12 @@ Do NOT audit non-review skills (like `ship`, `worktree`, `clean-all`, `merge-all
 
 Split by skill batch (run in parallel). Each agent gets a group of skills and performs Phase 1 + Phase 2 for those skills:
 
-- **Performance skills** — `review-latency`, `review-blocking`, `review-criticals`, `review-mcode`, `review-resource-leaks`
-- **Correctness skills** — `review-race-conditions`, `review-option-interaction`, `review-comments`, `review-ahk2`
+- **Performance skills** — `review-latency`, `review-blocking`, `review-criticals`, `review-mcode`, `review-resource-leaks`, `review-paint`, `review-d3d`
+- **Correctness skills** — `review-race-conditions`, `review-option-interaction`, `review-comments`, `review-ahk2`, `review-reentrancy`
 - **Static analysis skills** — `review-static-coverage`, `review-static-history`, `review-static-lintignore`, `review-static-speed`
-- **Test/tool skills** — `review-test-coverage`, `review-test-quality`, `review-test-speed`, `review-test-skips`, `review-tool-coverage`, `review-tool-speed`
+- **Test/tool skills** — `review-test-coverage`, `review-test-quality`, `review-test-speed`, `review-test-skips`, `review-test-reliability`, `review-tool-coverage`, `review-tool-speed`
 - **Code structure skills** — `review-dead-code`, `review-code-quality`, `review-function-visibility`, `review-ownership-manifest`, `review-file-size`, `review-constants-to-configs`
+- **Rendering skills** — `review-shaders`, `review-shaders-open`
 - **UX/meta skills** — `review-professionalism`, `review-debug`, `review-outside-box`, `review-reviews`
 
 Phase 3 (architecture/rules consistency) should run as a separate pass after Phase 1/2, since it requires cross-referencing findings across skills.

--- a/.claude/skills/review-static-coverage/SKILL.md
+++ b/.claude/skills/review-static-coverage/SKILL.md
@@ -20,8 +20,6 @@ A proposed check must clear ALL of these:
 ## Current Check Inventory
 
 **Standalone checks** (complex enough to warrant their own process):
-- `check_includes.ps1` — include path validation
-- `check_profile_markers.ps1` — profiler instrumentation consistency
 - `check_warn.ps1` — warn directive enforcement
 
 **Batch checks** (grouped to share file cache and reduce PowerShell overhead):

--- a/.claude/skills/review-static-lintignore/SKILL.md
+++ b/.claude/skills/review-static-lintignore/SKILL.md
@@ -15,7 +15,7 @@ Static analysis checks in `tests/check_batch_*.ps1` support inline suppression v
 ### Phase 1 — Inventory which checks have lint-ignore support
 
 Scan `tests/check_batch_*.ps1` files for suppression tag definitions. For each one, document:
-- The tag name (e.g., `lint-ignore: critical-section`)
+- The tag name (e.g., `lint-ignore: critical-leak`)
 - Which check/sub-check it belongs to
 - What the check is trying to enforce
 - How many usage sites exist in `.ahk` files
@@ -59,19 +59,19 @@ For each finding:
 
 | Tag | Check File | Enforces | Usage Count |
 |-----|-----------|----------|-------------|
-| `critical-section` | `check_batch_guards.ps1` | Critical "Off" before return | 14 |
+| `critical-leak` | `check_batch_guards.ps1` | Critical "Off" before return | 14 |
 
 **Section 2 — Tag-level evaluation:**
 
 | Tag | Keep Argument | Remove Argument | Verdict |
 |-----|--------------|----------------|---------|
-| `critical-section` | State machine returns inside outer Critical scope — checker can't see caller context | 14 uses may indicate the check needs scope awareness | Keep — but enhance check |
+| `critical-leak` | State machine returns inside outer Critical scope — checker can't see caller context | 14 uses may indicate the check needs scope awareness | Keep — but enhance check |
 
 **Section 3 — Per-usage audit:**
 
 | File | Line | Tag | Code | Classification | Action |
 |------|------|-----|------|---------------|--------|
-| `gui_state.ahk` | 130 | `critical-section` | `return ; lint-ignore: critical-section` | Appropriate — outer function holds Critical | None |
+| `gui_state.ahk` | 130 | `critical-leak` | `return ; lint-ignore: critical-leak` | Appropriate — outer function holds Critical | None |
 | `foo.ahk` | 55 | `dead-param` | `MyFunc(a, b) { ; lint-ignore: dead-param` | Workaround — param `b` could be removed | Remove suppression, remove param |
 
 Order by action needed: workarounds and stale suppressions first, appropriate ones last.

--- a/.claude/skills/review-tool-coverage/SKILL.md
+++ b/.claude/skills/review-tool-coverage/SKILL.md
@@ -26,6 +26,10 @@ Query tools (`tools/query_*.ps1`) exist to give structured answers without loadi
 | `query_state.ps1` | State machine branch extractor |
 | `query_timers.ps1` | SetTimer inventory by file |
 | `query_visibility.ps1` | Public functions with few external callers |
+| `query_callchain.ps1` | Call graph traversal (forward and `-Reverse`) |
+| `query_impact.ps1` | Mutation impact analysis |
+| `query_includes.ps1` | Cross-file `#Include` analysis |
+| `query_mutations.ps1` | Global mutation tracking |
 
 ## Audit Steps
 


### PR DESCRIPTION
## Summary

- Fix 18 stale references across 9 review skills and `ahk-patterns.md` found by review-reviews audit
- **High impact**: `review-resource-leaks` Known Safe section pointed at non-existent GDI+ identifiers (`Gdip_GetCachedBrush` → `D2D_GetCachedBrush`, `gGdip_Res` → `gD2D_Res`)
- **Meta impact**: `review-reviews` was missing 6 skills from its batch list — they'd be skipped on next audit
- **Medium**: Wrong file paths (`gui_antiflash.ahk`, `wizard.ahk`), non-existent functions (`_WEH_OnFocusChange`, `_KS_ProcessState`, `_BL_MatchPattern`), broken tool suggestion (`query_global_ownership.ps1` on `src/lib/`), non-existent suppression tag (`critical-section` → `critical-leak`), removed static checks (`check_includes.ps1`, `check_profile_markers.ps1`), missing tools in inventory
- **Upstream**: `ahk-patterns.md` line 80 had the same stale GDI+ references that caused the skill drift

Closes #192

## Test plan

- [ ] Verify no other review skills reference `Gdip_GetCachedBrush` or `gGdip_Res`
- [ ] Spot-check: `query_function_visibility.ps1 _WEH_WinEventProc` returns the function
- [ ] Spot-check: `query_function_visibility.ps1 D2D_GetCachedBrush` returns the function
- [ ] Run `/review-reviews` on next audit cycle to confirm zero self-referential findings

Generated with [Claude Code](https://claude.com/claude-code)