### PR TITLE
Add profiler instrumentation to compositor and hot-path functions

### DIFF
--- a/src/core/icon_pump.ahk
+++ b/src/core/icon_pump.ahk
@@ -233,6 +233,7 @@ IconPump_CleanupWindow(hwnd) {
 ;   Phase 2 (Critical OFF): Icon resolution (SendMessageTimeoutW may block up to 500ms)
 ;   Phase 3 (Critical ON):  Re-validate record, apply results (discard if removed during Phase 2)
 _IP_Tick() {
+    Profiler.Enter("_IP_Tick") ; @profile
     global IconBatchPerTick, _IP_Attempts, _IP_IdleTicks, _IP_IdleThreshold, _IP_TimerOn
     global IconMaxAttempts, IconAttemptBackoffMs, IconAttemptBackoffMultiplier
     global IP_LOG_TITLE_MAX_LEN, _IP_DiagEnabled, _IP_LogPath
@@ -244,12 +245,16 @@ _IP_Tick() {
     logEnabled := _IP_DiagEnabled && _IP_LogPath != ""
     static _errCount := 0  ; Error boundary: consecutive error tracking
     static _backoffUntil := 0  ; Tick-based cooldown for exponential backoff
-    if (A_TickCount < _backoffUntil)
+    if (A_TickCount < _backoffUntil) {
+        Profiler.Leave() ; @profile
         return
+    }
     ; Skip icon resolution during active Alt-Tab — keyboard hooks must not be blocked
     ; by SendMessageTimeoutW. Queue persists; deferred icons process when overlay dismisses.
-    if (gGUI_State = "ALT_PENDING" || gGUI_State = "ACTIVE")
+    if (gGUI_State = "ALT_PENDING" || gGUI_State = "ACTIVE") {
+        Profiler.Leave() ; @profile
         return
+    }
     try {
 
     ; PERF: Periodically prune _IP_Attempts to prevent unbounded growth
@@ -264,6 +269,7 @@ _IP_Tick() {
     if (!IsObject(hwnds) || hwnds.Length = 0) {
         ; Idle detection: pause timer after threshold empty ticks to reduce CPU churn
         Pump_HandleIdle(&_IP_IdleTicks, _IP_IdleThreshold, &_IP_TimerOn, _IP_Tick, _IP_Log)
+        Profiler.Leave() ; @profile
         return
     }
     _IP_IdleTicks := 0  ; Reset idle counter when we have work
@@ -475,19 +481,23 @@ _IP_Tick() {
         global LOG_PATH_ICONPUMP
         HandleTimerError(e, &_errCount, &_backoffUntil, LOG_PATH_ICONPUMP, "IP_Tick")
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Get raw HICON from window via WM_GETICON or class icon (no CopyIcon).
 ; Returns the window's own icon handle — caller does NOT own it, do NOT DestroyIcon.
 ; Used by EnrichmentPump for nochange detection (raw handle is stable for unchanged icons).
 IP_GetRawWindowIcon(hWnd) {
+    Profiler.Enter("IP_GetRawWindowIcon") ; @profile
     global IP_WM_GETICON, IP_ICON_BIG, IP_ICON_SMALL, IP_ICON_SMALL2
     global IP_GCLP_HICONSM, IP_GCLP_HICON, IP_SMTO_ABORTIFHUNG, IP_RESOLVE_TIMEOUT_MS
     global _IP_DiagEnabled, _IP_LogPath
 
     try {
-        if (DllCall("user32\IsHungAppWindow", "ptr", hWnd, "int"))
+        if (DllCall("user32\IsHungAppWindow", "ptr", hWnd, "int")) {
+            Profiler.Leave() ; @profile
             return 0
+        }
 
         h := 0
         result := 0
@@ -503,11 +513,13 @@ IP_GetRawWindowIcon(hWnd) {
             h := DllCall("user32\GetClassLongPtrW", "ptr", hWnd, "int", IP_GCLP_HICON, "ptr")
         if (!h)
             h := DllCall("user32\GetClassLongPtrW", "ptr", hWnd, "int", IP_GCLP_HICONSM, "ptr")
+        Profiler.Leave() ; @profile
         return h
     } catch as e {
         if (_IP_DiagEnabled && _IP_LogPath != "")
             _IP_Log("WARN: IP_GetRawWindowIcon failed for hwnd=" hWnd " err=" e.Message)
     }
+    Profiler.Leave() ; @profile
     return 0
 }
 
@@ -723,24 +735,31 @@ _IP_GetPackagePath(pid) {
 ; Try to extract icon from UWP package
 ; Uses cached logo path lookup to avoid repeated manifest parsing for multiple windows from same app
 IP_TryResolveFromUWP(pid) {
+    Profiler.Enter("IP_TryResolveFromUWP") ; @profile
     global _IP_DiagEnabled, _IP_LogPath
     ; Get package path first (also confirms it's a UWP app)
     packagePath := _IP_GetPackagePath(pid)
-    if (packagePath = "")
+    if (packagePath = "") {
+        Profiler.Leave() ; @profile
         return 0
+    }
 
     ; Get logo path (cached by packagePath)
     logoPath := _IP_GetUWPLogoPathCached(packagePath)
-    if (logoPath = "" || !FileExist(logoPath))
+    if (logoPath = "" || !FileExist(logoPath)) {
+        Profiler.Leave() ; @profile
         return 0
+    }
 
     ; Load PNG as HBITMAP
     hBitmap := 0
     hIcon := 0
     try {
         hBitmap := LoadPicture(logoPath, "GDI+")
-        if (!hBitmap)
+        if (!hBitmap) {
+            Profiler.Leave() ; @profile
             return 0
+        }
 
         ; Convert HBITMAP to HICON
         hIcon := _IP_BitmapToIcon(hBitmap)
@@ -753,6 +772,7 @@ IP_TryResolveFromUWP(pid) {
     if (hBitmap)
         DllCall("gdi32\DeleteObject", "ptr", hBitmap)
 
+    Profiler.Leave() ; @profile
     return hIcon
 }
 

--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -619,6 +619,7 @@ _KomorebiSub_IssueRead() {
 ; Signature: (overlappedObj, err, bytesTransferred) per OVERLAPPED.ahk calling convention.
 ; Runs on the AHK thread (marshaled via SendMessageW from thread pool).
 _KomorebiSub_OnReadComplete(overlappedObj, err, bytesTransferred) { ; lint-ignore: dead-param
+    Profiler.Enter("_KomorebiSub_OnReadComplete") ; @profile
     global _KSub_hPipe, _KSub_ReadPending, _KSub_LastEventTick, _KSub_AsyncMode
     global _KSub_ReadBuffer, _KSub_ReadBufferLen
     global KSUB_READ_BUF, KSUB_BUFFER_MAX_BYTES, IPC_ERROR_BROKEN_PIPE
@@ -627,6 +628,7 @@ _KomorebiSub_OnReadComplete(overlappedObj, err, bytesTransferred) { ; lint-ignor
     static _backoffUntil := 0
     if (A_TickCount < _backoffUntil) {
         _KSub_ReadPending := false
+        Profiler.Leave() ; @profile
         return  ; In backoff — maintenance timer will re-issue later
     }
     try {
@@ -642,16 +644,19 @@ _KomorebiSub_OnReadComplete(overlappedObj, err, bytesTransferred) { ; lint-ignor
         ; ERROR_OPERATION_ABORTED (995) = CancelIoEx from Stop()
         if (err = IPC_ERROR_BROKEN_PIPE) {
             _KomorebiSub_Start()
+            Profiler.Leave() ; @profile
             return
         }
         if (err = 995) {
             ; Cancellation — do NOT re-issue or restart
+            Profiler.Leave() ; @profile
             return
         }
 
         ; Other error: try to recover by re-issuing read
         if (_KSub_AsyncMode && _KSub_hPipe)
             _KomorebiSub_IssueRead()
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -704,6 +709,7 @@ _KomorebiSub_OnReadComplete(overlappedObj, err, bytesTransferred) { ; lint-ignor
         if (_KSub_AsyncMode && _KSub_hPipe)
             _KomorebiSub_IssueRead()
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Maintenance timer for async mode. Runs at a slow interval (default 2000ms).

--- a/src/core/proc_pump.ahk
+++ b/src/core/proc_pump.ahk
@@ -114,19 +114,23 @@ ProcPump_EnsureRunning() {
 
 ; Main pump tick
 _PP_Tick() {
+    Profiler.Enter("_PP_Tick") ; @profile
     global ProcBatchPerTick, _PP_IdleTicks, _PP_IdleThreshold, _PP_TimerOn, cfg
 
     global gPP_PopBatch, gPP_GetProcNameCached, gPP_UpdateProcessName
     static _errCount := 0  ; Error boundary: consecutive error tracking
     static _backoffUntil := 0  ; Tick-based cooldown for exponential backoff
-    if (A_TickCount < _backoffUntil)
+    if (A_TickCount < _backoffUntil) {
+        Profiler.Leave() ; @profile
         return
+    }
     logEnabled := cfg.DiagProcPumpLog
     try {
     pids := gPP_PopBatch(ProcBatchPerTick)
     if (!IsObject(pids) || pids.Length = 0) {
         ; Idle detection: pause timer after threshold empty ticks to reduce CPU churn
         Pump_HandleIdle(&_PP_IdleTicks, _PP_IdleThreshold, &_PP_TimerOn, _PP_Tick, _PP_Log)
+        Profiler.Leave() ; @profile
         return
     }
     _PP_IdleTicks := 0  ; Reset idle counter when we have work
@@ -185,6 +189,7 @@ _PP_Tick() {
         global LOG_PATH_PROCPUMP
         HandleTimerError(e, &_errCount, &_backoffUntil, LOG_PATH_PROCPUMP, "PP_Tick")
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Get full process path from PID (uses shared utility with logging)

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -227,6 +227,7 @@ Anim_Shutdown() {
 ;   Tier 3: QPC spin-wait only — pure software cap
 ; After pacing: Sleep(0) message pump → Critical On (paint) → Critical Off.
 _Anim_FrameLoop() {
+    Profiler.Enter("_Anim_FrameLoop") ; @profile
     global gAnim_TimerRunning, gAnim_Tweens, gAnim_LastFrameTime, gAnim_FrameCapMs, gAnim_FrameDt
     global gAnim_OverlayOpacity, gAnim_HidePending, gAnim_FrameTimeDisplay
     global gGUI_OverlayVisible, cfg
@@ -328,6 +329,7 @@ _Anim_FrameLoop() {
         }
     }
 
+    Profiler.Leave() ; @profile
     Anim_StopTimer()
 }
 
@@ -336,10 +338,12 @@ _Anim_FrameLoop() {
 ; AHK's Sleep(N>0) goes through MsgSleep which oversleeps by ~10-15ms, making it
 ; unusable for sub-20ms frame caps. Pure spin is precise and CPU-cheap (yielded).
 _Anim_FramePace() {
+    Profiler.Enter("_Anim_FramePace") ; @profile
     global gAnim_LastFrameTime, gAnim_FrameCapMs
     nextFrame := gAnim_LastFrameTime + gAnim_FrameCapMs
     while (QPC() < nextFrame)
         DllCall("ntdll\NtYieldExecution")
+    Profiler.Leave() ; @profile
 }
 
 _Anim_SyncOverlayOpacity() {
@@ -412,13 +416,16 @@ Anim_ForceCompleteHide() {
 }
 
 _Anim_DoActualHide() {
+    Profiler.Enter("_Anim_DoActualHide") ; @profile
     global gGUI_OverlayVisible, gGUI_Base, gGUI_BaseH, gGUI_Revealed, gD2D_RT
     global cfg, GUI_LOG_TRIM_EVERY_N_HIDES
     global gGUI_DisplayItems
     static hideCount := 0
 
-    if (!gGUI_OverlayVisible)
+    if (!gGUI_OverlayVisible) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     ; Release deferred display items — kept alive during hide-fade so the
     ; frame loop paints the frozen list while fading out (not the live MRU).
@@ -455,6 +462,7 @@ _Anim_DoActualHide() {
     if (Mod(hideCount, GUI_LOG_TRIM_EVERY_N_HIDES) = 0) {
         Paint_LogTrim()
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= SELECTION SLIDE =========================

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -316,11 +316,14 @@ FX_UpdateAmbient(dt) {
 
 ; Pre-render all active shader layers (D3D11 pipeline). Called BEFORE D2D BeginDraw.
 FX_PreRenderShaderLayers(w, h) {
+    Profiler.Enter("FX_PreRenderShaderLayers") ; @profile
     global gFX_ShaderLayers, gShader_Ready, gFX_AmbientTime, gFX_ShaderTime ; lint-ignore: phantom-global (gShader_Ready in src/lib/d2d_shader.ahk)
     global gFX_GPUReady, cfg
 
-    if (!gShader_Ready || !gFX_GPUReady || gFX_ShaderLayers.Length = 0)
+    if (!gShader_Ready || !gFX_GPUReady || gFX_ShaderLayers.Length = 0) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     for _, layer in gFX_ShaderLayers {
         if (layer.key = "")
@@ -350,15 +353,19 @@ FX_PreRenderShaderLayers(w, h) {
                 LogAppend(LOG_PATH_SHADER, errDetail)
         }
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Draw all active shader layers inside D2D BeginDraw.
 ; Opacity is baked into shader output via AT_PostProcess — no PushLayer needed.
 FX_DrawShaderLayers(wPhys, hPhys) { ; lint-ignore: dead-param
+    Profiler.Enter("FX_DrawShaderLayers") ; @profile
     global gD2D_RT, gFX_ShaderLayers, gShader_Ready ; lint-ignore: phantom-global (gShader_Ready in src/lib/d2d_shader.ahk)
 
-    if (!gShader_Ready || gFX_ShaderLayers.Length = 0)
+    if (!gShader_Ready || gFX_ShaderLayers.Length = 0) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     for _, layer in gFX_ShaderLayers {
         if (layer.key = "")
@@ -367,18 +374,22 @@ FX_DrawShaderLayers(wPhys, hPhys) { ; lint-ignore: dead-param
         if (pBitmap)
             gD2D_RT.DrawImage(pBitmap)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= MOUSE EFFECT =========================
 
 ; Pre-render the mouse effect (D3D11 pipeline). Called BEFORE D2D BeginDraw.
 FX_PreRenderMouseEffect(w, h) {
+    Profiler.Enter("FX_PreRenderMouseEffect") ; @profile
     global gFX_MouseEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime ; lint-ignore: phantom-global
     global gFX_MouseX, gFX_MouseY, gFX_MouseInWindow, cfg
     global gFX_MousePrevX, gFX_MousePrevY, gFX_MouseVelX, gFX_MouseVelY, gFX_MouseSpeed, gFX_MousePrevValid
 
-    if (gFX_MouseEffect.key = "" || !gShader_Ready || !gFX_GPUReady)
+    if (gFX_MouseEffect.key = "" || !gShader_Ready || !gFX_GPUReady) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     ; --- Compute mouse velocity (CPU-side, per frame) ---
     baseTime := gFX_AmbientTime / 1000.0 * gFX_MouseEffect.speed
@@ -423,6 +434,7 @@ FX_PreRenderMouseEffect(w, h) {
 
     if (cfg.PerfAdaptiveMouseFPS && mouseSkipNext) {
         mouseSkipNext := false  ; always render the frame after a skip
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -444,18 +456,23 @@ FX_PreRenderMouseEffect(w, h) {
     ; If the mouse shader alone took more than half the frame budget, skip next frame
     if (cfg.PerfAdaptiveMouseFPS && mouseLastRenderMs > gAnim_FrameCapMs * 0.5)
         mouseSkipNext := true
+    Profiler.Leave() ; @profile
 }
 
 ; Draw the mouse effect inside D2D BeginDraw.
 FX_DrawMouseEffect(wPhys, hPhys) { ; lint-ignore: dead-param
+    Profiler.Enter("FX_DrawMouseEffect") ; @profile
     global gD2D_RT, gFX_MouseEffect, gShader_Ready ; lint-ignore: phantom-global
 
-    if (gFX_MouseEffect.key = "" || !gShader_Ready)
+    if (gFX_MouseEffect.key = "" || !gShader_Ready) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     pBitmap := Shader_GetBitmap(gFX_MouseEffect.key)
     if (pBitmap)
         gD2D_RT.DrawImage(pBitmap)
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= SELECTION EFFECT =========================
@@ -463,11 +480,14 @@ FX_DrawMouseEffect(wPhys, hPhys) { ; lint-ignore: dead-param
 ; Pre-render the selection shader. Called DURING paint (needs selection geometry).
 ; Decomposes ARGB ints to premultiplied float4 RGBA for the shader cbuffer.
 FX_PreRenderSelectionEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borderWidth, isHovered, entranceT, rowRadius := 0.0) {
+    Profiler.Enter("FX_PreRenderSelectionEffect") ; @profile
     global gFX_SelectionEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime ; lint-ignore: phantom-global
     global gShader_Registry, cfg ; lint-ignore: phantom-global
 
-    if (gFX_SelectionEffect.key = "" || !gShader_Ready || !gFX_GPUReady)
+    if (gFX_SelectionEffect.key = "" || !gShader_Ready || !gFX_GPUReady) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     ; Set selGlow/selIntensity right before render (shared-entry fix with hover)
     if (!gFX_SelectionEffect.isBGShader && gShader_Registry.Has(gFX_SelectionEffect.key)) {
@@ -522,19 +542,25 @@ FX_PreRenderSelectionEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, b
         if (cfg.DiagShaderLog)
             LogAppend(LOG_PATH_SHADER, errDetail)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Draw the selection effect inside D2D BeginDraw.
 ; selX/selY/selW/selH/rad are only needed for BG-as-selection (clipping + border).
 FX_DrawSelectionEffect(wPhys, hPhys, selX := 0, selY := 0, selW := 0, selH := 0, rad := 0) { ; lint-ignore: dead-param
+    Profiler.Enter("FX_DrawSelectionEffect") ; @profile
     global gD2D_RT, gFX_SelectionEffect, gShader_Ready, cfg ; lint-ignore: phantom-global
 
-    if (gFX_SelectionEffect.key = "" || !gShader_Ready)
+    if (gFX_SelectionEffect.key = "" || !gShader_Ready) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     pBitmap := Shader_GetBitmap(gFX_SelectionEffect.key)
-    if (!pBitmap)
+    if (!pBitmap) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     if (gFX_SelectionEffect.isBGShader) {
         static srcRect := Buffer(16), tgtPt := Buffer(8), dstRect := Buffer(16)
@@ -566,6 +592,7 @@ FX_DrawSelectionEffect(wPhys, hPhys, selX := 0, selY := 0, selW := 0, selH := 0,
     } else {
         gD2D_RT.DrawImage(pBitmap)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= SHADER CONFIG RESOLUTION =========================
@@ -1064,11 +1091,14 @@ FX_CycleSelectionEffect() {
 ; Pre-render the hover shader. Mirrors FX_PreRenderSelectionEffect but uses hover config.
 ; Sets selGlow/selIntensity on the registry entry right before render to avoid shared-entry conflict.
 FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borderWidth, entranceT, rowRadius := 0.0) {
+    Profiler.Enter("FX_PreRenderHoverEffect") ; @profile
     global gFX_HoverEffect, gShader_Ready, gFX_GPUReady, gFX_AmbientTime, gFX_ShaderTime ; lint-ignore: phantom-global
     global gShader_Registry, cfg ; lint-ignore: phantom-global
 
-    if (gFX_HoverEffect.key = "" || !gShader_Ready || !gFX_GPUReady)
+    if (gFX_HoverEffect.key = "" || !gShader_Ready || !gFX_GPUReady) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     ; Set selGlow/selIntensity right before render (shared-entry fix)
     hovIntensity := cfg.GUI_HoverSelectionIntensity
@@ -1123,18 +1153,24 @@ FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borde
         if (cfg.DiagShaderLog)
             LogAppend(LOG_PATH_SHADER, errDetail)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Draw the hover effect inside D2D BeginDraw.
 FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: dead-param
+    Profiler.Enter("FX_DrawHoverEffect") ; @profile
     global gD2D_RT, gFX_HoverEffect, gShader_Ready, cfg ; lint-ignore: phantom-global
 
-    if (gFX_HoverEffect.key = "" || !gShader_Ready)
+    if (gFX_HoverEffect.key = "" || !gShader_Ready) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     pBitmap := Shader_GetBitmap(gFX_HoverEffect.key)
-    if (!pBitmap)
+    if (!pBitmap) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     if (gFX_HoverEffect.isBGShader) {
         static hov_srcRect := Buffer(16), hov_tgtPt := Buffer(8), hov_dstRect := Buffer(16)
@@ -1164,6 +1200,7 @@ FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: d
     } else {
         gD2D_RT.DrawImage(pBitmap)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Cycle the hover effect.

--- a/src/gui/gui_gdip.ahk
+++ b/src/gui/gui_gdip.ahk
@@ -335,14 +335,19 @@ D2D_DisposeResources() {
 ; Extract BGRA pixel data from HICON (preserving alpha channel).
 ; Returns {pixels: Buffer, w: int, h: int, stride: int} or 0 on failure.
 _D2D_ExtractIconPixels(hIcon) {
-    if (!hIcon)
+    Profiler.Enter("_D2D_ExtractIconPixels") ; @profile
+    if (!hIcon) {
+        Profiler.Leave() ; @profile
         return 0
+    }
 
     ; Get icon info — gives us color bitmap and mask
     iiSize := 8 + A_PtrSize * 3
     ii := Buffer(iiSize, 0)
-    if (!DllCall("user32\GetIconInfo", "ptr", hIcon, "ptr", ii.Ptr, "int"))
+    if (!DllCall("user32\GetIconInfo", "ptr", hIcon, "ptr", ii.Ptr, "int")) {
+        Profiler.Leave() ; @profile
         return 0
+    }
 
     hbmMask := NumGet(ii, 8 + A_PtrSize, "ptr")
     hbmColor := NumGet(ii, 8 + A_PtrSize * 2, "ptr")
@@ -350,6 +355,7 @@ _D2D_ExtractIconPixels(hIcon) {
     if (!hbmColor) {
         if (hbmMask)
             DllCall("gdi32\DeleteObject", "ptr", hbmMask)
+        Profiler.Leave() ; @profile
         return 0
     }
 
@@ -360,6 +366,7 @@ _D2D_ExtractIconPixels(hIcon) {
         DllCall("gdi32\DeleteObject", "ptr", hbmColor)
         if (hbmMask)
             DllCall("gdi32\DeleteObject", "ptr", hbmMask)
+        Profiler.Leave() ; @profile
         return 0
     }
 
@@ -371,6 +378,7 @@ _D2D_ExtractIconPixels(hIcon) {
         DllCall("gdi32\DeleteObject", "ptr", hbmColor)
         if (hbmMask)
             DllCall("gdi32\DeleteObject", "ptr", hbmMask)
+        Profiler.Leave() ; @profile
         return 0
     }
 
@@ -395,6 +403,7 @@ _D2D_ExtractIconPixels(hIcon) {
         DllCall("gdi32\DeleteObject", "ptr", hbmColor)
         if (hbmMask)
             DllCall("gdi32\DeleteObject", "ptr", hbmMask)
+        Profiler.Leave() ; @profile
         return 0
     }
 
@@ -416,6 +425,7 @@ _D2D_ExtractIconPixels(hIcon) {
     if (hbmMask)
         DllCall("gdi32\DeleteObject", "ptr", hbmMask)
 
+    Profiler.Leave() ; @profile
     return {pixels: pixels, w: w, h: h, stride: stride}
 }
 
@@ -459,21 +469,29 @@ _D2D_CreateBitmapFromPixels(iconData) {
 ; Called when icons are resolved so the bitmap is ready before paint.
 ; Backward-compatible name for gui_data.ahk callers.
 Gdip_PreCacheIcon(hwnd, hIcon) {
+    Profiler.Enter("Gdip_PreCacheIcon") ; @profile
     global gGdip_IconCache, gD2D_RT
-    if (!hIcon || !gD2D_RT)
+    if (!hIcon || !gD2D_RT) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     ; Already cached with same hIcon — nothing to do
     cached := gGdip_IconCache.Get(hwnd, 0)
-    if (cached && cached.hicon = hIcon && cached.bitmap)
+    if (cached && cached.hicon = hIcon && cached.bitmap) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     ; Extract pixel data and create D2D bitmap
     iconData := _D2D_ExtractIconPixels(hIcon)
-    if (!iconData)
+    if (!iconData) {
+        Profiler.Leave() ; @profile
         return
+    }
     bitmap := _D2D_CreateBitmapFromPixels(iconData)
     gGdip_IconCache[hwnd] := {hicon: hIcon, bitmap: bitmap}
+    Profiler.Leave() ; @profile
 }
 
 ; Draw icon with caching — avoids HICON→D2D bitmap conversion on every frame.

--- a/src/gui/gui_input.ahk
+++ b/src/gui/gui_input.ahk
@@ -36,10 +36,12 @@ _GUI_GetDisplayItems() {
 ; ========================= SELECTION MOVEMENT =========================
 
 _GUI_MoveSelection(delta) {
+    Profiler.Enter("_GUI_MoveSelection") ; @profile
     global gGUI_Sel, gGUI_ScrollTop, gGUI_OverlayH, cfg
 
     items := _GUI_GetDisplayItems()
     if (items.Length = 0 || delta = 0) {
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -86,6 +88,7 @@ _GUI_MoveSelection(delta) {
     ; during rapid mouse wheel scroll (Logitech infinite scroll).
     if (cfg.PerfAnimationType = "None")
         GUI_Repaint()
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= HOVER DETECTION =========================
@@ -352,6 +355,7 @@ _GUI_RemoveItemAt(idx1) {
 ; ========================= MOUSE HANDLERS =========================
 
 GUI_OnClick(x, y) {
+    Profiler.Enter("GUI_OnClick") ; @profile
     global gGUI_LiveItems, gGUI_Sel, gGUI_OverlayH, gGUI_OverlayVisible, gGUI_ScrollTop, cfg
     global gGUI_LeftArrowRect, gGUI_RightArrowRect, gGUI_State, gGUI_DisplayItems
 
@@ -360,6 +364,7 @@ GUI_OnClick(x, y) {
     ; Don't process clicks if overlay isn't visible
     if (!gGUI_OverlayVisible) {
         Critical "Off"
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -370,6 +375,7 @@ GUI_OnClick(x, y) {
             && y >= gGUI_LeftArrowRect.y && y < gGUI_LeftArrowRect.y + gGUI_LeftArrowRect.h) {
             Critical "Off"
             GUI_ToggleWorkspaceMode()
+            Profiler.Leave() ; @profile
             return
         }
         ; Right arrow click
@@ -377,6 +383,7 @@ GUI_OnClick(x, y) {
             && y >= gGUI_RightArrowRect.y && y < gGUI_RightArrowRect.y + gGUI_RightArrowRect.h) {
             Critical "Off"
             GUI_ToggleWorkspaceMode()
+            Profiler.Leave() ; @profile
             return
         }
     }
@@ -387,6 +394,7 @@ GUI_OnClick(x, y) {
     if (act != "") {
         Critical "Off"
         _GUI_PerformAction(act, idx)
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -394,6 +402,7 @@ GUI_OnClick(x, y) {
     count := items.Length
     if (count = 0) {
         Critical "Off"
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -403,12 +412,14 @@ GUI_OnClick(x, y) {
     rowsTopDip := cfg.GUI_MarginY + GUI_HeaderBlockDip()
     if (yDip < rowsTopDip) {
         Critical "Off"
+        Profiler.Leave() ; @profile
         return
     }
 
     vis := GUI_GetVisibleRows()
     if (vis <= 0) {
         Critical "Off"
+        Profiler.Leave() ; @profile
         return
     }
     rowsDrawn := vis
@@ -422,6 +433,7 @@ GUI_OnClick(x, y) {
     }
     if (idxVisible > rowsDrawn) {
         Critical "Off"
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -438,6 +450,7 @@ GUI_OnClick(x, y) {
         ; run in a normal timer context where the frame loop can present.
         Critical "Off"
         SetTimer(_GUI_DeferredClickActivate, -1)
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -450,6 +463,7 @@ GUI_OnClick(x, y) {
     Critical "Off"
 
     GUI_Repaint()
+    Profiler.Leave() ; @profile
 }
 
 _GUI_DeferredClickActivate() {

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -263,6 +263,7 @@ _GUI_Main_Init() {
 ; Called by producers (via gWS_OnStoreChanged) after modifying the store.
 ; Triggers GUI refresh when overlay is visible or pre-warming.
 _GUI_OnProducerRevChanged(isStructural := true) {
+    Profiler.Enter("_GUI_OnProducerRevChanged") ; @profile
     global gGUI_State
 
     ; Error boundary: producers run in-process, so unhandled errors propagate
@@ -299,6 +300,7 @@ _GUI_OnProducerRevChanged(isStructural := true) {
         global LOG_PATH_STORE
         try LogAppend(LOG_PATH_STORE, "producer_rev_callback err=" e.Message " file=" e.File " line=" e.Line)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; GUI_OnWorkspaceFlips() moved to gui_state.ahk (workspace state owner)

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -757,10 +757,13 @@ D2D_IsHDRActive() {
 ; With FLIP_DISCARD, back buffer content is undefined after Present(),
 ; so each frame gets a fresh buffer (~6μs per acquire).
 D2D_AcquireBackBuffer() {
+    Profiler.Enter("D2D_AcquireBackBuffer") ; @profile
     global gD2D_SwapChain, gD2D_RT, gD2D_BackBuffer
 
-    if (!gD2D_SwapChain || !gD2D_RT)
+    if (!gD2D_SwapChain || !gD2D_RT) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     ; Static buffer: hot path (~120fps), avoid per-frame allocation
     static bp1 := 0
@@ -776,17 +779,20 @@ D2D_AcquireBackBuffer() {
     surface := gD2D_SwapChain.GetBuffer(0)
     gD2D_BackBuffer := gD2D_RT.CreateBitmapFromDxgiSurface(surface, bp1)
     gD2D_RT.SetTarget(gD2D_BackBuffer)
+    Profiler.Leave() ; @profile
     return true
 }
 
 ; Release the back buffer after EndDraw(). Must be called BEFORE Present().
 ; Unbinding the target allows the swap chain to flip the buffer.
 D2D_ReleaseBackBuffer() {
+    Profiler.Enter("D2D_ReleaseBackBuffer") ; @profile
     global gD2D_RT, gD2D_BackBuffer
     if (gD2D_BackBuffer) {
         gD2D_RT.SetTarget(0)
         gD2D_BackBuffer := 0  ; COM Release via __Delete
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= D2D PRESENT =========================
@@ -795,10 +801,14 @@ D2D_ReleaseBackBuffer() {
 ; syncInterval=0 for immediate (waitable swap chain handles pacing).
 ; Fallback path: frame loop spin-waits for frame boundary instead of VSync.
 D2D_Present(syncInterval := 0) {
+    Profiler.Enter("D2D_Present") ; @profile
     global gD2D_SwapChain
-    if (!gD2D_SwapChain)
+    if (!gD2D_SwapChain) {
+        Profiler.Leave() ; @profile
         return
+    }
     gD2D_SwapChain.Present(syncInterval, 0)
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= DCOMP CLIP (Phase 2) =========================

--- a/src/gui/gui_pump.ahk
+++ b/src/gui/gui_pump.ahk
@@ -193,17 +193,22 @@ GUIPump_EnsureRunning() {
 ; Event-driven: started by GUIPump_EnsureRunning, pauses after idle threshold.
 
 _GUIPump_CollectTick() {
+    Profiler.Enter("_GUIPump_CollectTick") ; @profile
     global _gPump_Client, _gPump_Connected, cfg, FR_EV_ENRICH_REQ, gFR_Enabled
     global _gPump_LastRequestTick, _gPump_LastResponseTick
     global _gPump_IdleTicks, _gPump_IdleThreshold, _gPump_TimerOn, _gPump_CollectTimerFn
     global _gPump_HelloSent, _gPump_PumpHwnd, _GPUMP_HEARTBEAT_MS
     static _errCount := 0
     static _backoffUntil := 0  ; Tick-based cooldown for exponential backoff
-    if (A_TickCount < _backoffUntil)
+    if (A_TickCount < _backoffUntil) {
+        Profiler.Leave() ; @profile
         return
+    }
     try {
-        if (!_gPump_Connected)
+        if (!_gPump_Connected) {
+            Profiler.Leave() ; @profile
             return
+        }
 
         ; Hang detection: sent request but no response within timeout.
         ; Must run before idle check — timer must stay running while request is in flight.
@@ -212,6 +217,7 @@ _GUIPump_CollectTick() {
             if (cfg.DiagPumpLog)
                 _GUIPump_Log("HUNG: No response for " (A_TickCount - _gPump_LastRequestTick) "ms, declaring pump hung")
             _GUIPump_HandleFailure("hung")
+            Profiler.Leave() ; @profile
             return
         }
 
@@ -243,8 +249,10 @@ _GUIPump_CollectTick() {
 
         if (hwnds.Length = 0) {
             ; Don't pause if waiting for a response — need timer running for hang detection
-            if (_gPump_LastRequestTick > _gPump_LastResponseTick)
+            if (_gPump_LastRequestTick > _gPump_LastResponseTick) {
+                Profiler.Leave() ; @profile
                 return
+            }
             ; Switch to heartbeat mode after idle threshold — slow timer checks pump health.
             ; Unlike local pumps (which fully stop), the enrichment pump needs to detect
             ; process death even when idle, since it's the only path to PUMP_FAILED signal.
@@ -259,6 +267,7 @@ _GUIPump_CollectTick() {
                     _GUIPump_Log("HEARTBEAT: Pump window gone, declaring pump dead")
                 _GUIPump_HandleFailure("process_exit")
             }
+            Profiler.Leave() ; @profile
             return
         }
 
@@ -297,6 +306,7 @@ _GUIPump_CollectTick() {
         ok := IPC_PipeClient_Send(_gPump_Client, requestJson, _gPump_PumpHwnd)
         if (!ok) {
             _GUIPump_HandleFailure("pipe_write")
+            Profiler.Leave() ; @profile
             return
         }
         _gPump_LastRequestTick := A_TickCount
@@ -309,11 +319,13 @@ _GUIPump_CollectTick() {
         global LOG_PATH_IPC
         HandleTimerError(e, &_errCount, &_backoffUntil, LOG_PATH_IPC, "GUIPump_CollectTick")
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= MESSAGE HANDLER =========================
 
 _GUIPump_OnMessage(msg, hPipe) { ; lint-ignore: dead-param
+    Profiler.Enter("_GUIPump_OnMessage") ; @profile
     global cfg, FR_EV_ENRICH_RESP, _gPump_LastResponseTick, _gPump_LastRequestTick, gFR_Enabled
     global _gPump_PumpHwnd, _gPump_EnrichCount, g_TestingMode
     _gPump_LastResponseTick := A_TickCount
@@ -327,6 +339,7 @@ _GUIPump_OnMessage(msg, hPipe) { ; lint-ignore: dead-param
     } catch {
         if (cfg.DiagPumpLog)
             _GUIPump_Log("ERROR: Failed to parse pump response, msg=" SubStr(msg, 1, 200))
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -336,6 +349,7 @@ _GUIPump_OnMessage(msg, hPipe) { ; lint-ignore: dead-param
     if (msgType != IPC_MSG_ENRICHMENT) {
         if (cfg.DiagPumpLog)
             _GUIPump_Log("WARN: unexpected type='" msgType "' (expected '" IPC_MSG_ENRICHMENT "')")
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -349,6 +363,7 @@ _GUIPump_OnMessage(msg, hPipe) { ; lint-ignore: dead-param
     if (!parsed.Has("results")) {
         if (cfg.DiagPumpLog)
             _GUIPump_Log("WARN: no 'results' key in response")
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -419,6 +434,7 @@ _GUIPump_OnMessage(msg, hPipe) { ; lint-ignore: dead-param
             _GUIPump_WriteEnrichSignal(_gPump_EnrichCount)
         }
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= PIPE WAKE =========================

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -412,6 +412,7 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
 ; ========================= GRACE TIMER =========================
 
 _GUI_GraceTimerFired() {
+    Profiler.Enter("_GUI_GraceTimerFired") ; @profile
     ; RACE FIX: Prevent race with Alt_Up hotkey - timer can fire while
     ; GUI_OnInterceptorEvent is processing ALT_UP, causing inconsistent state
     Critical "On"
@@ -424,12 +425,14 @@ _GUI_GraceTimerFired() {
         _GUI_ShowOverlayWithFrozen()
     }
     Critical "Off"
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= WORKSPACE FLIP CALLBACK =========================
 
 ; Called by KomorebiSub (via gWS_OnWorkspaceChanged) when workspace changes.
 GUI_OnWorkspaceFlips() {
+    Profiler.Enter("GUI_OnWorkspaceFlips") ; @profile
     global gGUI_CurrentWSName, gWS_Meta, cfg
 
     ; Error boundary: same rationale as _GUI_OnProducerRevChanged in gui_main.
@@ -452,6 +455,7 @@ GUI_OnWorkspaceFlips() {
         global LOG_PATH_STORE
         try LogAppend(LOG_PATH_STORE, "workspace_flip_callback err=" e.Message " file=" e.File " line=" e.Line)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= FROZEN STATE HELPERS =========================
@@ -510,13 +514,16 @@ GUI_HandleWorkspaceSwitch() {
 ; When filtering is active, avoids the intermediate throwaway array that two
 ; sequential filter calls would create.
 GUI_FilterDisplayItems(items) {
+    Profiler.Enter("GUI_FilterDisplayItems") ; @profile
     global gGUI_WorkspaceMode, WS_MODE_ALL
     global gGUI_MonitorMode, MON_MODE_ALL, gGUI_OverlayMonitorHandle
 
     wsAll := (gGUI_WorkspaceMode = WS_MODE_ALL)
     monAll := (gGUI_MonitorMode = MON_MODE_ALL) || !gGUI_OverlayMonitorHandle
-    if (wsAll && monAll)
+    if (wsAll && monAll) {
+        Profiler.Leave() ; @profile
         return items
+    }
     result := []
     for _, item in items {
         if (!wsAll && !GUI_WorkspaceItemPasses(item))
@@ -525,6 +532,7 @@ GUI_FilterDisplayItems(items) {
             continue
         result.Push(item)
     }
+    Profiler.Leave() ; @profile
     return result
 }
 
@@ -552,6 +560,7 @@ GUI_RefilterForWorkspaceChange() {
 ; Unlike RefilterForWorkspaceChange (which selects foreground window),
 ; this preserves MRU-based selection since the user is browsing, not switching.
 GUI_ApplyWorkspaceFilter() {
+    Profiler.Enter("GUI_ApplyWorkspaceFilter") ; @profile
     global gGUI_DisplayItems, gGUI_ToggleBase
     ; RACE FIX: Keep Critical through repaint — a hotkey can interrupt between filter and
     ; repaint, reassigning gGUI_DisplayItems via GUI_OnInterceptorEvent. Follows the
@@ -565,11 +574,13 @@ GUI_ApplyWorkspaceFilter() {
     ; GUI_ResizeToRows separately causes a stale frame (old content at new size).
     GUI_Repaint()
     Critical "Off"
+    Profiler.Leave() ; @profile
 }
 
 ; Re-filter display items after monitor mode toggle.
 ; Same pattern as ApplyWorkspaceFilter — preserves MRU selection.
 GUI_ApplyMonitorFilter() {
+    Profiler.Enter("GUI_ApplyMonitorFilter") ; @profile
     global gGUI_DisplayItems, gGUI_ToggleBase
     Critical "On"
     gGUI_DisplayItems := GUI_FilterDisplayItems(gGUI_ToggleBase)
@@ -578,6 +589,7 @@ GUI_ApplyMonitorFilter() {
     ; Let GUI_Repaint handle resize atomically (same as ApplyWorkspaceFilter).
     GUI_Repaint()
     Critical "Off"
+    Profiler.Leave() ; @profile
 }
 
 ; Reset selection to MRU position (1 or 2) and clamp to list bounds.
@@ -754,10 +766,12 @@ _GUI_ShowOverlayWithFrozen() {
 }
 
 _GUI_MoveSelectionFrozen(delta) {
+    Profiler.Enter("_GUI_MoveSelectionFrozen") ; @profile
     global gGUI_Sel, gGUI_DisplayItems, gGUI_ScrollTop, cfg
     global gFX_GPUReady
 
     if (gGUI_DisplayItems.Length = 0) {
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -785,6 +799,7 @@ _GUI_MoveSelectionFrozen(delta) {
         if (gFX_SelectionEffect.key != "")
             Anim_StartTween("fx_sel_entrance", 0.0, 1.0, 200, Anim_EaseOutCubic)
     }
+    Profiler.Leave() ; @profile
 }
 
 _GUI_ActivateFromFrozen() {
@@ -1034,11 +1049,13 @@ _GUI_ActivateItem(item) {
 }
 
 GUI_ClickActivate(item) {
+    Profiler.Enter("GUI_ClickActivate") ; @profile
     global gGUI_State, gGUI_DisplayItems, cfg
     global gAnim_HidePending
     Critical "On"
     if (gGUI_State != "ACTIVE") {
         Critical "Off"
+        Profiler.Leave() ; @profile
         return
     }
     ; Match keyboard path: hide first, activate, set IDLE last.
@@ -1055,6 +1072,7 @@ GUI_ClickActivate(item) {
     gGUI_State := "IDLE"
     Stats_AccumulateSession()
     Critical "Off"
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= SWITCH-ACTIVATE METHOD =========================
@@ -1470,6 +1488,7 @@ _GUI_ResyncKeyboardState() {
 ; Updates: gGUI_LiveItems array order
 ; NOTE: Callers hold Critical — do NOT call Critical "Off" here (leaks caller's Critical state)
 _GUI_UpdateLocalMRU(hwnd) {
+    Profiler.Enter("_GUI_UpdateLocalMRU") ; @profile
     Critical "On"  ; Harmless assertion — documents that Critical is required
     global gGUI_LiveItems, gGUI_LiveItemsMap, cfg
     global FR_EV_MRU_UPDATE, gFR_Enabled
@@ -1482,6 +1501,7 @@ _GUI_UpdateLocalMRU(hwnd) {
             FR_Record(FR_EV_MRU_UPDATE, hwnd, 0)
         if (diagLog)
             GUI_LogEvent("MRU UPDATE: hwnd " hwnd " not in map, skip scan")
+        Profiler.Leave() ; @profile
         return false
     }
 
@@ -1509,6 +1529,7 @@ _GUI_UpdateLocalMRU(hwnd) {
     WL_UpdateFields(hwnd, {lastActivatedTick: tick, isFocused: true}, "gui_activate")
     if (gFR_Enabled)
         FR_Record(FR_EV_MRU_UPDATE, hwnd, 1)
+    Profiler.Leave() ; @profile
     return true
 }
 
@@ -1699,11 +1720,14 @@ _GUI_UncloakWindow(hwnd) {
 ; Try COM-based uncloaking and activation
 ; Returns: 0 = failed, 1 = uncloak only, 2 = uncloak + SwitchTo succeeded
 _GUI_TryComUncloak(hwnd) {
+    Profiler.Enter("_GUI_TryComUncloak") ; @profile
     global gGUI_AppViewCollection, cfg
 
     ; Try to initialize if not already done
-    if (!gGUI_AppViewCollection && !_GUI_InitAppViewCollection())
+    if (!gGUI_AppViewCollection && !_GUI_InitAppViewCollection()) {
+        Profiler.Leave() ; @profile
         return 0
+    }
 
     viewVtable := 0
     try {
@@ -1721,6 +1745,7 @@ _GUI_TryComUncloak(hwnd) {
         if (hr != 0 || !pView) {
             if (cfg.DiagEventLog)
                 GUI_LogEvent("COM: GetViewForHwnd failed")
+            Profiler.Leave() ; @profile
             return 0
         }
 
@@ -1751,12 +1776,18 @@ _GUI_TryComUncloak(hwnd) {
         releaseView := NumGet(viewVtable, 2 * A_PtrSize, "UPtr")
         DllCall(releaseView, "Ptr", pView)
 
-        if (uncloakOk && switchOk)
+        if (uncloakOk && switchOk) {
+            Profiler.Leave() ; @profile
             return 2  ; Full success
-        else if (uncloakOk)
+        }
+        else if (uncloakOk) {
+            Profiler.Leave() ; @profile
             return 1  ; Uncloak worked, SwitchTo failed
-        else
+        }
+        else {
+            Profiler.Leave() ; @profile
             return 0  ; Failed
+        }
     } catch as e {
         ; Release pView if it was acquired before the exception
         if (pView && viewVtable) {
@@ -1765,8 +1796,10 @@ _GUI_TryComUncloak(hwnd) {
         }
         if (cfg.DiagEventLog)
             GUI_LogEvent("COM: Exception - " e.Message)
+        Profiler.Leave() ; @profile
         return 0
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= KOMOREBI SOCKET COMMANDS =========================
@@ -1841,11 +1874,14 @@ _GUI_SendKomorebiSocketCmd(cmdType, content) {
 ; cliCmd: CLI subcommand (e.g., "focus-named-workspace")
 ; wsName: Target workspace name
 _GUI_KomorebiWorkspaceCmd(socketCmd, cliCmd, wsName) {
+    Profiler.Enter("_GUI_KomorebiWorkspaceCmd") ; @profile
     global cfg
 
     if (cfg.KomorebiUseSocket) {
-        if (_GUI_SendKomorebiSocketCmd(socketCmd, wsName))
+        if (_GUI_SendKomorebiSocketCmd(socketCmd, wsName)) {
+            Profiler.Leave() ; @profile
             return true
+        }
         if (cfg.DiagEventLog)
             GUI_LogEvent("SOCKET: " socketCmd " failed, falling back to komorebic.exe")
     }
@@ -1855,6 +1891,7 @@ _GUI_KomorebiWorkspaceCmd(socketCmd, cliCmd, wsName) {
     if (cfg.DiagEventLog)
         GUI_LogEvent("KOMOREBIC: Running " cmd)
     ProcessUtils_RunHidden(cmd)
+    Profiler.Leave() ; @profile
     return true
 }
 

--- a/src/shared/blacklist.ahk
+++ b/src/shared/blacklist.ahk
@@ -301,6 +301,7 @@ BL_ProbeVisMinCloak(hwnd, &outVis, &outMin, &outCloak) {
 ; Extended Alt-Tab eligibility - returns vis/min/cloak via ByRef
 ; Used by Blacklist_IsWindowEligibleEx to avoid redundant DllCalls in WinUtils_ProbeWindow
 _BL_IsAltTabEligibleEx(hwnd, &outVis, &outMin, &outCloak) {
+    Profiler.Enter("_BL_IsAltTabEligibleEx") ; @profile
     global BL_WS_CHILD, BL_WS_EX_TOOLWINDOW, BL_WS_EX_APPWINDOW, BL_WS_EX_NOACTIVATE
     global GWL_STYLE, GWL_EXSTYLE, GW_OWNER
 
@@ -311,8 +312,10 @@ _BL_IsAltTabEligibleEx(hwnd, &outVis, &outMin, &outCloak) {
     style := DllCall("user32\GetWindowLongPtrW", "ptr", hwnd, "int", GWL_STYLE, "ptr")
 
     ; Child windows are never Alt-Tab eligible
-    if (style & BL_WS_CHILD)
+    if (style & BL_WS_CHILD) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     ; Get extended window style
     ex := DllCall("user32\GetWindowLongPtrW", "ptr", hwnd, "int", GWL_EXSTYLE, "ptr")
@@ -322,24 +325,33 @@ _BL_IsAltTabEligibleEx(hwnd, &outVis, &outMin, &outCloak) {
     isNoActivate := (ex & BL_WS_EX_NOACTIVATE) != 0
 
     ; Tool windows are never Alt-Tab eligible
-    if (isTool)
+    if (isTool) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     ; NoActivate windows are not Alt-Tab eligible
-    if (isNoActivate)
+    if (isNoActivate) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     ; Get owner window
     owner := DllCall("user32\GetWindow", "ptr", hwnd, "uint", GW_OWNER, "ptr")
 
     ; Owned windows need WS_EX_APPWINDOW to be eligible
-    if (owner != 0 && !isApp)
+    if (owner != 0 && !isApp) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     ; Must be visible, minimized, or cloaked
-    if !(outVis || outMin || outCloak)
+    if !(outVis || outMin || outCloak) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
+    Profiler.Leave() ; @profile
     return true
 }
 

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -446,14 +446,17 @@ _WS_ApplyPatch(row, patch, hwnd) {
 }
 
 WL_UpdateFields(hwnd, patch, source := "", returnRow := false) {
+    Profiler.Enter("WL_UpdateFields") ; @profile
     global gWS_Store, gWS_Rev, gWS_SortOrderDirty, gWS_ContentDirty
     global gWS_MRUBumpOnly
     ; RACE FIX: Wrap body in Critical to prevent two producers from interleaving
     ; check-then-set on the same hwnd's fields (timer/hotkey interruption)
     Critical "On"
     hwnd := hwnd + 0
-    if (!gWS_Store.Has(hwnd))
+    if (!gWS_Store.Has(hwnd)) {
+        Profiler.Leave() ; @profile
         return { changed: false, exists: false, rev: gWS_Rev }
+    }
     row := gWS_Store[hwnd]
 
     ; Apply patch using shared helper
@@ -469,8 +472,11 @@ WL_UpdateFields(hwnd, patch, source := "", returnRow := false) {
         _WS_BumpRev("UpdateFields:" . source)
     }
     ; Return row when requested to avoid redundant GetByHwnd lookups
-    if (returnRow)
+    if (returnRow) {
+        Profiler.Leave() ; @profile
         return { changed: changed, exists: true, rev: gWS_Rev, row: row }
+    }
+    Profiler.Leave() ; @profile
     return { changed: changed, exists: true, rev: gWS_Rev }
 }
 
@@ -770,6 +776,7 @@ WL_IsOnCurrentWorkspace(workspaceName, currentWSName) {
 }
 
 WL_SetCurrentWorkspace(id, name := "") {
+    Profiler.Enter("WL_SetCurrentWorkspace") ; @profile
     global gWS_Meta, gWS_Rev, gWS_Store, gWS_SortOrderDirty, gWS_ContentDirty, gWS_MRUBumpOnly
     global gWS_OnWorkspaceChanged
     ; RACE FIX: Wrap entire body in Critical — meta writes (currentWSId, currentWSName)
@@ -782,8 +789,10 @@ WL_SetCurrentWorkspace(id, name := "") {
 
     ; Only recalculate window state if workspace NAME changed
     ; ID is metadata only — GUI cares about name for filtering
-    if (gWS_Meta["currentWSName"] = name)
+    if (gWS_Meta["currentWSName"] = name) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     gWS_Meta["currentWSName"] := name
 
@@ -810,6 +819,7 @@ WL_SetCurrentWorkspace(id, name := "") {
     if (gWS_OnWorkspaceChanged)
         gWS_OnWorkspaceChanged()  ; lint-ignore: critical-leak
 
+    Profiler.Leave() ; @profile
     return anyFlipped
 }
 


### PR DESCRIPTION
## Summary

- Instruments 39 new functions with `Profiler.Enter/Leave` pairs across 13 source files, doubling coverage from 39 to 78 functions
- Covers previously invisible compositor pipeline: shader pre-render, effect compositing (mouse/selection/hover), swap chain acquire/release/present, frame loop and pacing
- Adds visibility into state machine actions (grace timer, workspace flips, click activate), input handling, background pumps (icon/proc/GUI), and window data updates
- Braceless `if`-`return` patterns wrapped in braces to maintain correct control flow with inserted `Profiler.Leave()` calls
- All markers tagged with `; @profile` for zero-cost stripping in release builds

Closes #195

## Test plan

- [x] Static analysis passes all profile marker balance checks (every Enter has matching Leave at all return paths)
- [x] No new unreachable code violations (braceless if-return wrapping verified)
- [x] Pre-existing static analysis failures confirmed identical on main (dead functions, undefined Shader_PreRender)
- [ ] Manual smoke test: Alt-Tab overlay shows/hides correctly
- [ ] Profile build (`compile.ps1 --profile`): verify new spans appear in speedscope flame graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)