### PR TITLE
Fix race conditions in komorebi handler and bypass reassert

### DIFF
--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -1074,6 +1074,7 @@ _KSub_OnNotification(jsonLine) {
             KSub_DiagLog("  WS event: " eventType " -> '" wsName "'")
         }
         if (wsName != "") {
+            Critical "On"
             global _KSub_LastWorkspaceName
             ; Capture old workspace BEFORE updating (needed for move events)
             previousWsName := _KSub_LastWorkspaceName
@@ -1124,6 +1125,7 @@ _KSub_OnNotification(jsonLine) {
 
             ; GUI notification is now handled inside WL_SetCurrentWorkspace itself.
             handledWorkspaceEvent := true
+            Critical "Off"
         }
     }
 
@@ -1145,6 +1147,7 @@ _KSub_OnNotification(jsonLine) {
     ; focused window = the one being moved). Patch it to the target workspace
     ; AFTER ProcessFullState to override any stale data.
     if (moveTargetHwnd && moveTargetWsName != "") {
+        Critical "On"
         global _KSub_WorkspaceCache
         try WL_UpdateFields(moveTargetHwnd, {
             workspaceName: moveTargetWsName,
@@ -1156,6 +1159,7 @@ _KSub_OnNotification(jsonLine) {
         _KSub_WorkspaceCache[moveTargetHwnd] := { wsName: moveTargetWsName, tick: A_TickCount }
         if (logEnabled)
             KSub_DiagLog("  Move post-fix: hwnd=" moveTargetHwnd " -> ws='" moveTargetWsName "'")
+        Critical "Off"
     }
 
     ; Deferred workspace update: MOVE events only. Now that ProcessFullState + post-fix
@@ -1596,7 +1600,9 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
             if (!gWS_Store.Has(hwnd))
                 continue
             if (!wsMapNames.Has(hwnd) && _KSub_WorkspaceCache.Has(hwnd)) {
-                cached := _KSub_WorkspaceCache[hwnd]
+                cached := _KSub_WorkspaceCache.Get(hwnd, 0)
+                if (!cached)
+                    continue
                 ; Check cache staleness - entries older than _KSub_CacheMaxAgeMs are skipped
                 if ((now - cached.tick) > _KSub_CacheMaxAgeMs) {
                     _KSub_WorkspaceCache.Delete(hwnd)  ; Clean up stale entry

--- a/src/gui/gui_interceptor.ahk
+++ b/src/gui/gui_interceptor.ahk
@@ -441,13 +441,17 @@ INT_SetBypassMode(shouldBypass) {
 ; Recovers from silent desync where Tab was left Off after a bypass toggle.
 ; Called from: focus-change callback (active use) and housekeeping timer (idle).
 INT_ReassertTabHotkey() {
+    Critical "On"
     global gINT_BypassMode
-    if (gINT_BypassMode)
+    if (gINT_BypassMode) {
+        Critical "Off"
         return
+    }
     try {
         Hotkey("$*Tab", "On")
         Hotkey("$*Tab Up", "On")
     }
+    Critical "Off"
 }
 
 _INT_BuildBypassList() {


### PR DESCRIPTION
## Summary

- **Komorebi workspace event**: Wrap `_KSub_LastWorkspaceName` + `_KSub_FocusedHwndByWS` read-modify-write in `Critical` to prevent interleaved notifications during rapid workspace switching from capturing wrong `previousWsName` → incorrect move target hwnd
- **Komorebi move post-fix**: Wrap `_KSub_WorkspaceCache` write after `ProcessFullState` in `Critical` to prevent another notification from reverting the move via stale cache → workspace label flicker
- **Workspace cache Has→read**: Replace `_KSub_WorkspaceCache[hwnd]` with `.Get(hwnd, 0)` + null check to prevent key-not-found error when `PruneStaleCache` timer deletes between `.Has()` and `[]` access (matches existing RACE FIX pattern at line 1528)
- **Bypass mode reassert**: Add `Critical` to `INT_ReassertTabHotkey` to prevent Tab re-enable racing with `INT_SetBypassMode` during game bypass

All fixes are in producer callbacks (not hotkey input path) — zero latency impact.

Closes #196

## Test plan

- [ ] Pre-gate static analysis passes (no new failures)
- [ ] Rapid workspace switching with komorebi — no wrong workspace labels
- [ ] Move window to another workspace — label updates correctly without flicker
- [ ] Fullscreen game bypass — Tab not briefly intercepted during focus transitions
- [ ] Normal Alt-Tab operation unaffected

Generated with [Claude Code](https://claude.com/claude-code)