### PR TITLE
Add cursor-position early-exit to hover polling timers

### DIFF
--- a/src/shared/theme.ahk
+++ b/src/shared/theme.ahk
@@ -1128,8 +1128,14 @@ _Theme_CheckButtonHover() {
     if (gTheme_ButtonMap.Count = 0)
         return
 
-    pt := Buffer(8, 0)
+    static lastX := -1, lastY := -1
+    static pt := Buffer(8, 0)
     DllCall("GetCursorPos", "Ptr", pt)
+    x := NumGet(pt, 0, "Int"), y := NumGet(pt, 4, "Int")
+    if (x = lastX && y = lastY)
+        return
+    lastX := x, lastY := y
+
     hwndUnder := DllCall("WindowFromPoint",
         "Int64", NumGet(pt, 0, "Int64"), "Ptr")
 

--- a/src/viewer/viewer.ahk
+++ b/src/viewer/viewer.ahk
@@ -894,16 +894,21 @@ _Viewer_CheckHover() {
     if (gViewer_ShuttingDown || !gViewer_LV)
         return
 
-    pt := Buffer(8, 0)
+    static lastX := -1, lastY := -1
+    static pt := Buffer(8, 0)
     DllCall("GetCursorPos", "Ptr", pt)
+    x := NumGet(pt, 0, "Int"), y := NumGet(pt, 4, "Int")
+    if (x = lastX && y = lastY)
+        return
+    lastX := x, lastY := y
 
     ; -- ListView row hover --
     newHotRow := -1
-    lvPt := Buffer(8, 0)
+    static lvPt := Buffer(8, 0)
     NumPut("Int", NumGet(pt, 0, "Int"), "Int", NumGet(pt, 4, "Int"), lvPt)
     DllCall("ScreenToClient", "Ptr", gViewer_LV.Hwnd, "Ptr", lvPt)
     ; LVHITTESTINFO: POINT(8) + flags(4) + iItem(4) + iSubItem(4) + iGroup(4) = 24
-    hitInfo := Buffer(24, 0)
+    static hitInfo := Buffer(24, 0)
     NumPut("Int", NumGet(lvPt, 0, "Int"), "Int", NumGet(lvPt, 4, "Int"), hitInfo)
     hitRow := DllCall("SendMessageW", "Ptr", gViewer_LV.Hwnd, "UInt", 0x1012,
         "Ptr", 0, "Ptr", hitInfo, "Int")  ; LVM_HITTEST
@@ -922,11 +927,11 @@ _Viewer_CheckHover() {
     hwndUnder := DllCall("WindowFromPoint", "Int64", NumGet(pt, 0, "Int64"), "Ptr")
     newHotHdr := -1
     if (hwndUnder = gViewer_LVHeaderHwnd) {
-        hdrPt := Buffer(8, 0)
+        static hdrPt := Buffer(8, 0)
         NumPut("Int", NumGet(pt, 0, "Int"), "Int", NumGet(pt, 4, "Int"), hdrPt)
         DllCall("ScreenToClient", "Ptr", gViewer_LVHeaderHwnd, "Ptr", hdrPt)
         ; HDHITTESTINFO: POINT(8) + flags(4) + iItem(4) = 16
-        hdrHit := Buffer(16, 0)
+        static hdrHit := Buffer(16, 0)
         NumPut("Int", NumGet(hdrPt, 0, "Int"), "Int", NumGet(hdrPt, 4, "Int"), hdrHit)
         DllCall("SendMessageW", "Ptr", gViewer_LVHeaderHwnd, "UInt", 0x1206,
             "Ptr", 0, "Ptr", hdrHit)  ; HDM_HITTEST


### PR DESCRIPTION
## Summary

- Cache last cursor position in `_Theme_CheckButtonHover()` and `_Viewer_CheckHover()`; skip all Win32 hit-testing and tooltip logic when cursor hasn't moved
- Make DllCall marshal Buffer objects (`pt`, `lvPt`, `hitInfo`, `hdrPt`, `hdrHit`) `static` in viewer hover path per hot-path rules
- Both timers only fire for optional secondary windows (config editor, debug viewer), never during Alt-Tab

Closes #194

## Test plan

- [ ] Open config editor → verify button hover highlighting still works
- [ ] Open debug viewer → verify row hover highlighting and header hover work
- [ ] Open debug viewer → verify button tooltips appear/disappear on hover
- [ ] Leave cursor stationary over viewer → confirm no unnecessary repaints (no flickering)

Generated with [Claude Code](https://claude.com/claude-code)