### PR TITLE
Move 6 global declarations to sole-writer files (manifest 23→17)

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -33,13 +33,7 @@ gGUI_HoverRow: gui_input, gui_paint
 gGUI_Sel: gui_input, gui_state
 gGUI_FocusBeforeShow: gui_state, gui_paint
 gAnim_DeferredTimerStart: gui_animation, gui_paint
-gAnim_FrameTimeDisplay: gui_paint
-gAnim_FPSEnabled: gui_interceptor
 gAnim_OverlayOpacity: gui_animation, gui_state
 gAnim_HidePending: gui_animation, gui_overlay
 gFX_AmbientTime: gui_animation, gui_effects
 gBGImg_EffectsReady: gui_bgimage, gui_effects
-gFX_MouseX: gui_input
-gFX_MouseY: gui_input
-gFX_MouseInWindow: gui_input
-LOG_PATH_PAINT_TIMING: config_loader

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -21,7 +21,6 @@ global gAnim_FrameDt := 0.0           ; Delta ms since last frame
 global gAnim_FrameCapMs := 6.94       ; ms per frame (default ~144Hz, set by Anim_Init)
 global gAnim_TargetFPS := 144         ; Resolved from config or monitor
 global gAnim_TimerPeriodOn := false   ; timeBeginPeriod(1) active?
-global gAnim_FPSEnabled := false      ; FPS debug overlay toggle (F key)
 global gAnim_OverlayOpacity := 1.0    ; Current overlay fade opacity (0.0-1.0)
 global gAnim_HidePending := false     ; Hide-fade in progress
 global gAnim_DeferredTimerStart := false  ; Deferred frame loop start (STA pump safety, #175)
@@ -33,7 +32,6 @@ global gFX_AmbientTime := 0.0         ; Cumulative ms for ambient loops (Full mo
 global gAnim_FPSFrameCount := 0
 global gAnim_FPSLastSample := 0.0
 global gAnim_FPSDisplay := 0          ; Displayed FPS (updated every 500ms)
-global gAnim_FrameTimeDisplay := 0.0  ; Displayed frame time ms
 
 ; Compositor Clock state (Win11+ display-adaptive pacing)
 global gAnim_pWaitForClock := 0    ; Function ptr: DCompositionWaitForCompositorClock (0 = unavailable)

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -24,9 +24,6 @@ global gFX_HoverEffect      ; Hover effect state: {key, name, opacity, darkness,
 gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0}
 gFX_SelectionEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
 gFX_HoverEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
-global gFX_MouseX := 0.0             ; Mouse X in client coords (physical px)
-global gFX_MouseY := 0.0             ; Mouse Y in client coords (physical px)
-global gFX_MouseInWindow := false    ; Mouse is inside overlay window
 global gFX_MousePrevX := 0.0        ; Previous frame mouse X
 global gFX_MousePrevY := 0.0        ; Previous frame mouse Y
 global gFX_MouseVelX := 0.0         ; Smoothed velocity X (px/sec)

--- a/src/gui/gui_input.ahk
+++ b/src/gui/gui_input.ahk
@@ -4,6 +4,9 @@
 #Warn VarUnset, Off  ; Suppress warnings for cross-file globals/functions
 
 ; ========================= HOVER / MOUSE STATE =========================
+global gFX_MouseX := 0.0             ; Mouse X in client coords (physical px)
+global gFX_MouseY := 0.0             ; Mouse Y in client coords (physical px)
+global gFX_MouseInWindow := false    ; Mouse is inside overlay window
 global gGUI_HoverRow := 0
 global gGUI_HoverBtn := ""
 global gGUI_MouseTracking := false  ; Whether we've requested WM_MOUSELEAVE notification

--- a/src/gui/gui_interceptor.ahk
+++ b/src/gui/gui_interceptor.ahk
@@ -13,6 +13,7 @@
 ; NOTE: Tab decision window now in config: cfg.AltTabTabDecisionMs (default 24ms)
 ; NOTE: Bypass settings are now in config: cfg.AltTabBypassFullscreen, cfg.AltTabBypassProcesses
 
+global gAnim_FPSEnabled := false      ; FPS debug overlay toggle (F key)
 global gINT_SessionActive := false
 global gINT_TabHeld := false
 global gINT_PressCount := 0

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -20,7 +20,7 @@ global gPaint_RepaintInProgress := false  ; Reentrancy guard (see #90)
 global gGUI_LastRowsDesired := -1
 global gGUI_LeftArrowRect := { x: 0, y: 0, w: 0, h: 0 }
 global gGUI_RightArrowRect := { x: 0, y: 0, w: 0, h: 0 }
-global LOG_PATH_PAINT_TIMING  ; Defined in config_loader.ahk
+global gAnim_FrameTimeDisplay := 0.0  ; Displayed frame time ms
 Paint_Log(msg) {
     global cfg, LOG_PATH_PAINT_TIMING
     if (!cfg.DiagPaintTimingLog)


### PR DESCRIPTION
## Summary

- Move 6 global declarations from consumer files to their sole-writer files, eliminating unnecessary cross-file ownership tracking
- `gAnim_FPSEnabled`: gui_animation → gui_interceptor (sole writer via F-key toggle)
- `gAnim_FrameTimeDisplay`: gui_animation → gui_paint (sole writer via timing measurement)
- `gFX_MouseX/Y/InWindow`: gui_effects → gui_input (sole writer via mouse tracking)
- `LOG_PATH_PAINT_TIMING`: remove redundant bare declaration from gui_paint (already declared in config_loader)
- Ownership manifest reduced from 23 → 17 entries (~26% reduction)

Closes #204

## Test plan

- [x] `query_global_ownership.ps1 -Generate` reports manifest up to date (17 entries)
- [ ] `tests\test.ps1 --live` passes (pre-gate + unit + live tests)
- [ ] Manual Alt+Tab cycle: overlay shows, FPS toggle (F key) works, mouse hover tracking works

Generated with [Claude Code](https://claude.com/claude-code)