### PR TITLE
Clean up user-facing error messages and config descriptions

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -339,8 +339,8 @@ if (g_AltTabbyMode = "repair-admin-task") {
 
         if (exitCode != 0) {
             ; Task run failed - launch directly instead
-            ThemeMsgBox("Admin mode was repaired, but the scheduled task could not start`n"
-                "(exit code " exitCode ").`n`nLaunching Alt-Tabby directly instead.", APP_NAME, "Icon!")
+            ThemeMsgBox("Admin mode was repaired, but the scheduled task could not start.`n`n"
+                "Launching Alt-Tabby directly instead.", APP_NAME, "Icon!")
             Run('"' exePath '"')
         }
     } else {

--- a/src/gui/gui_capture.ahk
+++ b/src/gui/gui_capture.ahk
@@ -126,7 +126,7 @@ _Capture_Screenshot() {
         DllCall("DeleteObject", "Ptr", hBitmap)
         DllCall("DeleteDC", "Ptr", hMemDC)
         DllCall("ReleaseDC", "Ptr", 0, "Ptr", hScreenDC)
-        ToolTip("Screenshot failed: GdipCreateBitmap error " gdipResult)
+        ToolTip("Screenshot failed (bitmap creation error)")
         SetTimer(() => ToolTip(), -3000)
         return
     }
@@ -146,7 +146,7 @@ _Capture_Screenshot() {
     DllCall("ReleaseDC", "Ptr", 0, "Ptr", hScreenDC)
 
     if (saveResult != 0) {
-        ToolTip("Screenshot failed: GdipSave error " saveResult " path=" filePath)
+        ToolTip("Screenshot failed (could not save to " fileName ")")
         SetTimer(() => ToolTip(), -5000)
         return
     }

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -344,7 +344,7 @@ FX_PreRenderShaderLayers(w, h) {
                 errDetail .= " extra=" e.Extra
             if (e.HasProp("Number") && e.Number != 0)
                 errDetail .= " hr=" Format("0x{:08x}", e.Number & 0xFFFFFFFF)
-            ToolTip(errDetail)
+            ToolTip("Shader effect failed — using fallback")
             SetTimer(() => ToolTip(), -5000)
             if (cfg.DiagShaderLog)
                 LogAppend(LOG_PATH_SHADER, errDetail)
@@ -434,7 +434,7 @@ FX_PreRenderMouseEffect(w, h) {
     } catch as e {
         global LOG_PATH_SHADER
         errDetail := "Mouse shader ERR [" gFX_MouseEffect.key "]: " e.Message " @ " e.What
-        ToolTip(errDetail)
+        ToolTip("Mouse effect failed — using fallback")
         SetTimer(() => ToolTip(), -5000)
         if (cfg.DiagShaderLog)
             LogAppend(LOG_PATH_SHADER, errDetail)
@@ -517,7 +517,7 @@ FX_PreRenderSelectionEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, b
     } catch as e {
         global LOG_PATH_SHADER
         errDetail := "Selection shader ERR [" gFX_SelectionEffect.key "]: " e.Message " @ " e.What
-        ToolTip(errDetail)
+        ToolTip("Selection effect failed — using fallback")
         SetTimer(() => ToolTip(), -5000)
         if (cfg.DiagShaderLog)
             LogAppend(LOG_PATH_SHADER, errDetail)
@@ -1118,7 +1118,7 @@ FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borde
     } catch as e {
         global LOG_PATH_SHADER
         errDetail := "Hover shader ERR [" gFX_HoverEffect.key "]: " e.Message " @ " e.What
-        ToolTip(errDetail)
+        ToolTip("Hover effect failed — using fallback")
         SetTimer(() => ToolTip(), -5000)
         if (cfg.DiagShaderLog)
             LogAppend(LOG_PATH_SHADER, errDetail)

--- a/src/launcher/launcher_install.ahk
+++ b/src/launcher/launcher_install.ahk
@@ -212,7 +212,7 @@ Launcher_ShowMismatchDialog(installedPath, title := "", message := "", question 
     result := ""  ; Will be set by button clicks
 
     ; Buttons: [Launch Installed] [Always Run From Here] ... gap ... [Run This Copy]
-    btnYes := mismatchGui.AddButton("x24 w140 y+24 Default", "Launch Installed")
+    btnYes := mismatchGui.AddButton("x24 w140 y+24 Default", "Run Installed")
     btnAlways := mismatchGui.AddButton("x+8 w170", "Always Run From Here")
     btnNo := mismatchGui.AddButton("x" (24 + contentW - 120) " yp w120", "Run This Copy")
 

--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -978,10 +978,10 @@ global gConfigRegistry := [
     {s: "Komorebi", k: "CrossWorkspaceMethod", g: "KomorebiCrossWorkspaceMethod", t: "enum", default: "MimicNative",
      options: ["MimicNative", "RevealMove", "SwitchActivate"],
      d: "How Alt-Tabby activates windows on other workspaces.`n"
-      . "MimicNative = directly uncloaks and activates via COM (like native Alt+Tab), letting komorebi reconcile.`n"
-      . "RevealMove = uncloaks window, focuses it, then commands komorebi to move it back to its workspace.`n"
+      . "MimicNative = directly reveals and activates using Windows APIs (like native Alt+Tab), letting komorebi sync its layout.`n"
+      . "RevealMove = reveals the window, focuses it, then commands komorebi to move it back to its workspace.`n"
       . "SwitchActivate = commands komorebi to switch first, waits for confirmation, then activates (may flash previously focused window).`n"
-      . "MimicNative and RevealMove require COM and fall back to SwitchActivate if COM fails."},
+      . "MimicNative and RevealMove fall back to SwitchActivate if activation fails."},
 
     {s: "Komorebi", k: "MimicNativeSettleMs", g: "KomorebiMimicNativeSettleMs", t: "int", default: 0,
      min: 0, max: 1000,
@@ -994,7 +994,7 @@ global gConfigRegistry := [
      options: ["PollKomorebic", "PollCloak", "AwaitDelta"],
      d: "How Alt-Tabby verifies a workspace switch completed (only used when CrossWorkspaceMethod=SwitchActivate).`n"
       . "PollKomorebic = polls komorebic CLI (spawns cmd.exe every 15ms), works on multi-monitor but highest CPU.`n"
-      . "PollCloak = checks DWM cloaked state (recommended, sub-microsecond DllCall).`n"
+      . "PollCloak = checks if windows are hidden (recommended, fastest method).`n"
       . "AwaitDelta = waits for store delta, lowest CPU but potentially higher latency."},
 
     {type: "subsection", section: "Komorebi", name: "Subscription",
@@ -1002,11 +1002,11 @@ global gConfigRegistry := [
 
     {s: "Komorebi", k: "SubPollMs", g: "KomorebiSubPollMs", t: "int", default: 50,
      min: 10, max: 1000,
-     d: "Legacy pipe poll interval. Used when async I/O is unavailable."},
+     d: "Legacy pipe poll interval. Used when overlapped I/O is unavailable."},
 
     {s: "Komorebi", k: "SubMaintenanceMs", g: "KomorebiSubMaintenanceMs", t: "int", default: 2000,
      min: 500, max: 10000,
-     d: "Maintenance timer interval when async I/O is active (idle recycle, connection check, read recovery). Ignored in legacy poll mode."},
+     d: "Background maintenance interval for subscription health monitoring. Ignored in legacy poll mode."},
 
     {s: "Komorebi", k: "SubIdleRecycleMs", g: "KomorebiSubIdleRecycleMs", t: "int", default: 120000,
      min: 10000, max: 600000,
@@ -1108,7 +1108,7 @@ global gConfigRegistry := [
 
     {s: "Store", k: "PumpIconPruneIntervalMs", g: "PumpIconPruneIntervalMs", t: "int", default: 300000,
      min: 10000, max: 3600000,
-     d: "Interval (ms) for pump to prune HICONs of closed windows"},
+     d: "Interval to clean up cached icons for closed windows"},
 
     {s: "Store", k: "PumpHangTimeoutMs", g: "PumpHangTimeoutMs", t: "int", default: 15000,
      min: 5000, max: 60000,
@@ -1128,7 +1128,7 @@ global gConfigRegistry := [
 
     {s: "Store", k: "DebounceMs", g: "WinEventHookDebounceMs", t: "int", default: 50,
      min: 10, max: 1000,
-     d: "Debounce rapid events (e.g., window moving fires many events)"},
+     d: "Ignore rapid duplicate events (e.g., dragging a window fires many events)"},
 
     {s: "Store", k: "BatchMs", g: "WinEventHookBatchMs", t: "int", default: 100,
      min: 10, max: 2000,


### PR DESCRIPTION
## Summary

- Replace shader error tooltips (4 locations in `gui_effects.ahk`) with friendly messages like "Shader effect failed — using fallback" instead of exposing internal error codes and function names; technical details still logged to shader log
- Remove raw exit code from admin repair dialog in `alt_tabby.ahk`
- Standardize mismatch dialog button verb from "Launch Installed" to "Run Installed" for consistency with "Run This Copy"
- Simplify screenshot error tooltips in `gui_capture.ahk` — no more GDI+ status codes or full file paths
- Reword 5 config descriptions in `config_registry.ahk` to remove jargon (HICONs, debounce, uncloaks, COM, sub-microsecond DllCall, async I/O)

Closes #198

## Test plan

- [ ] Static analysis passes (pre-existing failures only)
- [ ] Set a shader name to an invalid value in config.ini, launch, confirm tooltip shows friendly message
- [ ] Grep for old strings (`"Shader ERR"`, `"GdipCreateBitmap error"`, `"Launch Installed"`, `"HICONs"`, `"exit code"`) to confirm all replaced
- [ ] Visual check: config editor descriptions read naturally without jargon

Generated with [Claude Code](https://claude.com/claude-code)