### PR TITLE
Add test coverage for flight recorder, config array sections, ALT_DOWN invariant

### DIFF
--- a/tests/gui_tests_state.ahk
+++ b/tests/gui_tests_state.ahk
@@ -573,6 +573,58 @@ RunGUITests_State() {
 
     gFR_DumpInProgress := false
 
+    ; ============================================================
+    ; ALT_DOWN DURING ACTIVE STATE — INVARIANT TESTS
+    ; Alt key repeats fire ALT_DOWN while state is ACTIVE.
+    ; The handler must NOT corrupt gGUI_DisplayItems or gGUI_Sel.
+    ; Regression guard for commit e9a284b class of bugs.
+    ; ============================================================
+
+    ; ----- Test: Alt repeat during ACTIVE preserves display items -----
+    GUI_Log("Test: Alt repeat during ACTIVE preserves display items")
+    ResetGUIState()
+    SetupTestItems(5)
+
+    GUI_OnInterceptorEvent(TABBY_EV_ALT_DOWN, 0, 0)
+    GUI_OnInterceptorEvent(TABBY_EV_TAB_STEP, 0, 0)
+    GUI_AssertEq(gGUI_State, "ACTIVE", "AltRepeat setup: state is ACTIVE")
+    GUI_AssertEq(gGUI_DisplayItems.Length, 5, "AltRepeat setup: display items frozen (5)")
+
+    ; Save reference to display items before alt repeat
+    savedDisplayRef := gGUI_DisplayItems
+    savedDisplayLen := gGUI_DisplayItems.Length
+    savedFirstHwnd := gGUI_DisplayItems[1].hwnd
+
+    ; Fire ALT_DOWN during ACTIVE (simulates keyboard auto-repeat)
+    GUI_OnInterceptorEvent(TABBY_EV_ALT_DOWN, 0, 0)
+
+    ; Display items must be untouched (same array ref, same content)
+    GUI_AssertTrue(gGUI_DisplayItems == savedDisplayRef, "AltRepeat: display items same array reference")
+    GUI_AssertEq(gGUI_DisplayItems.Length, savedDisplayLen, "AltRepeat: display items length unchanged")
+    GUI_AssertEq(gGUI_DisplayItems[1].hwnd, savedFirstHwnd, "AltRepeat: display items[1] unchanged")
+
+    ; ----- Test: Alt repeat during ACTIVE preserves selection -----
+    GUI_Log("Test: Alt repeat during ACTIVE preserves selection")
+    ResetGUIState()
+    SetupTestItems(5)
+
+    GUI_OnInterceptorEvent(TABBY_EV_ALT_DOWN, 0, 0)
+    GUI_OnInterceptorEvent(TABBY_EV_TAB_STEP, 0, 0)
+    GUI_AssertEq(gGUI_Sel, 2, "AltRepeat sel setup: initial sel=2")
+
+    ; Advance selection to 3
+    GUI_OnInterceptorEvent(TABBY_EV_TAB_STEP, 0, 0)
+    GUI_AssertEq(gGUI_Sel, 3, "AltRepeat sel setup: sel=3 after 2nd Tab")
+
+    ; Fire ALT_DOWN during ACTIVE — sel should NOT be reset
+    GUI_OnInterceptorEvent(TABBY_EV_ALT_DOWN, 0, 0)
+    GUI_AssertEq(gGUI_Sel, 3, "AltRepeat sel: sel preserved at 3 (not reset by ALT_DOWN)")
+
+    ; Fire TAB_STEP — should work correctly after alt repeat
+    GUI_OnInterceptorEvent(TABBY_EV_TAB_STEP, 0, 0)
+    ; After ALT_DOWN, state is ALT_PENDING, so this TAB_STEP is a "first Tab" → sel=2
+    GUI_AssertEq(gGUI_Sel, 2, "AltRepeat sel: TAB_STEP after alt repeat produces sel=2 (re-freeze)")
+
     ; ----- Summary -----
     GUI_Log("`n=== GUI State Tests Summary ===")
     GUI_Log("Passed: " GUI_TestPassed)

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -589,9 +589,13 @@ $guiScript = "$PSScriptRoot\gui_tests.ahk"
 $guiLogFile = "$env:TEMP\gui_tests_${worktreeId}.log"
 $guiHandle = [IntPtr]::Zero
 $guiTimingRecorded = $false
+$frScript = "$PSScriptRoot\test_unit_flight_recorder.ahk"
+$frLogFile = "$env:TEMP\fr_tests_${worktreeId}.log"
+$frHandle = [IntPtr]::Zero
 $compileHandle = [IntPtr]::Zero
 
 Remove-Item -Force -ErrorAction SilentlyContinue $guiLogFile
+Remove-Item -Force -ErrorAction SilentlyContinue $frLogFile
 
 # --- Live mode: Kill AltTabby + start compilation early (background) ---
 # Compilation overlaps with pre-gate checks to save ~3s on the critical path.
@@ -645,7 +649,8 @@ $filesToCheck = @(
     "$srcRoot\gui\gui_paint.ahk",
     "$srcRoot\gui\gui_input.ahk",
     "$srcRoot\gui\gui_overlay.ahk",
-    "$PSScriptRoot\gui_tests.ahk"
+    "$PSScriptRoot\gui_tests.ahk",
+    "$PSScriptRoot\test_unit_flight_recorder.ahk"
 )
 
 # Launch all syntax checks in parallel — direct AHK launch with captured output
@@ -799,6 +804,10 @@ $guiStartTickMs = $masterSw.ElapsedMilliseconds
 if (Test-Path $guiScript) {
     Write-Host "Starting GUI tests in background..." -ForegroundColor Cyan
     $guiHandle = [SilentProcess]::Start('"' + $ahk + '" /ErrorStdOut "' + $guiScript + '"')
+}
+if (Test-Path $frScript) {
+    Write-Host "Starting flight recorder tests in background..." -ForegroundColor Cyan
+    $frHandle = [SilentProcess]::Start('"' + $ahk + '" /ErrorStdOut "' + $frScript + '"')
 }
 
 # Launch unit suites immediately (they don't need compilation)
@@ -1218,6 +1227,20 @@ if ($guiHandle -ne [IntPtr]::Zero) {
     }
 } else {
     Write-Host "  SKIP: gui_tests.ahk not found" -ForegroundColor Yellow
+}
+
+# --- Flight Recorder Tests Phase (Collect Results) ---
+Write-Host "`n--- Flight Recorder Tests Phase ---" -ForegroundColor Yellow
+
+if ($frHandle -ne [IntPtr]::Zero) {
+    $frExitCode = [SilentProcess]::WaitAndGetExitCode($frHandle)
+    Show-TestSummary -LogPath $frLogFile -Label "FlightRecorder"
+
+    if ($frExitCode -ne 0) {
+        $mainExitCode = $frExitCode
+    }
+} else {
+    Write-Host "  SKIP: test_unit_flight_recorder.ahk not found" -ForegroundColor Yellow
 }
 
 Show-TimingReport

--- a/tests/test_unit_core_config.ahk
+++ b/tests/test_unit_core_config.ahk
@@ -968,4 +968,179 @@ RunUnitTests_CoreConfig() {
     ; Restore
     cfg.PumpPipeName := savedPipe
     cfg.AltTabGraceMs := savedGrace
+
+    ; ============================================================
+    ; Config Array Section Load / Normalize / Prune Tests
+    ; ============================================================
+    ; Tests {N} template expansion, excess pruning, gap normalization,
+    ; and CL_DeleteSections edge cases for array sections ([Shader.1]...[Shader.4]).
+    Log("`n--- Config Array Section Tests ---")
+
+    global gConfigIniPath, gConfigLoaded
+    savedIniPath2 := gConfigIniPath
+    savedLoaded2 := gConfigLoaded
+
+    ; Test 1: Array section basic load — {N} template expansion
+    Log("Testing array section basic load...")
+    _Test_WithTempDir("tabby_array_test", _Test_ArraySectionLoad)
+    _Test_ArraySectionLoad(dir) {
+        global TestPassed, TestErrors, gConfigIniPath, cfg
+
+        testCfgPath := dir "\config.ini"
+        gConfigIniPath := testCfgPath
+
+        ; Write [Shader.1] and [Shader.2] with known ShaderName values (IniWrite avoids UTF-8 BOM issues)
+        IniWrite("testShader1", testCfgPath, "Shader.1", "ShaderName")
+        IniWrite("testShader2", testCfgPath, "Shader.2", "ShaderName")
+
+        _CL_InitializeDefaults()
+        _CL_LoadAllSettings()
+
+        ; Verify {N} expansion: cfg.Shader1_ShaderName and cfg.Shader2_ShaderName
+        if (cfg.Shader1_ShaderName = "testShader1" && cfg.Shader2_ShaderName = "testShader2") {
+            Log("PASS: Array section load — {N} template expansion works")
+            TestPassed++
+        } else {
+            Log("FAIL: Array section load — expected Shader1=testShader1, Shader2=testShader2")
+            Log("  Got: Shader1=" cfg.Shader1_ShaderName ", Shader2=" cfg.Shader2_ShaderName)
+            TestErrors++
+        }
+    }
+
+    ; Test 2: Excess pruning — [Shader.5] removed when max is 4
+    Log("Testing excess array section pruning...")
+    _Test_WithTempDir("tabby_prune_test", _Test_ArraySectionPrune)
+    _Test_ArraySectionPrune(dir) {
+        global TestPassed, TestErrors, gConfigIniPath
+
+        testCfgPath := dir "\config.ini"
+        gConfigIniPath := testCfgPath
+
+        ; Write [Shader.1] (valid) and [Shader.5] (excess — max is 4)
+        IniWrite("valid", testCfgPath, "Shader.1", "ShaderName")
+        IniWrite("excess", testCfgPath, "Shader.5", "ShaderName")
+
+        arraySections := Map("Shader", 4)
+        _CL_PruneExcessArraySections(arraySections)
+
+        ; Read back and verify [Shader.5] was removed
+        result := FileRead(testCfgPath, "UTF-8")
+        hasValid := InStr(result, "[Shader.1]")
+        hasExcess := InStr(result, "[Shader.5]")
+
+        if (hasValid && !hasExcess) {
+            Log("PASS: Excess pruning — [Shader.5] removed, [Shader.1] preserved")
+            TestPassed++
+        } else {
+            Log("FAIL: Excess pruning — valid=" hasValid ", excess=" hasExcess)
+            Log("  Content: " SubStr(result, 1, 200))
+            TestErrors++
+        }
+    }
+
+    ; Test 3: Gap normalization — [Shader.1] + [Shader.4] compacted to [Shader.1] + [Shader.2]
+    Log("Testing gap normalization...")
+    _Test_WithTempDir("tabby_normalize_test", _Test_ArraySectionNormalize)
+    _Test_ArraySectionNormalize(dir) {
+        global TestPassed, TestErrors, gConfigIniPath, cfg
+
+        testCfgPath := dir "\config.ini"
+        gConfigIniPath := testCfgPath
+
+        ; Write [Shader.1] and [Shader.4] (skip .2/.3 — creates a gap)
+        IniWrite("first", testCfgPath, "Shader.1", "ShaderName")
+        IniWrite("fourth", testCfgPath, "Shader.4", "ShaderName")
+
+        ; Full load cycle: init defaults, load settings (which prunes + normalizes)
+        _CL_InitializeDefaults()
+        _CL_LoadAllSettings()
+
+        ; After normalization: .4 should be shifted to .2 in cfg
+        normalizeOk := true
+        if (cfg.Shader1_ShaderName != "first") {
+            Log("FAIL: Normalization — Shader1 expected 'first', got '" cfg.Shader1_ShaderName "'")
+            normalizeOk := false
+        }
+        if (cfg.Shader2_ShaderName != "fourth") {
+            Log("FAIL: Normalization — Shader2 expected 'fourth' (shifted from .4), got '" cfg.Shader2_ShaderName "'")
+            normalizeOk := false
+        }
+
+        ; Verify INI was rewritten with [Shader.2], not [Shader.4]
+        result := FileRead(testCfgPath, "UTF-8")
+        if (InStr(result, "[Shader.4]")) {
+            Log("FAIL: Normalization — [Shader.4] still in INI after normalization")
+            normalizeOk := false
+        }
+
+        if (normalizeOk) {
+            Log("PASS: Gap normalization — .4 shifted to .2 in cfg and INI")
+            TestPassed++
+        } else {
+            TestErrors++
+        }
+    }
+
+    ; Test 4: No-op when contiguous — [Shader.1] + [Shader.2] unchanged
+    Log("Testing normalization no-op for contiguous sections...")
+    _Test_WithTempDir("tabby_noop_test", _Test_ArraySectionNoOp)
+    _Test_ArraySectionNoOp(dir) {
+        global TestPassed, TestErrors, gConfigIniPath, cfg
+
+        testCfgPath := dir "\config.ini"
+        gConfigIniPath := testCfgPath
+
+        IniWrite("alpha", testCfgPath, "Shader.1", "ShaderName")
+        IniWrite("beta", testCfgPath, "Shader.2", "ShaderName")
+
+        _CL_InitializeDefaults()
+        _CL_LoadAllSettings()
+
+        ; Values should be unchanged (no shift needed)
+        if (cfg.Shader1_ShaderName = "alpha" && cfg.Shader2_ShaderName = "beta") {
+            Log("PASS: No-op normalization — contiguous sections preserved")
+            TestPassed++
+        } else {
+            Log("FAIL: No-op normalization — Shader1=" cfg.Shader1_ShaderName ", Shader2=" cfg.Shader2_ShaderName)
+            TestErrors++
+        }
+    }
+
+    ; Test 5: CL_DeleteSections handles duplicate section headers
+    Log("Testing CL_DeleteSections with duplicates...")
+    _Test_WithTempDir("tabby_delsec_test", _Test_DeleteSectionsDuplicates)
+    _Test_DeleteSectionsDuplicates(dir) {
+        global TestPassed, TestErrors, gConfigIniPath
+
+        testCfgPath := dir "\config.ini"
+        gConfigIniPath := testCfgPath
+
+        ; Write INI with duplicate [Shader.3] headers and a keeper section
+        ; Use UTF-8-RAW to avoid BOM issues with section header parsing
+        content := "[Shader.1]`nShaderName=keep`n[Shader.3]`nShaderName=dup1`n[Other]`nFoo=bar`n[Shader.3]`nShaderName=dup2`n"
+        FileAppend(content, testCfgPath, "UTF-8-RAW")
+
+        CL_DeleteSections(["Shader.3"])
+
+        result := FileRead(testCfgPath, "UTF-8")
+        hasDup := InStr(result, "[Shader.3]")
+        hasKeeper := InStr(result, "[Shader.1]")
+        hasOther := InStr(result, "[Other]")
+
+        if (!hasDup && hasKeeper && hasOther) {
+            Log("PASS: CL_DeleteSections — all [Shader.3] duplicates removed, [Shader.1] and [Other] preserved")
+            TestPassed++
+        } else {
+            Log("FAIL: CL_DeleteSections — dup=" hasDup ", keeper=" hasKeeper ", other=" hasOther)
+            Log("  Content: " SubStr(result, 1, 300))
+            TestErrors++
+        }
+    }
+
+    ; Restore original config state
+    gConfigIniPath := savedIniPath2
+    gConfigLoaded := savedLoaded2
+    _CL_InitializeDefaults()
+    _CL_LoadAllSettings()
+    _CL_ValidateSettings()
 }

--- a/tests/test_unit_flight_recorder.ahk
+++ b/tests/test_unit_flight_recorder.ahk
@@ -1,0 +1,241 @@
+; Flight Recorder Ring Buffer Tests
+; Tests FR_Record() wraparound, slot population, and disabled guard.
+; Standalone file — must NOT be included in test chains that stub FR_Record.
+#Requires AutoHotkey v2.0
+#Warn VarUnset, Off
+A_IconHidden := true  ; No tray icon during tests
+
+; Worktree-scoped log path
+SplitPath(A_ScriptDir, , &_frWorktreeParent)
+SplitPath(_frWorktreeParent, &_frWorktreeId)
+global FR_TestLogPath := A_Temp "\fr_tests_" _frWorktreeId ".log"
+
+; Test tracking
+global FR_TestPassed := 0
+global FR_TestFailed := 0
+
+; ============================================================
+; MOCKS (defined BEFORE gui_flight_recorder.ahk include)
+; ============================================================
+
+; Mock QPC — incrementing counter for predictable timestamps
+global gMock_QPCCounter := 0
+QPC() {
+    global gMock_QPCCounter
+    gMock_QPCCounter += 1
+    return gMock_QPCCounter
+}
+
+; Mocks for functions called inside _FR_Dump/_FR_DumpPhase2/_FR_ShowNoteDialog.
+; Never called in tests, but AHK v2 needs them defined at load time.
+GUI_ForceReset() {
+}
+GUI_HideOverlay() {
+}
+GUI_GetItemWSName(item) {
+    return ""
+}
+GUI_GetItemIsOnCurrent(item) {
+    return true
+}
+GUI_AntiFlashPrepare(params*) {
+}
+GUI_AntiFlashReveal(params*) {
+}
+Theme_GetBgColor() {
+    return "000000"
+}
+Theme_ApplyToGui(params*) {
+    return ""
+}
+Theme_GetAccentColor() {
+    return "FFFFFF"
+}
+Theme_ApplyToControl(params*) {
+}
+Theme_MarkAccent(params*) {
+}
+Theme_UntrackGui(params*) {
+}
+
+; Globals referenced by _FR_Dump() / FR_Init() in gui_flight_recorder.ahk.
+; Never called in tests, but static analysis requires declarations.
+global cfg := {DiagFlightRecorder: false, DiagFlightRecorderBufferSize: 2000, DiagFlightRecorderHotkey: "F12"}
+global gGUI_State := "IDLE"
+global gGUI_LiveItems := []
+global gGUI_LiveItemsMap := Map()
+global gGUI_DisplayItems := []
+global gGUI_Sel := 1
+global gGUI_PendingPhase := ""
+global gGUI_CurrentWSName := ""
+global gGUI_OverlayVisible := false
+global gGUI_ScrollTop := 0
+global gINT_SessionActive := false
+global gINT_BypassMode := false
+global gINT_AltIsDown := false
+global gINT_TabPending := false
+global gINT_PressCount := 0
+global gINT_TabHeld := false
+global gINT_AltUpDuringPending := false
+global gINT_PendingDecideArmed := false
+global gWS_Rev := 0
+global gWS_Store := Map()
+global gWS_SortOrderDirty := false
+global gWS_ContentDirty := false
+global gWS_MRUBumpOnly := false
+global gWS_DirtyHwnds := Map()
+global gWS_IconQueue := []
+global gWS_PidQueue := []
+global gWS_ZQueue := []
+
+; ============================================================
+; INCLUDE PRODUCTION CODE
+; ============================================================
+#Include %A_ScriptDir%\..\src\gui\gui_flight_recorder.ahk
+
+; ============================================================
+; TEST UTILITIES
+; ============================================================
+
+FR_ResetBuffer(size := 5) {
+    global gFR_Enabled, gFR_Size, gFR_Buffer, gFR_Idx, gFR_Count, gMock_QPCCounter
+    gFR_Enabled := true
+    gFR_Size := size
+    gFR_Buffer := []
+    gFR_Buffer.Length := size
+    Loop size
+        gFR_Buffer[A_Index] := [0, 0, 0, 0, 0, 0]
+    gFR_Idx := 0
+    gFR_Count := 0
+    gMock_QPCCounter := 0
+}
+
+FR_AssertEq(actual, expected, testName) {
+    global FR_TestPassed, FR_TestFailed
+    if (actual = expected) {
+        FR_TestPassed++
+        return true
+    }
+    FR_TestFailed++
+    FR_Log("FAIL: " testName " - Expected: " expected ", Got: " actual)
+    return false
+}
+
+FR_Log(msg) {
+    global FR_TestLogPath
+    FileAppend(msg "`n", FR_TestLogPath, "UTF-8")
+}
+
+; ============================================================
+; TESTS
+; ============================================================
+
+RunFlightRecorderTests() {
+    global FR_TestPassed, FR_TestFailed
+    global gFR_Enabled, gFR_Buffer, gFR_Idx, gFR_Size, gFR_Count
+    global FR_EV_ALT_DN, FR_EV_TAB_DN, FR_EV_STATE, FR_EV_FREEZE, FR_EV_SESSION_START
+
+    FR_Log("=== Flight Recorder Ring Buffer Tests ===")
+
+    ; ----- Test 1: Single record populates slot 1 -----
+    FR_Log("Test: Single record populates slot 1")
+    FR_ResetBuffer(5)
+
+    FR_Record(FR_EV_ALT_DN, 10, 20, 30, 40)
+
+    FR_AssertEq(gFR_Idx, 1, "Single: idx=1")
+    FR_AssertEq(gFR_Count, 1, "Single: count=1")
+    b := gFR_Buffer[1]
+    FR_AssertEq(b[1], 1, "Single: timestamp=1 (first QPC call)")
+    FR_AssertEq(b[2], FR_EV_ALT_DN, "Single: event=FR_EV_ALT_DN")
+    FR_AssertEq(b[3], 10, "Single: d1=10")
+    FR_AssertEq(b[4], 20, "Single: d2=20")
+    FR_AssertEq(b[5], 30, "Single: d3=30")
+    FR_AssertEq(b[6], 40, "Single: d4=40")
+
+    ; ----- Test 2: Fill buffer to capacity -----
+    FR_Log("Test: Fill buffer to capacity (5 records)")
+    FR_ResetBuffer(5)
+
+    FR_Record(FR_EV_ALT_DN, 1, 0, 0, 0)
+    FR_Record(FR_EV_TAB_DN, 2, 0, 0, 0)
+    FR_Record(FR_EV_STATE, 3, 0, 0, 0)
+    FR_Record(FR_EV_FREEZE, 4, 0, 0, 0)
+    FR_Record(FR_EV_SESSION_START, 5, 0, 0, 0)
+
+    FR_AssertEq(gFR_Idx, 5, "Full: idx=5")
+    FR_AssertEq(gFR_Count, 5, "Full: count=5")
+    FR_AssertEq(gFR_Buffer[1][2], FR_EV_ALT_DN, "Full: slot 1 = ALT_DN")
+    FR_AssertEq(gFR_Buffer[2][2], FR_EV_TAB_DN, "Full: slot 2 = TAB_DN")
+    FR_AssertEq(gFR_Buffer[3][2], FR_EV_STATE, "Full: slot 3 = STATE")
+    FR_AssertEq(gFR_Buffer[4][2], FR_EV_FREEZE, "Full: slot 4 = FREEZE")
+    FR_AssertEq(gFR_Buffer[5][2], FR_EV_SESSION_START, "Full: slot 5 = SESSION_START")
+
+    ; ----- Test 3: Wraparound — 6th record overwrites slot 1 -----
+    FR_Log("Test: 6th record wraps to slot 1")
+    FR_ResetBuffer(5)
+
+    Loop 5
+        FR_Record(FR_EV_STATE, A_Index, 0, 0, 0)
+
+    ; 6th record should wrap to slot 1
+    FR_Record(FR_EV_ALT_DN, 99, 0, 0, 0)
+
+    FR_AssertEq(gFR_Idx, 1, "Wrap: idx=1 (wrapped)")
+    FR_AssertEq(gFR_Count, 6, "Wrap: count=6")
+    FR_AssertEq(gFR_Buffer[1][2], FR_EV_ALT_DN, "Wrap: slot 1 overwritten with ALT_DN")
+    FR_AssertEq(gFR_Buffer[1][3], 99, "Wrap: slot 1 d1=99")
+    ; Slots 2-5 should still have original data
+    FR_AssertEq(gFR_Buffer[2][3], 2, "Wrap: slot 2 preserved (d1=2)")
+    FR_AssertEq(gFR_Buffer[5][3], 5, "Wrap: slot 5 preserved (d1=5)")
+
+    ; ----- Test 4: Double wraparound — 12 records (2+ full cycles) -----
+    FR_Log("Test: 12 records (2+ full cycles)")
+    FR_ResetBuffer(5)
+
+    Loop 12
+        FR_Record(FR_EV_STATE, A_Index, 0, 0, 0)
+
+    FR_AssertEq(gFR_Idx, 2, "Double: idx=2 (12 mod 5 = 2)")
+    FR_AssertEq(gFR_Count, 12, "Double: count=12")
+    ; Latest 5 records (8-12) occupy slots: 3,4,5,1,2
+    FR_AssertEq(gFR_Buffer[3][3], 8, "Double: slot 3 = record 8")
+    FR_AssertEq(gFR_Buffer[4][3], 9, "Double: slot 4 = record 9")
+    FR_AssertEq(gFR_Buffer[5][3], 10, "Double: slot 5 = record 10")
+    FR_AssertEq(gFR_Buffer[1][3], 11, "Double: slot 1 = record 11")
+    FR_AssertEq(gFR_Buffer[2][3], 12, "Double: slot 2 = record 12")
+
+    ; ----- Test 5: Disabled guard prevents recording -----
+    FR_Log("Test: Disabled guard prevents recording")
+    FR_ResetBuffer(5)
+
+    ; Record one event to verify buffer works
+    FR_Record(FR_EV_ALT_DN, 1, 0, 0, 0)
+    FR_AssertEq(gFR_Count, 1, "Guard setup: 1 record written")
+
+    ; Disable and try to record
+    gFR_Enabled := false
+    FR_Record(FR_EV_TAB_DN, 99, 0, 0, 0)
+
+    FR_AssertEq(gFR_Count, 1, "Guard: count unchanged (still 1)")
+    FR_AssertEq(gFR_Idx, 1, "Guard: idx unchanged (still 1)")
+    FR_AssertEq(gFR_Buffer[2][2], 0, "Guard: slot 2 not written (ev=0)")
+
+    ; ----- Summary -----
+    FR_Log("`n=== Flight Recorder Tests Summary ===")
+    FR_Log("Passed: " FR_TestPassed)
+    FR_Log("Failed: " FR_TestFailed)
+    FR_Log("Result: " (FR_TestFailed = 0 ? "ALL TESTS PASSED" : "SOME TESTS FAILED"))
+
+    return FR_TestFailed = 0
+}
+
+; ============================================================
+; ENTRY POINT
+; ============================================================
+
+if (A_ScriptFullPath = A_LineFile) {
+    try FileDelete(FR_TestLogPath)
+    result := RunFlightRecorderTests()
+    ExitApp(result ? 0 : 1)
+}


### PR DESCRIPTION
## Summary

- **Flight recorder ring buffer**: New standalone `test_unit_flight_recorder.ahk` with 5 tests (32 assertions) covering FR_Record() wraparound, slot population, fill-to-capacity, double wraparound, and disabled guard
- **Config array section load/normalize/prune**: 5 tests added to `test_unit_core_config.ahk` covering `{N}` template expansion, excess pruning (`[Shader.5]` beyond max 4), gap normalization (`.1+.4` → `.1+.2`), contiguous no-op, and `CL_DeleteSections` duplicate header removal
- **ALT_DOWN during ACTIVE state**: 2 tests added to `gui_tests_state.ahk` verifying keyboard auto-repeat doesn't corrupt display items or reset selection (regression guard for `e9a284b` class of bugs)
- FR test registered in `test.ps1` as parallel background process with syntax checking

Closes #200

## Test plan

- [x] Flight recorder tests pass standalone (32/32 assertions)
- [x] GUI state tests pass including new ALT_DOWN invariant tests (122 total)
- [x] Config unit tests pass including new array section tests
- [x] Full unit test suite passes (no regressions)
- [x] Static analysis passes for new test file (all globals declared, cfg properties mocked)

Generated with [Claude Code](https://claude.com/claude-code)