### PR TITLE
Reduce inline lint-ignore suppressions by 191 via smarter checks

### DIFF
--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -618,7 +618,7 @@ _KomorebiSub_IssueRead() {
 ; Async read completion callback — called by OVERLAPPED library when ReadFile completes.
 ; Signature: (overlappedObj, err, bytesTransferred) per OVERLAPPED.ahk calling convention.
 ; Runs on the AHK thread (marshaled via SendMessageW from thread pool).
-_KomorebiSub_OnReadComplete(overlappedObj, err, bytesTransferred) { ; lint-ignore: dead-param
+_KomorebiSub_OnReadComplete(overlappedObj, err, bytesTransferred) {
     global _KSub_hPipe, _KSub_ReadPending, _KSub_LastEventTick, _KSub_AsyncMode
     global _KSub_ReadBuffer, _KSub_ReadBufferLen
     global KSUB_READ_BUF, KSUB_BUFFER_MAX_BYTES, IPC_ERROR_BROKEN_PIPE

--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -193,7 +193,7 @@ WinEventHook_IsRunning() {
 ;   0x8005 = EVENT_OBJECT_FOCUS
 ;   0x800B = EVENT_OBJECT_LOCATIONCHANGE
 ;   0x800C = EVENT_OBJECT_NAMECHANGE
-_WEH_WinEventProc(hWinEventHook, event, hwnd, idObject, idChild, idEventThread, dwmsEventTime) { ; lint-ignore: dead-param
+_WEH_WinEventProc(hWinEventHook, event, hwnd, idObject, idChild, idEventThread, dwmsEventTime) {
     global _WEH_PendingHwnds, _WEH_ShellWindow, _WEH_PendingFocusHwnd, _WEH_PendingZNeeded
     global cfg, gWS_Store
 

--- a/src/editors/config_editor_native.ahk
+++ b/src/editors/config_editor_native.ahk
@@ -686,9 +686,9 @@ _CEN_AddSettings(pageGui, settings, controls, blocks, y, contentW, sectionName, 
             y += descH + 4
 
         } else if (setting.HasOwnProp("dynamicOptions")) {
-            global SHADER_KEYS, SHADER_NAMES ; lint-ignore: phantom-global
-            global MOUSE_SHADER_KEYS, MOUSE_SHADER_NAMES ; lint-ignore: phantom-global
-            global SELECTION_SHADER_KEYS, SELECTION_SHADER_NAMES ; lint-ignore: phantom-global
+            global SHADER_KEYS, SHADER_NAMES
+            global MOUSE_SHADER_KEYS, MOUSE_SHADER_NAMES
+            global SELECTION_SHADER_KEYS, SELECTION_SHADER_NAMES
             lbl := pageGui.AddText("x24 y" y " w" CEN_LABEL_W " h20 +0x200 c" gTheme_Palette.text, setting.k)
             lbl.SetFont("s9 bold", "Segoe UI")
             controls.Push({ctrl: lbl, origY: y, origX: 24})
@@ -1332,7 +1332,7 @@ _CEN_SyncFloatEditToSlider(editCtrl, sliderCtrl, guard, fMin, fMax, sMax) {
 ; Use NM_CUSTOMDRAW to paint the thumb in accent colors on hover/press.
 
 ; WM_NOTIFY handler for slider NM_CUSTOMDRAW (same technique as mock_dark_controls.ahk)
-_CEN_OnWmNotify(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns (OnMessage: bare return = default handling) ; lint-ignore: dead-param
+_CEN_OnWmNotify(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns (OnMessage: bare return = default handling)
     global gCEN_SliderHwnds
     code := NumGet(lParam, 16, "Int")   ; NMHDR.code (offset 16 on x64: hwndFrom=8 + idFrom=8)
     if (code != -12)  ; NM_CUSTOMDRAW
@@ -1428,7 +1428,7 @@ global gCEN_SliderHwnds := Map()  ; hwnd -> true
 global gCEN_SliderSubclassPtr := CallbackCreate(_CEN_SliderSubclassProc, , 6)
 global gCEN_SwatchSubclassPtr := CallbackCreate(_CEN_SwatchSubclassProc, , 6)
 
-_CEN_SliderSubclassProc(hwnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) { ; lint-ignore: dead-param
+_CEN_SliderSubclassProc(hwnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) {
     global gCEN_SliderSubclassPtr, gTheme_Palette
     if (uMsg = 0x0014) {  ; WM_ERASEBKGND — fill with page bg instead of white
         rc := Buffer(16)
@@ -1445,7 +1445,7 @@ _CEN_SliderSubclassProc(hwnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) { ; 
 }
 
 ; Swatch subclass: WM_PAINT draws checkerboard + AlphaBlend overlay
-_CEN_SwatchSubclassProc(hwnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) { ; lint-ignore: dead-param
+_CEN_SwatchSubclassProc(hwnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) {
     global gCEN_SwatchSubclassPtr, gCEN_SwatchColors, gCEN_SwatchAlphas, gTheme_Palette
 
     if (uMsg = 0x000F) {  ; WM_PAINT
@@ -1548,7 +1548,7 @@ _CEN_UpdateSwatchColor(swCtrl, rgb, alpha := 255) {
 }
 
 ; WM_CTLCOLORSTATIC handler: swatches return nothing (subclass handles paint)
-_CEN_OnSwatchCtlColor(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_CEN_OnSwatchCtlColor(wParam, lParam, msg, hwnd) {
     global gCEN_SwatchHwnds
     if (!gCEN_SwatchHwnds.Has(lParam))
         return  ; Fall through to theme handler
@@ -1979,7 +1979,7 @@ _CEN_GetViewportHeight() {
 ; EVENT HANDLERS
 ; ============================================================
 
-_CEN_OnResize(gui, minMax, w, h) { ; lint-ignore: dead-param
+_CEN_OnResize(gui, minMax, w, h) {
     global gCEN
     global CEN_SIDEBAR_W, CEN_CONTENT_X, CEN_FOOTER_H, CEN_SEARCH_H
 
@@ -2062,7 +2062,7 @@ _CEN_OnCancel(*) {
     gCEN["MainGui"].Destroy()
 }
 
-_CEN_OnClose(guiObj) { ; lint-ignore: dead-param
+_CEN_OnClose(guiObj) {
     if (_CEN_HasUnsavedChanges()) {
         result := ThemeMsgBox("You have unsaved changes. Save before closing?", "Alt-Tabby Configuration", "YesNoCancel Icon?")
         if (result = "Cancel")
@@ -2162,7 +2162,7 @@ _CEN_Cleanup() {
 ; SEARCH
 ; ============================================================
 
-_CEN_OnSearchInput(ctrl, *) { ; lint-ignore: dead-param
+_CEN_OnSearchInput(ctrl, *) {
     global gCEN
     if (gCEN["SearchTimer"])
         SetTimer(_CEN_DoSearch, 0)

--- a/src/editors/config_editor_webview.ahk
+++ b/src/editors/config_editor_webview.ahk
@@ -178,7 +178,7 @@ CE_RunWebView2(launcherHwnd := 0) {
 ; EVENT HANDLERS
 ; ============================================================
 
-_CEW_OnClose(guiObj) { ; lint-ignore: dead-param
+_CEW_OnClose(guiObj) {
     global gCEW_Controller, gCEW_HasChanges
     ; Warn about unsaved changes (matches native editor behavior)
     if (gCEW_HasChanges) {
@@ -198,7 +198,7 @@ _CEW_OnClose(guiObj) { ; lint-ignore: dead-param
     return false  ; Allow close
 }
 
-_CEW_OnSize(guiObj, minMax, width, height) { ; lint-ignore: dead-param
+_CEW_OnSize(guiObj, minMax, width, height) {
     global gCEW_Controller
     if (minMax = -1)  ; Minimized
         return

--- a/src/editors/config_registry_editor.ahk
+++ b/src/editors/config_registry_editor.ahk
@@ -92,7 +92,7 @@ _CRE_OnClose(*) {
     ExitApp()
 }
 
-_CRE_OnSize(guiObj, minMax, width, height) { ; lint-ignore: dead-param
+_CRE_OnSize(guiObj, minMax, width, height) {
     global gCRE_Controller
     if (minMax != -1 && gCRE_Controller)
         try gCRE_Controller.Fill()

--- a/src/gui/d2d_types.ahk
+++ b/src/gui/d2d_types.ahk
@@ -7,7 +7,7 @@
 ; ========================= D2D1_COLOR_F (16 bytes) =========================
 ; Layout: { float r, g, b, a }
 
-D2D_ColorF(argb) { ; lint-ignore: dead-function
+D2D_ColorF(argb) {
     buf := Buffer(16)
     NumPut("float", ((argb >> 16) & 0xFF) / 255.0,
            "float", ((argb >> 8) & 0xFF) / 255.0,
@@ -20,7 +20,7 @@ D2D_ColorF(argb) { ; lint-ignore: dead-function
 ; ========================= D2D1_RECT_F (16 bytes) =========================
 ; Layout: { float left, top, right, bottom }
 
-D2D_RectF(left, top, right, bottom) { ; lint-ignore: dead-function
+D2D_RectF(left, top, right, bottom) {
     buf := Buffer(16)
     NumPut("float", Float(left), "float", Float(top),
            "float", Float(right), "float", Float(bottom), buf)
@@ -30,7 +30,7 @@ D2D_RectF(left, top, right, bottom) { ; lint-ignore: dead-function
 ; ========================= D2D1_ROUNDED_RECT (24 bytes) =========================
 ; Layout: { D2D1_RECT_F rect (16), float radiusX, float radiusY }
 
-D2D_RoundedRect(left, top, right, bottom, radiusX, radiusY?) { ; lint-ignore: dead-function
+D2D_RoundedRect(left, top, right, bottom, radiusX, radiusY?) {
     if !IsSet(radiusY)
         radiusY := radiusX
     buf := Buffer(24)
@@ -43,7 +43,7 @@ D2D_RoundedRect(left, top, right, bottom, radiusX, radiusY?) { ; lint-ignore: de
 ; ========================= D2D1_ELLIPSE (16 bytes) =========================
 ; Layout: { D2D1_POINT_2F center (8), float radiusX, float radiusY }
 
-D2D_Ellipse(cx, cy, rx, ry) { ; lint-ignore: dead-function
+D2D_Ellipse(cx, cy, rx, ry) {
     buf := Buffer(16)
     NumPut("float", Float(cx), "float", Float(cy),
            "float", Float(rx), "float", Float(ry), buf)
@@ -53,7 +53,7 @@ D2D_Ellipse(cx, cy, rx, ry) { ; lint-ignore: dead-function
 ; ========================= D2D1_POINT_2F as int64 (8 bytes) =========================
 ; Pack two floats for by-value passing in x64 ComCall/DllCall
 
-D2D_Point2F(x, y) { ; lint-ignore: dead-function
+D2D_Point2F(x, y) {
     static buf := Buffer(8)
     NumPut("float", Float(x), "float", Float(y), buf)
     return NumGet(buf, "int64")
@@ -62,7 +62,7 @@ D2D_Point2F(x, y) { ; lint-ignore: dead-function
 ; ========================= D2D1_SIZE_U (8 bytes) =========================
 ; Layout: { uint32 width, uint32 height }
 
-D2D_SizeU(w, h) { ; lint-ignore: dead-function
+D2D_SizeU(w, h) {
     buf := Buffer(8)
     NumPut("uint", w, "uint", h, buf)
     return buf
@@ -71,7 +71,7 @@ D2D_SizeU(w, h) { ; lint-ignore: dead-function
 ; ========================= D2D1_SIZE_F (8 bytes) =========================
 ; Layout: { float width, float height }
 
-D2D_SizeF(w, h) { ; lint-ignore: dead-function
+D2D_SizeF(w, h) {
     buf := Buffer(8)
     NumPut("float", Float(w), "float", Float(h), buf)
     return buf
@@ -83,7 +83,7 @@ D2D_SizeF(w, h) { ; lint-ignore: dead-function
 ; ========================= D2D1_BITMAP_PROPERTIES (20 bytes) =========================
 ; Layout: { D2D1_PIXEL_FORMAT pixelFormat (8), float dpiX, float dpiY }
 
-D2D_BitmapProps(dpiX := 96.0, dpiY := 96.0, format := 87, alphaMode := 1) { ; lint-ignore: dead-function
+D2D_BitmapProps(dpiX := 96.0, dpiY := 96.0, format := 87, alphaMode := 1) {
     ; format 87 = DXGI_FORMAT_B8G8R8A8_UNORM
     ; alphaMode 1 = D2D1_ALPHA_MODE_PREMULTIPLIED
     buf := Buffer(20, 0)
@@ -97,7 +97,7 @@ D2D_BitmapProps(dpiX := 96.0, dpiY := 96.0, format := 87, alphaMode := 1) { ; li
 ; ========================= D2D1_MATRIX_3X2_F (24 bytes) =========================
 ; Layout: { float _11, _12, _21, _22, _31, _32 }
 
-D2D_Matrix3x2_Identity() { ; lint-ignore: dead-function
+D2D_Matrix3x2_Identity() {
     buf := Buffer(24, 0)
     NumPut("float", 1.0, buf, 0)   ; _11
     NumPut("float", 1.0, buf, 12)  ; _22
@@ -109,12 +109,12 @@ D2D_Matrix3x2_Identity() { ; lint-ignore: dead-function
 
 ; Flag constants ; lint-ignore: dead-global (consumed by dwm_thumbnail.ahk in Phase 2)
 global DWM_TNP_RECTDESTINATION := 0x01
-global DWM_TNP_RECTSOURCE      := 0x02 ; lint-ignore: dead-global
+global DWM_TNP_RECTSOURCE      := 0x02
 global DWM_TNP_OPACITY         := 0x04
 global DWM_TNP_VISIBLE         := 0x08
 global DWM_TNP_SOURCECLIENTAREAONLY := 0x10
 
-DWM_ThumbnailProps(destL, destT, destR, destB, visible := true, opacity := 255, clientOnly := true) { ; lint-ignore: dead-function
+DWM_ThumbnailProps(destL, destT, destR, destB, visible := true, opacity := 255, clientOnly := true) {
     global DWM_TNP_RECTDESTINATION, DWM_TNP_VISIBLE, DWM_TNP_OPACITY, DWM_TNP_SOURCECLIENTAREAONLY
     ; Layout: { DWORD flags (4), RECT dest (16), RECT source (16),
     ;           BYTE opacity (1+3 pad), BOOL visible (4), BOOL srcClientOnly (4) }
@@ -136,7 +136,7 @@ DWM_ThumbnailProps(destL, destT, destR, destB, visible := true, opacity := 255, 
 ; ========================= D2D1_ARC_SEGMENT (28 bytes) =========================
 ; Used with path geometry for per-corner rounded rects
 
-D2D_ArcSegment(endX, endY, rx, ry, rotation := 0.0, sweepDir := 1, arcSize := 0) { ; lint-ignore: dead-function
+D2D_ArcSegment(endX, endY, rx, ry, rotation := 0.0, sweepDir := 1, arcSize := 0) {
     buf := Buffer(28, 0)
     NumPut("float", Float(endX), "float", Float(endY), buf, 0)
     NumPut("float", Float(rx), "float", Float(ry), buf, 8)
@@ -153,7 +153,7 @@ D2D_ArcSegment(endX, endY, rx, ry, rotation := 0.0, sweepDir := 1, arcSize := 0)
 ;            DXGI_ALPHA_MODE AlphaMode, UINT Flags }
 ; Size: 48 bytes
 
-D2D_SwapChainDesc1(w, h, format, bufferCount, swapEffect, alphaMode, flags := 0) { ; lint-ignore: dead-function
+D2D_SwapChainDesc1(w, h, format, bufferCount, swapEffect, alphaMode, flags := 0) {
     buf := Buffer(48, 0)
     NumPut("uint", w, buf, 0)           ; Width
     NumPut("uint", h, buf, 4)           ; Height
@@ -175,7 +175,7 @@ D2D_SwapChainDesc1(w, h, format, bufferCount, swapEffect, alphaMode, flags := 0)
 ;            D2D1_BITMAP_OPTIONS options, ID2D1ColorContext* colorContext }
 ; Size: 24 bytes (on x64: 20 + 4 pad = 24 with ptr alignment)
 
-D2D_BitmapProps1(options, dpiX := 96.0, dpiY := 96.0, format := 87, alphaMode := 1) { ; lint-ignore: dead-function
+D2D_BitmapProps1(options, dpiX := 96.0, dpiY := 96.0, format := 87, alphaMode := 1) {
     ; format 87 = DXGI_FORMAT_B8G8R8A8_UNORM
     ; alphaMode 1 = D2D1_ALPHA_MODE_PREMULTIPLIED
     buf := Buffer(A_PtrSize = 8 ? 32 : 24, 0)
@@ -190,64 +190,64 @@ D2D_BitmapProps1(options, dpiX := 96.0, dpiY := 96.0, format := 87, alphaMode :=
 
 ; ========================= D2D ENUMS ========================= ; lint-ignore: dead-global (consumed by gui_render.ahk / gui_paint.ahk in Phase 0)
 
-global D2DERR_RECREATE_TARGET     := 0x8899000C ; lint-ignore: dead-global
-global D2D1_ALPHA_MODE_PREMULTIPLIED := 1 ; lint-ignore: dead-global
-global D2D1_ANTIALIAS_MODE_PER_PRIMITIVE := 0 ; lint-ignore: dead-global
-global D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE := 2 ; lint-ignore: dead-global
-global D2D1_DRAW_TEXT_OPTIONS_CLIP := 2 ; lint-ignore: dead-global
-global DXGI_FORMAT_B8G8R8A8_UNORM := 87 ; lint-ignore: dead-global
-global DXGI_FORMAT_UNKNOWN := 0 ; lint-ignore: dead-global
+global D2DERR_RECREATE_TARGET     := 0x8899000C
+global D2D1_ALPHA_MODE_PREMULTIPLIED := 1
+global D2D1_ANTIALIAS_MODE_PER_PRIMITIVE := 0
+global D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE := 2
+global D2D1_DRAW_TEXT_OPTIONS_CLIP := 2
+global DXGI_FORMAT_B8G8R8A8_UNORM := 87
+global DXGI_FORMAT_UNKNOWN := 0
 
 ; DXGI / D3D11 / D2D1.1 enums
-global DXGI_SWAP_EFFECT_FLIP_DISCARD := 4 ; lint-ignore: dead-global
-global DXGI_ALPHA_MODE_PREMULTIPLIED := 1 ; lint-ignore: dead-global
-global D2D1_BITMAP_OPTIONS_TARGET := 0x00000001 ; lint-ignore: dead-global
-global D2D1_BITMAP_OPTIONS_CANNOT_DRAW := 0x00000002 ; lint-ignore: dead-global
-global D3D11_CREATE_DEVICE_BGRA_SUPPORT := 0x00000020 ; lint-ignore: dead-global
-global DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT := 0x40 ; lint-ignore: dead-global
+global DXGI_SWAP_EFFECT_FLIP_DISCARD := 4
+global DXGI_ALPHA_MODE_PREMULTIPLIED := 1
+global D2D1_BITMAP_OPTIONS_TARGET := 0x00000001
+global D2D1_BITMAP_OPTIONS_CANNOT_DRAW := 0x00000002
+global D3D11_CREATE_DEVICE_BGRA_SUPPORT := 0x00000020
+global DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT := 0x40
 
 ; DirectWrite enums
-global DWRITE_FONT_WEIGHT_REGULAR  := 400 ; lint-ignore: dead-global
-global DWRITE_FONT_WEIGHT_SEMIBOLD := 600 ; lint-ignore: dead-global
-global DWRITE_FONT_WEIGHT_BOLD     := 700 ; lint-ignore: dead-global
-global DWRITE_FONT_WEIGHT_EXTRABOLD := 800 ; lint-ignore: dead-global
-global DWRITE_FONT_STYLE_NORMAL    := 0 ; lint-ignore: dead-global
-global DWRITE_FONT_STRETCH_NORMAL  := 5 ; lint-ignore: dead-global
-global DWRITE_WORD_WRAPPING_NO_WRAP := 1 ; lint-ignore: dead-global
-global DWRITE_TEXT_ALIGNMENT_LEADING := 0 ; lint-ignore: dead-global
-global DWRITE_TEXT_ALIGNMENT_TRAILING := 1 ; lint-ignore: dead-global
-global DWRITE_TEXT_ALIGNMENT_CENTER := 2 ; lint-ignore: dead-global
-global DWRITE_PARAGRAPH_ALIGNMENT_NEAR := 0 ; lint-ignore: dead-global
-global DWRITE_PARAGRAPH_ALIGNMENT_FAR := 1 ; lint-ignore: dead-global
-global DWRITE_PARAGRAPH_ALIGNMENT_CENTER := 2 ; lint-ignore: dead-global
+global DWRITE_FONT_WEIGHT_REGULAR  := 400
+global DWRITE_FONT_WEIGHT_SEMIBOLD := 600
+global DWRITE_FONT_WEIGHT_BOLD     := 700
+global DWRITE_FONT_WEIGHT_EXTRABOLD := 800
+global DWRITE_FONT_STYLE_NORMAL    := 0
+global DWRITE_FONT_STRETCH_NORMAL  := 5
+global DWRITE_WORD_WRAPPING_NO_WRAP := 1
+global DWRITE_TEXT_ALIGNMENT_LEADING := 0
+global DWRITE_TEXT_ALIGNMENT_TRAILING := 1
+global DWRITE_TEXT_ALIGNMENT_CENTER := 2
+global DWRITE_PARAGRAPH_ALIGNMENT_NEAR := 0
+global DWRITE_PARAGRAPH_ALIGNMENT_FAR := 1
+global DWRITE_PARAGRAPH_ALIGNMENT_CENTER := 2
 
 ; ========================= D2D1 EFFECT CLSIDs =========================
 ; Pre-computed 16-byte GUID buffers for ID2D1DeviceContext::CreateEffect.
 ; Initialized by FX_InitCLSIDs() at startup; declared here for global access.
 
-global CLSID_D2D1GaussianBlur ; lint-ignore: dead-global
-global CLSID_D2D1Shadow       ; lint-ignore: dead-global
-global CLSID_D2D1Flood        ; lint-ignore: dead-global
-global CLSID_D2D1Crop         ; lint-ignore: dead-global
-global CLSID_D2D1ColorMatrix  ; lint-ignore: dead-global
-global CLSID_D2D1Saturation   ; lint-ignore: dead-global
-global CLSID_D2D1Blend        ; lint-ignore: dead-global
-global CLSID_D2D1Composite    ; lint-ignore: dead-global
-global CLSID_D2D1Turbulence   ; lint-ignore: dead-global
-global CLSID_D2D1Morphology   ; lint-ignore: dead-global
-global CLSID_D2D1GammaTransfer ; lint-ignore: dead-global
-global CLSID_D2D1DirectionalBlur ; lint-ignore: dead-global
-global CLSID_D2D1PointSpecular  ; lint-ignore: dead-global
+global CLSID_D2D1GaussianBlur
+global CLSID_D2D1Shadow
+global CLSID_D2D1Flood
+global CLSID_D2D1Crop
+global CLSID_D2D1ColorMatrix
+global CLSID_D2D1Saturation
+global CLSID_D2D1Blend
+global CLSID_D2D1Composite
+global CLSID_D2D1Turbulence
+global CLSID_D2D1Morphology
+global CLSID_D2D1GammaTransfer
+global CLSID_D2D1DirectionalBlur
+global CLSID_D2D1PointSpecular
 
 ; Convert a GUID string to a 16-byte CLSID buffer.
-_D2D_CLSID(str) { ; lint-ignore: dead-function
+_D2D_CLSID(str) {
     buf := Buffer(16, 0)
     DllCall("ole32\CLSIDFromString", "str", str, "ptr", buf, "hresult")
     return buf
 }
 
 ; Initialize all effect CLSIDs. Call once at startup.
-FX_InitCLSIDs() { ; lint-ignore: dead-function
+FX_InitCLSIDs() {
     global CLSID_D2D1GaussianBlur, CLSID_D2D1Shadow, CLSID_D2D1Flood
     global CLSID_D2D1Crop, CLSID_D2D1ColorMatrix, CLSID_D2D1Saturation
     global CLSID_D2D1Blend, CLSID_D2D1Composite, CLSID_D2D1Turbulence
@@ -273,108 +273,108 @@ FX_InitCLSIDs() { ; lint-ignore: dead-function
 ; Property indices for SetFloat/SetUInt/SetEnum/SetColorF on each effect type.
 
 ; D2D1_GAUSSIANBLUR_PROP
-global FX_BLUR_STDEV      := 0  ; FLOAT — standard deviation (px) ; lint-ignore: dead-global
-global FX_BLUR_OPTIMIZATION := 1  ; ENUM  — speed vs quality ; lint-ignore: dead-global
-global FX_BLUR_BORDER_MODE := 2  ; ENUM  — soft/hard edge ; lint-ignore: dead-global
+global FX_BLUR_STDEV      := 0  ; FLOAT — standard deviation (px)
+global FX_BLUR_OPTIMIZATION := 1  ; ENUM  — speed vs quality
+global FX_BLUR_BORDER_MODE := 2  ; ENUM  — soft/hard edge
 
 ; D2D1_SHADOW_PROP
-global FX_SHADOW_BLUR      := 0  ; FLOAT — shadow blur radius ; lint-ignore: dead-global
-global FX_SHADOW_COLOR     := 1  ; VECTOR4 — shadow color (r,g,b,a) ; lint-ignore: dead-global
+global FX_SHADOW_BLUR      := 0  ; FLOAT — shadow blur radius
+global FX_SHADOW_COLOR     := 1  ; VECTOR4 — shadow color (r,g,b,a)
 
 ; D2D1_FLOOD_PROP
-global FX_FLOOD_COLOR      := 0  ; VECTOR4 — flood fill color ; lint-ignore: dead-global
+global FX_FLOOD_COLOR      := 0  ; VECTOR4 — flood fill color
 
 ; D2D1_CROP_PROP
-global FX_CROP_RECT        := 0  ; VECTOR4 — crop rectangle (l,t,r,b) ; lint-ignore: dead-global
-global FX_CROP_BORDER_MODE := 1  ; ENUM ; lint-ignore: dead-global
+global FX_CROP_RECT        := 0  ; VECTOR4 — crop rectangle (l,t,r,b)
+global FX_CROP_BORDER_MODE := 1  ; ENUM
 
 ; D2D1_COLORMATRIX_PROP
-global FX_CMATRIX_MATRIX   := 0  ; MATRIX_5X4 — 5×4 color transform ; lint-ignore: dead-global
-global FX_CMATRIX_ALPHA_MODE := 1  ; ENUM ; lint-ignore: dead-global
-global FX_CMATRIX_CLAMP    := 2  ; BOOL ; lint-ignore: dead-global
+global FX_CMATRIX_MATRIX   := 0  ; MATRIX_5X4 — 5×4 color transform
+global FX_CMATRIX_ALPHA_MODE := 1  ; ENUM
+global FX_CMATRIX_CLAMP    := 2  ; BOOL
 
 ; D2D1_SATURATION_PROP
-global FX_SAT_SATURATION   := 0  ; FLOAT — 0.0 (grayscale) to 1.0 (original) ; lint-ignore: dead-global
+global FX_SAT_SATURATION   := 0  ; FLOAT — 0.0 (grayscale) to 1.0 (original)
 
 ; D2D1_BLEND_PROP
-global FX_BLEND_MODE       := 0  ; ENUM — blend mode ; lint-ignore: dead-global
+global FX_BLEND_MODE       := 0  ; ENUM — blend mode
 
 ; D2D1_COMPOSITE_PROP
-global FX_COMPOSITE_MODE   := 0  ; ENUM — composite mode ; lint-ignore: dead-global
+global FX_COMPOSITE_MODE   := 0  ; ENUM — composite mode
 
 ; D2D1_TURBULENCE_PROP
-global FX_TURB_OFFSET      := 0  ; VECTOR2 — noise offset ; lint-ignore: dead-global
-global FX_TURB_SIZE        := 1  ; VECTOR2 — bounding size of noise output (default {0,0} = infinite) ; lint-ignore: dead-global
-global FX_TURB_FREQ        := 2  ; VECTOR2 — base frequency ; lint-ignore: dead-global
-global FX_TURB_OCTAVES     := 3  ; UINT32 — octave count ; lint-ignore: dead-global
-global FX_TURB_SEED        := 4  ; UINT32 — random seed ; lint-ignore: dead-global
-global FX_TURB_NOISE       := 5  ; ENUM — fractalSum(0) or turbulence(1) ; lint-ignore: dead-global
-global FX_TURB_STITCHABLE  := 6  ; BOOL ; lint-ignore: dead-global
+global FX_TURB_OFFSET      := 0  ; VECTOR2 — noise offset
+global FX_TURB_SIZE        := 1  ; VECTOR2 — bounding size of noise output (default {0,0} = infinite)
+global FX_TURB_FREQ        := 2  ; VECTOR2 — base frequency
+global FX_TURB_OCTAVES     := 3  ; UINT32 — octave count
+global FX_TURB_SEED        := 4  ; UINT32 — random seed
+global FX_TURB_NOISE       := 5  ; ENUM — fractalSum(0) or turbulence(1)
+global FX_TURB_STITCHABLE  := 6  ; BOOL
 
 ; D2D1_MORPHOLOGY_PROP
-global FX_MORPH_MODE       := 0  ; ENUM — erode(0) or dilate(1) ; lint-ignore: dead-global
-global FX_MORPH_WIDTH      := 1  ; UINT32 — kernel width ; lint-ignore: dead-global
-global FX_MORPH_HEIGHT     := 2  ; UINT32 — kernel height ; lint-ignore: dead-global
+global FX_MORPH_MODE       := 0  ; ENUM — erode(0) or dilate(1)
+global FX_MORPH_WIDTH      := 1  ; UINT32 — kernel width
+global FX_MORPH_HEIGHT     := 2  ; UINT32 — kernel height
 
 ; D2D1_GAMMATRANSFER_PROP (per-channel: Red, Green, Blue, Alpha)
-global FX_GAMMA_RED_AMP    := 0  ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_RED_EXP    := 1  ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_RED_OFF    := 2  ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_RED_DISABLE := 3 ; BOOL ; lint-ignore: dead-global
-global FX_GAMMA_GREEN_AMP  := 4  ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_GREEN_EXP  := 5  ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_GREEN_OFF  := 6  ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_GREEN_DISABLE := 7 ; BOOL ; lint-ignore: dead-global
-global FX_GAMMA_BLUE_AMP   := 8  ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_BLUE_EXP   := 9  ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_BLUE_OFF   := 10 ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_BLUE_DISABLE := 11 ; BOOL ; lint-ignore: dead-global
-global FX_GAMMA_ALPHA_AMP  := 12 ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_ALPHA_EXP  := 13 ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_ALPHA_OFF  := 14 ; FLOAT ; lint-ignore: dead-global
-global FX_GAMMA_ALPHA_DISABLE := 15 ; BOOL ; lint-ignore: dead-global
+global FX_GAMMA_RED_AMP    := 0  ; FLOAT
+global FX_GAMMA_RED_EXP    := 1  ; FLOAT
+global FX_GAMMA_RED_OFF    := 2  ; FLOAT
+global FX_GAMMA_RED_DISABLE := 3 ; BOOL
+global FX_GAMMA_GREEN_AMP  := 4  ; FLOAT
+global FX_GAMMA_GREEN_EXP  := 5  ; FLOAT
+global FX_GAMMA_GREEN_OFF  := 6  ; FLOAT
+global FX_GAMMA_GREEN_DISABLE := 7 ; BOOL
+global FX_GAMMA_BLUE_AMP   := 8  ; FLOAT
+global FX_GAMMA_BLUE_EXP   := 9  ; FLOAT
+global FX_GAMMA_BLUE_OFF   := 10 ; FLOAT
+global FX_GAMMA_BLUE_DISABLE := 11 ; BOOL
+global FX_GAMMA_ALPHA_AMP  := 12 ; FLOAT
+global FX_GAMMA_ALPHA_EXP  := 13 ; FLOAT
+global FX_GAMMA_ALPHA_OFF  := 14 ; FLOAT
+global FX_GAMMA_ALPHA_DISABLE := 15 ; BOOL
 
 ; D2D1_POINTSPECULAR_PROP
-global FX_SPEC_LIGHT_POS     := 0  ; VECTOR3 — light position (x, y, z in px) ; lint-ignore: dead-global
-global FX_SPEC_EXPONENT      := 1  ; FLOAT — specular exponent (1-128, higher=tighter) ; lint-ignore: dead-global
-global FX_SPEC_SURFACE_SCALE := 2  ; FLOAT — height map multiplier ; lint-ignore: dead-global
-global FX_SPEC_CONSTANT      := 3  ; FLOAT — specular intensity (0-10000) ; lint-ignore: dead-global
-global FX_SPEC_COLOR         := 4  ; VECTOR3 — light color (r, g, b as 0.0-1.0) ; lint-ignore: dead-global
-global FX_SPEC_KERNEL_UNIT   := 5  ; VECTOR2 — kernel unit length ; lint-ignore: dead-global
-global FX_SPEC_SCALE_MODE    := 6  ; ENUM — scale mode ; lint-ignore: dead-global
+global FX_SPEC_LIGHT_POS     := 0  ; VECTOR3 — light position (x, y, z in px)
+global FX_SPEC_EXPONENT      := 1  ; FLOAT — specular exponent (1-128, higher=tighter)
+global FX_SPEC_SURFACE_SCALE := 2  ; FLOAT — height map multiplier
+global FX_SPEC_CONSTANT      := 3  ; FLOAT — specular intensity (0-10000)
+global FX_SPEC_COLOR         := 4  ; VECTOR3 — light color (r, g, b as 0.0-1.0)
+global FX_SPEC_KERNEL_UNIT   := 5  ; VECTOR2 — kernel unit length
+global FX_SPEC_SCALE_MODE    := 6  ; ENUM — scale mode
 
 ; D2D1_DIRECTIONALBLUR_PROP
-global FX_DIRBLUR_STDEV    := 0  ; FLOAT — standard deviation (px) ; lint-ignore: dead-global
-global FX_DIRBLUR_ANGLE    := 1  ; FLOAT — angle in degrees (0=right, 90=down) ; lint-ignore: dead-global
-global FX_DIRBLUR_OPT      := 2  ; ENUM — optimization (speed/balanced/quality) ; lint-ignore: dead-global
-global FX_DIRBLUR_BORDER   := 3  ; ENUM — border mode (soft/hard) ; lint-ignore: dead-global
+global FX_DIRBLUR_STDEV    := 0  ; FLOAT — standard deviation (px)
+global FX_DIRBLUR_ANGLE    := 1  ; FLOAT — angle in degrees (0=right, 90=down)
+global FX_DIRBLUR_OPT      := 2  ; ENUM — optimization (speed/balanced/quality)
+global FX_DIRBLUR_BORDER   := 3  ; ENUM — border mode (soft/hard)
 
 ; D2D1_BLEND_MODE enum values (for FX_BLEND_MODE)
-global D2D1_BLEND_MULTIPLY  := 0  ; lint-ignore: dead-global
-global D2D1_BLEND_SCREEN    := 1  ; lint-ignore: dead-global
-global D2D1_BLEND_DARKEN    := 2  ; lint-ignore: dead-global
-global D2D1_BLEND_LIGHTEN   := 3  ; lint-ignore: dead-global
-global D2D1_BLEND_OVERLAY   := 11 ; lint-ignore: dead-global
-global D2D1_BLEND_SOFTLIGHT := 13 ; lint-ignore: dead-global
+global D2D1_BLEND_MULTIPLY  := 0
+global D2D1_BLEND_SCREEN    := 1
+global D2D1_BLEND_DARKEN    := 2
+global D2D1_BLEND_LIGHTEN   := 3
+global D2D1_BLEND_OVERLAY   := 11
+global D2D1_BLEND_SOFTLIGHT := 13
 
 ; D2D1_COMPOSITE_MODE enum values (for FX_COMPOSITE_MODE / DrawImage)
-global D2D1_COMPOSITE_SOURCE_OVER := 0 ; lint-ignore: dead-global
-global D2D1_COMPOSITE_SOURCE_IN   := 5 ; lint-ignore: dead-global
-global D2D1_COMPOSITE_SOURCE_ATOP := 7 ; lint-ignore: dead-global
+global D2D1_COMPOSITE_SOURCE_OVER := 0
+global D2D1_COMPOSITE_SOURCE_IN   := 5
+global D2D1_COMPOSITE_SOURCE_ATOP := 7
 
 ; D2D1_GAUSSIANBLUR_OPTIMIZATION
-global D2D1_BLUR_OPT_SPEED   := 0 ; lint-ignore: dead-global
-global D2D1_BLUR_OPT_BALANCED := 1 ; lint-ignore: dead-global
-global D2D1_BLUR_OPT_QUALITY  := 2 ; lint-ignore: dead-global
+global D2D1_BLUR_OPT_SPEED   := 0
+global D2D1_BLUR_OPT_BALANCED := 1
+global D2D1_BLUR_OPT_QUALITY  := 2
 
 ; D2D1_BORDER_MODE
-global D2D1_BORDER_SOFT := 0 ; lint-ignore: dead-global
-global D2D1_BORDER_HARD := 1 ; lint-ignore: dead-global
+global D2D1_BORDER_SOFT := 0
+global D2D1_BORDER_HARD := 1
 
 ; ========================= Color Matrix Helpers =========================
 
 ; Build a 5×4 identity color matrix (80 bytes, 20 floats).
-D2D_ColorMatrix_Identity() { ; lint-ignore: dead-function
+D2D_ColorMatrix_Identity() {
     m := Buffer(80, 0)
     NumPut("float", 1.0, m, 0)   ; [0][0] = R→R
     NumPut("float", 1.0, m, 20)  ; [1][1] = G→G
@@ -385,7 +385,7 @@ D2D_ColorMatrix_Identity() { ; lint-ignore: dead-function
 
 ; Build a tint matrix: multiplies RGB by tint color, preserves alpha.
 ; tintR/G/B in 0.0-1.0 range.
-D2D_ColorMatrix_Tint(tintR, tintG, tintB) { ; lint-ignore: dead-function
+D2D_ColorMatrix_Tint(tintR, tintG, tintB) {
     m := Buffer(80, 0)
     NumPut("float", Float(tintR), m, 0)   ; R scale
     NumPut("float", Float(tintG), m, 20)  ; G scale

--- a/src/gui/gui_constants.ahk
+++ b/src/gui/gui_constants.ahk
@@ -39,23 +39,23 @@ global SWP_NOOWNERZORDER := 0x0200
 global MONITOR_DEFAULTTONEAREST := 2
 
 ; GDI+ enums (legacy — kept for launcher_splash.ahk and other non-D2D windows)
-global GDIP_UNIT_PIXEL := 2 ; lint-ignore: dead-global
-global GDIP_STRING_ALIGN_NEAR := 0 ; lint-ignore: dead-global
-global GDIP_STRING_ALIGN_CENTER := 1 ; lint-ignore: dead-global
-global GDIP_STRING_ALIGN_FAR := 2 ; lint-ignore: dead-global
-global GDIP_STRING_FORMAT_NO_WRAP := 0x00001000 ; lint-ignore: dead-global
-global GDIP_STRING_FORMAT_LINE_LIMIT := 0x00004000 ; lint-ignore: dead-global
+global GDIP_UNIT_PIXEL := 2
+global GDIP_STRING_ALIGN_NEAR := 0
+global GDIP_STRING_ALIGN_CENTER := 1
+global GDIP_STRING_ALIGN_FAR := 2
+global GDIP_STRING_FORMAT_NO_WRAP := 0x00001000
+global GDIP_STRING_FORMAT_LINE_LIMIT := 0x00004000
 global GDIP_STRING_TRIMMING_ELLIPSIS := 3
 
 ; GDI+ rendering modes (legacy)
-global GDIP_SMOOTHING_ANTIALIAS := 4 ; lint-ignore: dead-global
-global GDIP_TEXT_RENDER_ANTIALIAS_GRIDFIT := 5 ; lint-ignore: dead-global
-global GDIP_PIXEL_FORMAT_32BPP_ARGB := 0x26200A ; lint-ignore: dead-global
-global GDIP_IMAGE_LOCK_WRITE := 2 ; lint-ignore: dead-global
+global GDIP_SMOOTHING_ANTIALIAS := 4
+global GDIP_TEXT_RENDER_ANTIALIAS_GRIDFIT := 5
+global GDIP_PIXEL_FORMAT_32BPP_ARGB := 0x26200A
+global GDIP_IMAGE_LOCK_WRITE := 2
 
 ; BITMAPINFOHEADER (legacy)
-global BITMAPINFOHEADER_SIZE := 40 ; lint-ignore: dead-global
-global BPP_32 := 32 ; lint-ignore: dead-global
+global BITMAPINFOHEADER_SIZE := 40
+global BPP_32 := 32
 
 ; ============================================================
 ; Paint Layout Constants (DIP = Device-Independent Pixels)

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -39,7 +39,7 @@ global gFX_MousePrevValid := false   ; False until first valid sample
 FX_GPU_Init() {
     global gD2D_RT, gFX_GPU, gFX_GPUReady, gFX_GPUOutput, gFX_HDRActive, cfg
     global gFX_ShaderLayers, gFX_MouseEffect, gFX_SelectionEffect, gFX_HoverEffect
-    global SHADER_KEYS ; lint-ignore: phantom-global
+    global SHADER_KEYS
     global CLSID_D2D1GaussianBlur, CLSID_D2D1Shadow, CLSID_D2D1Flood
     global CLSID_D2D1Crop, CLSID_D2D1ColorMatrix, CLSID_D2D1Saturation
     global CLSID_D2D1Blend, CLSID_D2D1Composite
@@ -316,7 +316,7 @@ FX_UpdateAmbient(dt) {
 
 ; Pre-render all active shader layers (D3D11 pipeline). Called BEFORE D2D BeginDraw.
 FX_PreRenderShaderLayers(w, h) {
-    global gFX_ShaderLayers, gShader_Ready, gFX_AmbientTime, gFX_ShaderTime ; lint-ignore: phantom-global (gShader_Ready in src/lib/d2d_shader.ahk)
+    global gFX_ShaderLayers, gShader_Ready, gFX_AmbientTime, gFX_ShaderTime
     global gFX_GPUReady, cfg
 
     if (!gShader_Ready || !gFX_GPUReady || gFX_ShaderLayers.Length = 0)
@@ -355,7 +355,7 @@ FX_PreRenderShaderLayers(w, h) {
 ; Draw all active shader layers inside D2D BeginDraw.
 ; Opacity is baked into shader output via AT_PostProcess — no PushLayer needed.
 FX_DrawShaderLayers(wPhys, hPhys) { ; lint-ignore: dead-param
-    global gD2D_RT, gFX_ShaderLayers, gShader_Ready ; lint-ignore: phantom-global (gShader_Ready in src/lib/d2d_shader.ahk)
+    global gD2D_RT, gFX_ShaderLayers, gShader_Ready
 
     if (!gShader_Ready || gFX_ShaderLayers.Length = 0)
         return
@@ -373,7 +373,7 @@ FX_DrawShaderLayers(wPhys, hPhys) { ; lint-ignore: dead-param
 
 ; Pre-render the mouse effect (D3D11 pipeline). Called BEFORE D2D BeginDraw.
 FX_PreRenderMouseEffect(w, h) {
-    global gFX_MouseEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime ; lint-ignore: phantom-global
+    global gFX_MouseEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime
     global gFX_MouseX, gFX_MouseY, gFX_MouseInWindow, cfg
     global gFX_MousePrevX, gFX_MousePrevY, gFX_MouseVelX, gFX_MouseVelY, gFX_MouseSpeed, gFX_MousePrevValid
 
@@ -448,7 +448,7 @@ FX_PreRenderMouseEffect(w, h) {
 
 ; Draw the mouse effect inside D2D BeginDraw.
 FX_DrawMouseEffect(wPhys, hPhys) { ; lint-ignore: dead-param
-    global gD2D_RT, gFX_MouseEffect, gShader_Ready ; lint-ignore: phantom-global
+    global gD2D_RT, gFX_MouseEffect, gShader_Ready
 
     if (gFX_MouseEffect.key = "" || !gShader_Ready)
         return
@@ -463,8 +463,8 @@ FX_DrawMouseEffect(wPhys, hPhys) { ; lint-ignore: dead-param
 ; Pre-render the selection shader. Called DURING paint (needs selection geometry).
 ; Decomposes ARGB ints to premultiplied float4 RGBA for the shader cbuffer.
 FX_PreRenderSelectionEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borderWidth, isHovered, entranceT, rowRadius := 0.0) {
-    global gFX_SelectionEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime ; lint-ignore: phantom-global
-    global gShader_Registry, cfg ; lint-ignore: phantom-global
+    global gFX_SelectionEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime
+    global gShader_Registry, cfg
 
     if (gFX_SelectionEffect.key = "" || !gShader_Ready || !gFX_GPUReady)
         return
@@ -527,7 +527,7 @@ FX_PreRenderSelectionEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, b
 ; Draw the selection effect inside D2D BeginDraw.
 ; selX/selY/selW/selH/rad are only needed for BG-as-selection (clipping + border).
 FX_DrawSelectionEffect(wPhys, hPhys, selX := 0, selY := 0, selW := 0, selH := 0, rad := 0) { ; lint-ignore: dead-param
-    global gD2D_RT, gFX_SelectionEffect, gShader_Ready, cfg ; lint-ignore: phantom-global
+    global gD2D_RT, gFX_SelectionEffect, gShader_Ready, cfg
 
     if (gFX_SelectionEffect.key = "" || !gShader_Ready)
         return
@@ -577,7 +577,7 @@ FX_DrawSelectionEffect(wPhys, hPhys, selX := 0, selY := 0, selW := 0, selH := 0,
 ; Skips entries already initialized (preserves time state across lazy-load).
 _FX_InitShaderTime() {
     global gFX_ShaderTime, gFX_ShaderLayers, gFX_MouseEffect, gFX_SelectionEffect, gFX_HoverEffect
-    global gShader_Registry ; lint-ignore: phantom-global
+    global gShader_Registry
 
     if (!IsObject(gFX_ShaderTime))
         gFX_ShaderTime := Map()
@@ -622,7 +622,7 @@ _FX_InitShaderTime() {
 ; Initialize shader time for a single shader key (mouse/selection effects).
 ; Uses shader JSON metadata for offset defaults.
 _FX_InitShaderTimeForKey(shaderKey) {
-    global gFX_ShaderTime, gShader_Registry ; lint-ignore: phantom-global
+    global gFX_ShaderTime, gShader_Registry
     if (shaderKey = "" || gFX_ShaderTime.Has(shaderKey))
         return
     minOff := 30, maxOff := 90, accum := true
@@ -644,8 +644,8 @@ _FX_InitShaderTimeForKey(shaderKey) {
 ; MouseEffect_*, and GUI_SelectionEffect into runtime state.
 _FX_ResolveConfiguredShaders() {
     global gFX_ShaderLayers, gFX_MouseEffect, gFX_SelectionEffect, gFX_HoverEffect, cfg
-    global SHADER_KEYS, MOUSE_SHADER_KEYS, SELECTION_SHADER_KEYS ; lint-ignore: phantom-global
-    global gShader_Registry ; lint-ignore: phantom-global
+    global SHADER_KEYS, MOUSE_SHADER_KEYS, SELECTION_SHADER_KEYS
+    global gShader_Registry
 
     gFX_ShaderLayers := []
 
@@ -860,9 +860,9 @@ _FX_ReleaseInactiveShaders() {
 
 ; Cycle the shader for a specific layer (1-based index).
 FX_CycleShaderLayer(layerIndex) {
-    global gFX_ShaderLayers, gFX_GPUReady, gShader_Ready, cfg ; lint-ignore: phantom-global
-    global SHADER_NAMES, SHADER_KEYS ; lint-ignore: phantom-global
-    global gShader_Registry ; lint-ignore: phantom-global
+    global gFX_ShaderLayers, gFX_GPUReady, gShader_Ready, cfg
+    global SHADER_NAMES, SHADER_KEYS
+    global gShader_Registry
 
     static cycling := false
     if (cycling)
@@ -964,8 +964,8 @@ FX_CycleShaderLayer(layerIndex) {
 
 ; Cycle the mouse effect.
 FX_CycleMouseEffect() {
-    global gFX_MouseEffect, gFX_GPUReady, gShader_Ready ; lint-ignore: phantom-global
-    global MOUSE_SHADER_NAMES, MOUSE_SHADER_KEYS, gShader_Registry ; lint-ignore: phantom-global
+    global gFX_MouseEffect, gFX_GPUReady, gShader_Ready
+    global MOUSE_SHADER_NAMES, MOUSE_SHADER_KEYS, gShader_Registry
 
     if (!gFX_GPUReady || !gShader_Ready)
         return
@@ -1008,9 +1008,9 @@ FX_CycleMouseEffect() {
 ; Cycle the selection effect.
 ; When UseBGShaderAsSelection is active, cycles through BG shaders instead.
 FX_CycleSelectionEffect() {
-    global gFX_SelectionEffect, gFX_GPUReady, gShader_Ready ; lint-ignore: phantom-global
-    global SELECTION_SHADER_NAMES, SELECTION_SHADER_KEYS, gShader_Registry ; lint-ignore: phantom-global
-    global SHADER_NAMES, SHADER_KEYS, cfg ; lint-ignore: phantom-global
+    global gFX_SelectionEffect, gFX_GPUReady, gShader_Ready
+    global SELECTION_SHADER_NAMES, SELECTION_SHADER_KEYS, gShader_Registry
+    global SHADER_NAMES, SHADER_KEYS, cfg
 
     if (!gFX_GPUReady || !gShader_Ready)
         return
@@ -1064,8 +1064,8 @@ FX_CycleSelectionEffect() {
 ; Pre-render the hover shader. Mirrors FX_PreRenderSelectionEffect but uses hover config.
 ; Sets selGlow/selIntensity on the registry entry right before render to avoid shared-entry conflict.
 FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borderWidth, entranceT, rowRadius := 0.0) {
-    global gFX_HoverEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime ; lint-ignore: phantom-global
-    global gShader_Registry, cfg ; lint-ignore: phantom-global
+    global gFX_HoverEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime
+    global gShader_Registry, cfg
 
     if (gFX_HoverEffect.key = "" || !gShader_Ready || !gFX_GPUReady)
         return
@@ -1127,7 +1127,7 @@ FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borde
 
 ; Draw the hover effect inside D2D BeginDraw.
 FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: dead-param
-    global gD2D_RT, gFX_HoverEffect, gShader_Ready, cfg ; lint-ignore: phantom-global
+    global gD2D_RT, gFX_HoverEffect, gShader_Ready, cfg
 
     if (gFX_HoverEffect.key = "" || !gShader_Ready)
         return
@@ -1169,9 +1169,9 @@ FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: d
 ; Cycle the hover effect.
 ; When UseBGShaderAsHoverSelection is active, cycles through BG shaders instead.
 FX_CycleHoverEffect() {
-    global gFX_HoverEffect, gFX_GPUReady, gShader_Ready ; lint-ignore: phantom-global
-    global SELECTION_SHADER_NAMES, SELECTION_SHADER_KEYS, gShader_Registry ; lint-ignore: phantom-global
-    global SHADER_NAMES, SHADER_KEYS, cfg ; lint-ignore: phantom-global
+    global gFX_HoverEffect, gFX_GPUReady, gShader_Ready
+    global SELECTION_SHADER_NAMES, SELECTION_SHADER_KEYS, gShader_Registry
+    global SHADER_NAMES, SHADER_KEYS, cfg
 
     if (!gFX_GPUReady || !gShader_Ready)
         return

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -554,7 +554,7 @@ _GUI_OnError(err, *) {
 }
 
 ; Clean up resources on exit
-_GUI_OnExit(reason, code) { ; lint-ignore: dead-param
+_GUI_OnExit(reason, code) {
     ; Send any unsent stats, then flush to disk
     try Stats_AccumulateSession()
     try Stats_ForceFlushToDisk()
@@ -665,7 +665,7 @@ if (!IsSet(g_AltTabbyMode) || g_AltTabbyMode = "gui") {
     Persistent()
 }
 
-_GUI_OnCopyData(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_GUI_OnCopyData(wParam, lParam, msg, hwnd) {
     Critical "On"
     global TABBY_CMD_TOGGLE_VIEWER, TABBY_CMD_PUMP_RESTARTED
     try {
@@ -705,7 +705,7 @@ _GUI_OnBlacklistFileChanged(path) { ; lint-ignore: dead-param
 ; Stats request handler — receives PostMessage(IPC_WM_STATS_REQUEST) from launcher.
 ; Responds with WM_COPYDATA containing JSON stats snapshot.
 ; Separate from WM_COPYDATA to avoid nested SendMessage deadlock in AHK v2.
-_GUI_OnStatsRequest(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_GUI_OnStatsRequest(wParam, lParam, msg, hwnd) {
     Critical "On"
     global TABBY_CMD_STATS_RESPONSE
     try {

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -390,7 +390,7 @@ GUI_CreateWindow() {
 
 ; WM_NCCALCSIZE: zero out non-client area to hide WS_CAPTION title bar.
 ; DWM still applies Mica to the caption style, but we consume the space as client area.
-_GUI_OnNcCalcSize(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_GUI_OnNcCalcSize(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param callback-critical — stateless WM handler, no shared state to protect
     try {
         global gGUI_BaseH
         if (hwnd = gGUI_BaseH && wParam)
@@ -401,7 +401,7 @@ _GUI_OnNcCalcSize(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
 
 ; Suppress WM_ERASEBKGND — return 1 to tell Windows we handled it.
 ; Prevents DWM from painting the default white background before D2D content.
-_GUI_OnEraseBkgnd(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_GUI_OnEraseBkgnd(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param callback-critical — stateless WM handler, no shared state to protect
     try {
         global gGUI_BaseH
         if (hwnd = gGUI_BaseH)

--- a/src/gui/gui_pump.ahk
+++ b/src/gui/gui_pump.ahk
@@ -313,7 +313,7 @@ _GUIPump_CollectTick() {
 
 ; ========================= MESSAGE HANDLER =========================
 
-_GUIPump_OnMessage(msg, hPipe) { ; lint-ignore: dead-param
+_GUIPump_OnMessage(msg, hPipe) {
     global cfg, FR_EV_ENRICH_RESP, _gPump_LastResponseTick, _gPump_LastRequestTick, gFR_Enabled
     global _gPump_PumpHwnd, _gPump_EnrichCount, g_TestingMode
     _gPump_LastResponseTick := A_TickCount
@@ -423,7 +423,7 @@ _GUIPump_OnMessage(msg, hPipe) { ; lint-ignore: dead-param
 
 ; ========================= PIPE WAKE =========================
 
-_GUIPump_OnPipeWake(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_GUIPump_OnPipeWake(wParam, lParam, msg, hwnd) {
     Critical "On"
     try {
         global _gPump_Client

--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -286,7 +286,7 @@ Launcher_StartSubprocesses() {
 }
 
 ; Cleanup handler called on exit
-_Launcher_OnExit(exitReason, exitCode) { ; lint-ignore: dead-param
+_Launcher_OnExit(exitReason, exitCode) {
     global g_LauncherMutex, g_ActiveMutex, g_ConfigEditorPID, g_BlacklistEditorPID
     try HideSplashScreen()
     try Launcher_ShutdownSubprocesses({config: g_ConfigEditorPID, blacklist: g_BlacklistEditorPID})
@@ -316,7 +316,7 @@ Launcher_ReacquireMutexes() {
 }
 
 ; Handle WM_COPYDATA control signals from child processes
-_Launcher_OnCopyData(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_Launcher_OnCopyData(wParam, lParam, msg, hwnd) {
     global cfg
     global TABBY_CMD_STATS_RESPONSE, TABBY_CMD_EDITOR_CLOSED, TABBY_CMD_PUMP_FAILED
     global g_StatsCache

--- a/src/launcher/launcher_tray.ahk
+++ b/src/launcher/launcher_tray.ahk
@@ -17,7 +17,7 @@ global g_NeedsAdminReload := true  ; Flag for admin config reload (start true fo
 global g_ConfigEditorPID := 0
 global g_BlacklistEditorPID := 0
 
-TrayIconClick(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param ; lint-ignore: error-boundary
+TrayIconClick(wParam, lParam, msg, hwnd) { ; lint-ignore: error-boundary
     ; 0x205 = WM_RBUTTONUP (right-click release)
     if (lParam = 0x205) {
         ; Dismiss splash screen if still showing — user wants to interact with tray,

--- a/src/pump/enrichment_pump.ahk
+++ b/src/pump/enrichment_pump.ahk
@@ -115,7 +115,7 @@ _Pump_OnDisconnect(hPipe) {
         _Pump_ClientPipe := 0
 }
 
-_Pump_OnPipeWake(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_Pump_OnPipeWake(wParam, lParam, msg, hwnd) {
     global _Pump_Server
     if (IsObject(_Pump_Server))
         IPC__ServerTick(_Pump_Server)

--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -1530,9 +1530,9 @@ global gConfigRegistry := [
 ; Returns a JSON string of the registry array suitable for JavaScript consumption.
 ConfigRegistry_SerializeToJSON() {
     global gConfigRegistry
-    global SHADER_KEYS, SHADER_NAMES ; lint-ignore: phantom-global
-    global MOUSE_SHADER_KEYS, MOUSE_SHADER_NAMES ; lint-ignore: phantom-global
-    global SELECTION_SHADER_KEYS, SELECTION_SHADER_NAMES ; lint-ignore: phantom-global
+    global SHADER_KEYS, SHADER_NAMES
+    global MOUSE_SHADER_KEYS, MOUSE_SHADER_NAMES
+    global SELECTION_SHADER_KEYS, SELECTION_SHADER_NAMES
 
     entries := []
     fields := ["type", "name", "desc", "long", "section", "s", "k", "g", "t", "d", "fmt"]

--- a/src/shared/theme.ahk
+++ b/src/shared/theme.ahk
@@ -641,7 +641,7 @@ _Theme_ApplyLightListView(ctrl) {
 ; Internal: WM_CTLCOLOR handlers
 ; ============================================================
 
-_Theme_OnCtlColorEdit(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns (OnMessage: bare return = default handling) ; lint-ignore: dead-param
+_Theme_OnCtlColorEdit(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns (OnMessage: bare return = default handling)
     global gTheme_Initialized, gTheme_Palette, gTheme_BrushEditBg
     if (!gTheme_Initialized)
         return
@@ -650,7 +650,7 @@ _Theme_OnCtlColorEdit(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns
     return gTheme_BrushEditBg
 }
 
-_Theme_OnCtlColorListBox(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns (OnMessage: bare return = default handling) ; lint-ignore: dead-param
+_Theme_OnCtlColorListBox(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns (OnMessage: bare return = default handling)
     global gTheme_Initialized, gTheme_Palette, gTheme_BrushEditBg, gTheme_BrushBg, gTheme_BrushPanelBg
     global gTheme_SidebarHwnds
     if (!gTheme_Initialized)
@@ -666,7 +666,7 @@ _Theme_OnCtlColorListBox(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-retu
     return gTheme_BrushEditBg
 }
 
-_Theme_OnCtlColorStatic(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns (OnMessage: bare return = default handling) ; lint-ignore: dead-param
+_Theme_OnCtlColorStatic(wParam, lParam, msg, hwnd) {  ; lint-ignore: mixed-returns (OnMessage: bare return = default handling)
     global gTheme_Initialized, gTheme_Palette, gTheme_BrushBg, gTheme_BrushPanelBg
     global gTheme_SemanticHwnds, gTheme_MutedHwnds, gTheme_AccentHwnds, gTheme_PanelParentHwnds
     if (!gTheme_Initialized)
@@ -791,7 +791,7 @@ _Theme_TabWndProc(hWnd, uMsg, wParam, lParam) {
 ; Internal: WM_SETTINGCHANGE listener
 ; ============================================================
 
-_Theme_OnSettingChange(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_Theme_OnSettingChange(wParam, lParam, msg, hwnd) {
     global gTheme_IsDark, gTheme_Palette, gTheme_Initialized, cfg
     if (!gTheme_Initialized)
         return
@@ -1023,7 +1023,7 @@ _Theme_RegisterOwnerDrawButton(ctrl) {
 }
 
 ; WM_DRAWITEM handler for owner-draw buttons
-_Theme_OnDrawItem(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_Theme_OnDrawItem(wParam, lParam, msg, hwnd) {
     global gTheme_ButtonMap, gTheme_Palette, cfg
 
     ; Only handle buttons (ODT_BUTTON = 4)

--- a/src/shared/win_utils.ahk
+++ b/src/shared/win_utils.ahk
@@ -150,7 +150,7 @@ _Win_RebuildMonitorCache() {
 }
 
 ; WM_DISPLAYCHANGE handler — clear cache so next lookup triggers rebuild
-_Win_OnDisplayChange(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param
+_Win_OnDisplayChange(wParam, lParam, msg, hwnd) {
     global gWin_MonitorLabelCache
     gWin_MonitorLabelCache := Map()
 }

--- a/src/viewer/viewer.ahk
+++ b/src/viewer/viewer.ahk
@@ -407,7 +407,7 @@ _Viewer_ForceRefresh() {
 
 ; ========================= RESIZE =========================
 
-_Viewer_OnResize(gui, minMax, w, h) { ; lint-ignore: dead-param
+_Viewer_OnResize(gui, minMax, w, h) {
     global gViewer_LV, gViewer_Status, gViewer_ShuttingDown
 
     if (gViewer_ShuttingDown)
@@ -560,7 +560,7 @@ _Viewer_InstallSubclass() {
 ; ========================= SUBCLASS CALLBACK (HEADER ONLY) =========================
 ; Only intercepts header NM_CUSTOMDRAW. All other notifications pass through.
 
-_Viewer_LVSubclassProc(hwnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) { ; lint-ignore: dead-param
+_Viewer_LVSubclassProc(hwnd, uMsg, wParam, lParam, uIdSubclass, dwRefData) {
     global gViewer_LVHeaderHwnd, gViewer_ShuttingDown
 
     if (gViewer_ShuttingDown || uMsg != 0x004E)  ; Not WM_NOTIFY
@@ -703,7 +703,7 @@ _Viewer_DrawHeader(lParam) {
 ; WM_NOTIFY handler for row NM_CUSTOMDRAW + focus events
 ; Routes notifications from the ListView to the appropriate handler.
 ; Only intercepts notifications from our ListView; everything else falls through.
-_Viewer_OnWMNotify(wParam, lParam, msg, hwnd) { ; lint-ignore: dead-param  lint-ignore: mixed-returns
+_Viewer_OnWMNotify(wParam, lParam, msg, hwnd) { ; lint-ignore: mixed-returns
     global gViewer_LV, gViewer_Gui, gViewer_ShuttingDown
     if (gViewer_ShuttingDown || !gViewer_LV || !gViewer_Gui)
         return
@@ -971,7 +971,7 @@ _Viewer_InvalidateRow(rowIdx) {
 
 ; ========================= COLUMN CLICK SORT =========================
 
-_Viewer_OnColClick(lv, col) { ; lint-ignore: dead-param
+_Viewer_OnColClick(lv, col) {
     global gViewer_SortCol, gViewer_SortAsc, gViewer_LVHeaderHwnd, gViewer_LastRev
     global gViewer_ShuttingDown
     if (gViewer_ShuttingDown)

--- a/tests/check_batch_functions.ps1
+++ b/tests/check_batch_functions.ps1
@@ -229,7 +229,8 @@ $MIN_GLOBAL_NAME_LENGTH = 2
 $sharedFuncDefs = @{}
 
 # --- Shared file-scope globals (for check_globals) ---
-$sharedFileGlobals = @{}  # globalName -> "relpath:lineNum" (src/ only)
+$sharedFileGlobals = @{}  # globalName -> "relpath:lineNum" (src/ only, excludes lib/)
+$libFileGlobals = @{}     # globalName -> "relpath:lineNum" (lib/ only, for phantom-global check)
 $testsDirNorm = ""
 if (Test-Path $testsDir) {
     $testsDirNorm = [System.IO.Path]::GetFullPath($testsDir).ToLower().TrimEnd('\') + '\'
@@ -287,11 +288,14 @@ foreach ($file in $allProjectFiles) {
     $isTestFile = $testsDirNorm -and $file.FullName.ToLower().StartsWith($testsDirNorm)
     $isLibFile = $file.FullName -like "*\lib\*"
 
-    # --- Fast path for lib/ files: only register function names + class names ---
-    # lib/ files only contribute to $ucDefinedFunctions (check_undefined_calls).
-    # Skip all other processing: no BF_CleanLine, no BF_CountBraces, no depth tracking,
-    # no global collection, no processedLines cache, no multi-line detection.
+    # --- Fast path for lib/ files: register function names, class names, AND file-scope globals ---
+    # lib/ files contribute to $ucDefinedFunctions (check_undefined_calls) and
+    # $libFileGlobals (phantom-global check only). Kept separate from $sharedFileGlobals
+    # to avoid false positives in the undeclared-globals check (lib/ globals like 'bitmap'
+    # and 'meta' are too generic — they'd flag every local variable with the same name).
+    # Lightweight depth tracking: only count braces to distinguish file-scope from function-scope.
     if ($isLibFile) {
+        $libDepth = 0
         for ($i = 0; $i -lt $lines.Count; $i++) {
             $raw = $lines[$i]
             if ($raw -match '^\s*;') { continue }
@@ -303,6 +307,24 @@ foreach ($file in $allProjectFiles) {
                 }
             } elseif ($raw -match '^\s*class\s+(\w+)') {
                 [void]$ucDefinedFunctions.Add($Matches[1])
+            }
+
+            # Collect file-scope globals (depth 0) into lib-only set for phantom-global check
+            if ($libDepth -eq 0) {
+                $mG = $script:RX_GLOBAL_DECL.Match($raw)
+                if ($mG.Success) {
+                    foreach ($gName in (BF_ExtractGlobalNames $mG.Groups[1].Value)) {
+                        if (-not $libFileGlobals.ContainsKey($gName)) {
+                            $libFileGlobals[$gName] = "${relPath}:$($i + 1)"
+                        }
+                    }
+                }
+            }
+
+            # Lightweight brace tracking for depth
+            foreach ($ch in $raw.ToCharArray()) {
+                if ($ch -eq '{') { $libDepth++ }
+                elseif ($ch -eq '}') { if ($libDepth -gt 0) { $libDepth-- } }
             }
         }
         continue  # Skip full processing for this file
@@ -907,8 +929,10 @@ $ENTRY_POINT_PATTERNS = @(
 $entryPointRegex = [regex]::new(($ENTRY_POINT_PATTERNS -join '|'), 'Compiled, IgnoreCase')
 
 # Build function definition list from sharedFuncDefs (src/ only)
+# Exempt d2d_types.ahk — D2D type constructors are a utility library, callers come and go.
 $deadFuncDefs = @{}
 foreach ($file in $srcFiles) {
+    if ($file.Name -eq 'd2d_types.ahk') { continue }
     $lines = $fileCache[$file.FullName]
     $relPath = $file.FullName.Replace("$projectRoot\", '')
     $inBlockComment2 = $false
@@ -1284,6 +1308,9 @@ foreach ($file in $allFilesForGlobals) {
                 if (-not $isTestFile) {
                     foreach ($gn in $funcDeclaredGlobals.Keys) {
                         if ($checkGlobals.ContainsKey($gn)) { continue }
+                        # Also accept globals declared in lib/ files (not in $checkGlobals
+                        # to avoid false positives in undeclared-globals, but valid for phantom check)
+                        if ($libFileGlobals.ContainsKey($gn)) { continue }
                         $declInfo = $funcGlobalDeclLines[$gn]
                         if ($declInfo -and $declInfo.Raw -match 'lint-ignore:\s*phantom-global') { continue }
                         [void]$phantomIssues.Add([PSCustomObject]@{

--- a/tests/check_batch_simple.ps1
+++ b/tests/check_batch_simple.ps1
@@ -1675,7 +1675,13 @@ $dgIssues = [System.Collections.ArrayList]::new()
 # Phase 1: Collect ALL file-scope global declarations from src/ files
 $dgAllGlobals = [System.Collections.ArrayList]::new()
 
+# Exempt API-surface / constant-definition library files from dead-global check.
+# These files declare D2D/DXGI/GDI+ enums and constants for completeness — not all
+# are consumed yet, but removing them means re-declaring when next needed.
+$dgExemptFiles = @('d2d_types.ahk', 'gui_constants.ahk')
+
 foreach ($file in $allFiles) {
+    if ($file.Name -in $dgExemptFiles) { continue }
     $processed = $processedCache[$file.FullName]
     $relPath = $file.FullName.Replace("$projectRoot\", '')
     $depth = 0
@@ -2126,10 +2132,34 @@ $sw.Stop()
 # Sub-check 14: dead_params
 # Detects function parameters never referenced in the function
 # body. Excludes variadic (*) and throwaway (_).
+# Auto-exempts functions registered as callbacks (framework-mandated signatures).
 # Suppress: ; lint-ignore: dead-param (on function definition line)
 # ============================================================
 $sw = [System.Diagnostics.Stopwatch]::StartNew()
 $dpIssues = [System.Collections.ArrayList]::new()
+
+# Build set of function names registered as callbacks (auto-exempt from dead-param).
+# AHK v2 callback signatures are framework-mandated — can't remove params without crash.
+$dpCallbackFuncs = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+$dpCbPatterns = @(
+    [regex]::new('(?:OnMessage|Hotkey)\s*\(\s*[^,]+,\s*(\w+)', 'Compiled'),
+    [regex]::new('(?:OnExit|OnError)\s*\(\s*(\w+)', 'Compiled'),
+    [regex]::new('CallbackCreate\s*\(\s*(\w+)', 'Compiled'),
+    [regex]::new('\.OnEvent\s*\(\s*"[^"]*"\s*,\s*(\w+)', 'Compiled'),
+    [regex]::new('IPC_Pipe\w+_(?:Connect|Start)\s*\(\s*[^,]+,\s*(\w+)', 'Compiled'),
+    [regex]::new('OVERLAPPED\s*\(\s*(\w+)', 'Compiled')
+)
+foreach ($f in $allFiles) {
+    $dpText = $fileCacheText[$f.FullName]
+    foreach ($rx in $dpCbPatterns) {
+        foreach ($m in $rx.Matches($dpText)) {
+            $cbName = $m.Groups[1].Value
+            if ($cbName -and $cbName -notin $BS_AHK_KEYWORDS) {
+                [void]$dpCallbackFuncs.Add($cbName)
+            }
+        }
+    }
+}
 
 foreach ($fd in $bsFuncDefs) {
     $dpProc = $processedCache[$fd.FullPath]
@@ -2138,6 +2168,9 @@ foreach ($fd in $bsFuncDefs) {
 
     # Function-level suppression
     if ($dpProc[$dpDefIdx].Raw -match 'lint-ignore:\s*dead-param') { continue }
+
+    # Auto-exempt functions registered as callbacks (framework-mandated signatures)
+    if ($dpCallbackFuncs.Contains($fd.Name)) { continue }
 
     $dpParamStr = $fd.Params.Trim()
     if ($dpParamStr -eq '' -or $dpParamStr -eq '*') { continue }


### PR DESCRIPTION
## Summary

Closes #185

- **Exempt constant-definition files** (`d2d_types.ahk`, `gui_constants.ahk`) from `dead-global` and `dead-function` checks — removes 134 inline suppressions from API surface definitions
- **Scan `src/lib/*.ahk` for global declarations** in the `phantom-global` check — recognizes shader bundle globals without enforcing other checks on lib files, removes 34 suppressions
- **Auto-detect framework callbacks** (OnMessage, OnEvent, Hotkey, CallbackCreate, IPC pipe, OVERLAPPED) and exempt them from `dead-param` — removes 33 suppressions from functions with mandatory signatures
- **Fix 2 latent callback-critical findings** on `_GUI_OnNcCalcSize`/`_GUI_OnEraseBkgnd` — previously masked by trailing comments breaking the function-definition regex

Net: 199 `lint-ignore` lines removed, 8 added (multi-tag lines) = **191 fewer inline suppressions**.

No new static analysis failures — only pre-existing `check_batch_functions.ps1` issues (dead functions + undefined `Shader_PreRender`).

## Test plan

- [x] Static analysis: 1 bundle failure (pre-existing), 9 passed — identical to baseline
- [ ] `.\tests\test.ps1 --live` blocked by pre-existing `check_batch_functions.ps1` failure (same on main)
- [x] Verified baseline equivalence via stash/unstash comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)