### PR TITLE
Eliminate per-frame waste in D2D paint pipeline

### DIFF
--- a/src/gui/d2d_types.ahk
+++ b/src/gui/d2d_types.ahk
@@ -8,7 +8,7 @@
 ; Layout: { float r, g, b, a }
 
 D2D_ColorF(argb) { ; lint-ignore: dead-function
-    buf := Buffer(16)
+    static buf := Buffer(16)
     NumPut("float", ((argb >> 16) & 0xFF) / 255.0,
            "float", ((argb >> 8) & 0xFF) / 255.0,
            "float", (argb & 0xFF) / 255.0,

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -16,6 +16,10 @@ global gFX_GPUReady := false  ; Set after successful init
 global gFX_GPUOutput := Map() ; name → ID2D1Image (cached GetOutput results)
 global gFX_HDRActive := false  ; True when HDR gamma compensation is active
 
+; Cached SoftRect effect object references (avoid Map lookups on hot path)
+global gFX_SoftRectFlood, gFX_SoftRectCrop, gFX_SoftRectBlur, gFX_SoftRectBlurOut
+global gFX_SoftRect2Flood, gFX_SoftRect2Crop, gFX_SoftRect2Blur, gFX_SoftRect2BlurOut
+
 global gFX_ShaderLayers := []        ; Array of {key, name, opacity, darkness, desat, speed} per configured layer
 global gFX_ShaderTime := Map()       ; layerIndex → {offset, carry, accumulate} — per-layer time state
 global gFX_MouseEffect      ; Mouse effect state: {key, name, opacity}
@@ -39,6 +43,8 @@ global gFX_MousePrevValid := false   ; False until first valid sample
 FX_GPU_Init() {
     global gD2D_RT, gFX_GPU, gFX_GPUReady, gFX_GPUOutput, gFX_HDRActive, cfg
     global gFX_ShaderLayers, gFX_MouseEffect, gFX_SelectionEffect, gFX_HoverEffect
+    global gFX_SoftRectFlood, gFX_SoftRectCrop, gFX_SoftRectBlur, gFX_SoftRectBlurOut
+    global gFX_SoftRect2Flood, gFX_SoftRect2Crop, gFX_SoftRect2Blur, gFX_SoftRect2BlurOut
     global SHADER_KEYS ; lint-ignore: phantom-global
     global CLSID_D2D1GaussianBlur, CLSID_D2D1Shadow, CLSID_D2D1Flood
     global CLSID_D2D1Crop, CLSID_D2D1ColorMatrix, CLSID_D2D1Saturation
@@ -77,6 +83,23 @@ FX_GPU_Init() {
         ; Cache frequently-used GetOutput() results (avoids COM call per frame)
         gFX_GPUOutput["blur"]  := gFX_GPU["blur"].GetOutput()
         gFX_GPUOutput["blur2"] := gFX_GPU["blur2"].GetOutput()
+
+        ; Set border modes once at init — these never change (Finding #5)
+        global FX_CROP_BORDER_MODE, FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT
+        gFX_GPU["crop"].SetEnum(FX_CROP_BORDER_MODE, D2D1_BORDER_SOFT)
+        gFX_GPU["blur"].SetEnum(FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT)
+        gFX_GPU["crop2"].SetEnum(FX_CROP_BORDER_MODE, D2D1_BORDER_SOFT)
+        gFX_GPU["blur2"].SetEnum(FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT)
+
+        ; Cache direct references for hot-path use (avoids Map lookups per frame)
+        gFX_SoftRectFlood := gFX_GPU["flood"]
+        gFX_SoftRectCrop := gFX_GPU["crop"]
+        gFX_SoftRectBlur := gFX_GPU["blur"]
+        gFX_SoftRectBlurOut := gFX_GPUOutput["blur"]
+        gFX_SoftRect2Flood := gFX_GPU["flood2"]
+        gFX_SoftRect2Crop := gFX_GPU["crop2"]
+        gFX_SoftRect2Blur := gFX_GPU["blur2"]
+        gFX_SoftRect2BlurOut := gFX_GPUOutput["blur2"]
 
         ; --- HDR compensation: CPU-side gamma on flood colors ---
         ; Previous approach inserted GammaTransfer AFTER blur, but gamma on blurred
@@ -191,53 +214,45 @@ FX_GPU_Dispose() {
 ; x,y,w,h: rectangle in physical pixels. argb: fill color. blurStdDev: blur amount.
 ; offsetX/Y: additional translation (e.g., shadow offset).
 FX_DrawSoftRect(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
-    global gD2D_RT, gFX_GPU, gFX_GPUOutput
-    global FX_FLOOD_COLOR, FX_CROP_RECT, FX_BLUR_STDEV, FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT
-
-    flood := gFX_GPU["flood"], crop := gFX_GPU["crop"], blur := gFX_GPU["blur"]
+    global gD2D_RT, FX_FLOOD_COLOR, FX_CROP_RECT, FX_BLUR_STDEV
+    global gFX_SoftRectFlood, gFX_SoftRectCrop, gFX_SoftRectBlur, gFX_SoftRectBlurOut
 
     ; HDR: gamma-correct the flood color CPU-side (avoids premultiplied alpha edge artifacts)
-    flood.SetColorF(FX_FLOOD_COLOR, FX_HDRCorrectARGB(argb))
+    gFX_SoftRectFlood.SetColorF(FX_FLOOD_COLOR, FX_HDRCorrectARGB(argb))
 
-    ; Configure crop to the rectangle bounds
-    crop.SetRectF(FX_CROP_RECT, Float(x), Float(y), Float(x + w), Float(y + h))
-    crop.SetEnum(1, D2D1_BORDER_SOFT)  ; soft border for smooth blur
+    ; Configure crop to the rectangle bounds (border mode set once in FX_GPU_Init)
+    gFX_SoftRectCrop.SetRectF(FX_CROP_RECT, Float(x), Float(y), Float(x + w), Float(y + h))
 
-    ; Configure blur
-    blur.SetFloat(FX_BLUR_STDEV, blurStdDev)
-    blur.SetEnum(FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT)
+    ; Configure blur (border mode set once in FX_GPU_Init)
+    gFX_SoftRectBlur.SetFloat(FX_BLUR_STDEV, blurStdDev)
 
     ; Draw at offset position
     if (offsetX != 0 || offsetY != 0) {
         static drawPt := Buffer(8)
         NumPut("float", Float(offsetX), "float", Float(offsetY), drawPt)
-        gD2D_RT.DrawImage(gFX_GPUOutput["blur"], drawPt)
+        gD2D_RT.DrawImage(gFX_SoftRectBlurOut, drawPt)
     } else {
-        gD2D_RT.DrawImage(gFX_GPUOutput["blur"])
+        gD2D_RT.DrawImage(gFX_SoftRectBlurOut)
     }
 }
 
 ; Draw a soft rectangle using the secondary chain (flood2→crop2→blur2).
 ; Allows drawing two different soft rects without reconfiguring the primary chain.
 FX_DrawSoftRect2(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
-    global gD2D_RT, gFX_GPU, gFX_GPUOutput
-    global FX_FLOOD_COLOR, FX_CROP_RECT, FX_BLUR_STDEV, FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT
-
-    flood2 := gFX_GPU["flood2"], crop2 := gFX_GPU["crop2"], blur2 := gFX_GPU["blur2"]
+    global gD2D_RT, FX_FLOOD_COLOR, FX_CROP_RECT, FX_BLUR_STDEV
+    global gFX_SoftRect2Flood, gFX_SoftRect2Crop, gFX_SoftRect2Blur, gFX_SoftRect2BlurOut
 
     ; HDR: gamma-correct the flood color CPU-side (avoids premultiplied alpha edge artifacts)
-    flood2.SetColorF(FX_FLOOD_COLOR, FX_HDRCorrectARGB(argb))
-    crop2.SetRectF(FX_CROP_RECT, Float(x), Float(y), Float(x + w), Float(y + h))
-    crop2.SetEnum(1, D2D1_BORDER_SOFT)
-    blur2.SetFloat(FX_BLUR_STDEV, blurStdDev)
-    blur2.SetEnum(FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT)
+    gFX_SoftRect2Flood.SetColorF(FX_FLOOD_COLOR, FX_HDRCorrectARGB(argb))
+    gFX_SoftRect2Crop.SetRectF(FX_CROP_RECT, Float(x), Float(y), Float(x + w), Float(y + h))
+    gFX_SoftRect2Blur.SetFloat(FX_BLUR_STDEV, blurStdDev)
 
     if (offsetX != 0 || offsetY != 0) {
         static drawPt := Buffer(8)
         NumPut("float", Float(offsetX), "float", Float(offsetY), drawPt)
-        gD2D_RT.DrawImage(gFX_GPUOutput["blur2"], drawPt)
+        gD2D_RT.DrawImage(gFX_SoftRect2BlurOut, drawPt)
     } else {
-        gD2D_RT.DrawImage(gFX_GPUOutput["blur2"])
+        gD2D_RT.DrawImage(gFX_SoftRect2BlurOut)
     }
 }
 
@@ -245,15 +260,20 @@ FX_DrawSoftRect2(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
 ; GPU-accelerated window-edge shadows (replaces gradient-strip approach).
 
 FX_GPU_DrawInnerShadow(wPhys, hPhys, depth, alpha) {
+    ; Pre-compute alpha multipliers — config-stable, only changes on config reload
+    static cachedAlpha := -1, cachedEdge := 0, cachedBot := 0
+    if (alpha != cachedAlpha) {
+        cachedEdge := Round(alpha * 1.2)
+        if (cachedEdge > 255) cachedEdge := 255
+        cachedBot := Round(alpha * 0.9)
+        cachedAlpha := alpha
+    }
     ; Top: dark band blurred downward
-    edgeAlpha := Round(alpha * 1.2)
-    if (edgeAlpha > 255) edgeAlpha := 255
-    topARGB := (edgeAlpha << 24) | 0x000000
+    topARGB := (cachedEdge << 24) | 0x000000
     FX_DrawSoftRect(0, -depth, wPhys, depth, topARGB, Float(depth * 0.8))
 
     ; Bottom
-    botAlpha := Round(alpha * 0.9)
-    botARGB := (botAlpha << 24) | 0x000000
+    botARGB := (cachedBot << 24) | 0x000000
     FX_DrawSoftRect2(0, hPhys, wPhys, depth, botARGB, Float(depth * 0.8))
 }
 
@@ -285,7 +305,11 @@ FX_HDRCorrectARGB(argb) {
     global gFX_HDRActive, cfg
     if (!gFX_HDRActive)
         return argb
+    ; Cache: inner shadow ARGB comes from config — same every frame
+    static lastIn := 0, lastOut := 0, lastExp := 0.0
     exp := cfg.PerfHDRGammaExponent
+    if (argb = lastIn && exp = lastExp)
+        return lastOut
     a := (argb >> 24) & 0xFF
     r := ((argb >> 16) & 0xFF) / 255.0
     g := ((argb >> 8) & 0xFF) / 255.0
@@ -293,7 +317,9 @@ FX_HDRCorrectARGB(argb) {
     r := Round((r ** exp) * 255)
     g := Round((g ** exp) * 255)
     b := Round((b ** exp) * 255)
-    return (a << 24) | (r << 16) | (g << 8) | b
+    lastIn := argb, lastExp := exp
+    lastOut := (a << 24) | (r << 16) | (g << 8) | b
+    return lastOut
 }
 
 ; Reset mouse velocity state (call when overlay hides/shows).
@@ -327,12 +353,11 @@ FX_PreRenderShaderLayers(w, h) {
             continue
 
         ; Compute effective time: (ambient / 1000) * speed + offset + carry
-        ; Time state is per-layer (keyed by layerIndex), not per-shader
+        ; Single Map.Get avoids Has+[] double lookup
         baseTime := gFX_AmbientTime / 1000.0
-        if (gFX_ShaderTime.Has(layer.layerIndex)) {
-            t := gFX_ShaderTime[layer.layerIndex]
+        t := gFX_ShaderTime.Get(layer.layerIndex, 0)
+        if (t)
             baseTime := t.offset + t.carry + (gFX_AmbientTime / 1000.0)
-        }
         effectiveTime := baseTime * layer.speed
 
         try {
@@ -382,10 +407,9 @@ FX_PreRenderMouseEffect(w, h) {
 
     ; --- Compute mouse velocity (CPU-side, per frame) ---
     baseTime := gFX_AmbientTime / 1000.0 * gFX_MouseEffect.speed
-    if (gFX_ShaderTime.Has(gFX_MouseEffect.key)) {
-        t := gFX_ShaderTime[gFX_MouseEffect.key]
+    t := gFX_ShaderTime.Get(gFX_MouseEffect.key, 0)
+    if (t)
         baseTime := (t.offset + t.carry + (gFX_AmbientTime / 1000.0)) * gFX_MouseEffect.speed
-    }
 
     static prevTime := 0.0
     dtSec := (prevTime > 0) ? baseTime - prevTime : 0.0
@@ -470,28 +494,38 @@ FX_PreRenderSelectionEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, b
         return
 
     ; Set selGlow/selIntensity right before render (shared-entry fix with hover)
+    ; Single Map lookup (avoids Has + [] double lookup)
     if (!gFX_SelectionEffect.isBGShader && gShader_Registry.Has(gFX_SelectionEffect.key)) {
-        gShader_Registry[gFX_SelectionEffect.key].selGlow := cfg.GUI_SelectionGlow
-        gShader_Registry[gFX_SelectionEffect.key].selIntensity := cfg.GUI_SelectionIntensity
+        entry := gShader_Registry[gFX_SelectionEffect.key]
+        entry.selGlow := cfg.GUI_SelectionGlow
+        entry.selIntensity := cfg.GUI_SelectionIntensity
     }
 
     baseTime := gFX_AmbientTime / 1000.0
-    if (gFX_ShaderTime.Has(gFX_SelectionEffect.key)) {
-        t := gFX_ShaderTime[gFX_SelectionEffect.key]
+    t := gFX_ShaderTime.Get(gFX_SelectionEffect.key, 0)
+    if (t)
         baseTime := t.offset + t.carry + (gFX_AmbientTime / 1000.0)
-    }
     baseTime *= gFX_SelectionEffect.speed
 
-    ; Decompose ARGB → premultiplied float4 RGBA
-    selA := ((selARGB >> 24) & 0xFF) / 255.0
-    selR := (((selARGB >> 16) & 0xFF) / 255.0) * selA
-    selG := (((selARGB >> 8) & 0xFF) / 255.0) * selA
-    selB := ((selARGB & 0xFF) / 255.0) * selA
-
-    bdrA := ((borderARGB >> 24) & 0xFF) / 255.0
-    bdrR := (((borderARGB >> 16) & 0xFF) / 255.0) * bdrA
-    bdrG := (((borderARGB >> 8) & 0xFF) / 255.0) * bdrA
-    bdrB := ((borderARGB & 0xFF) / 255.0) * bdrA
+    ; Decompose ARGB → premultiplied float4 RGBA (cached — config-stable values)
+    static _selLastARGB := -1, _selR := 0.0, _selG := 0.0, _selB := 0.0, _selA := 0.0
+    static _selLastBdr := -1, _bdrR := 0.0, _bdrG := 0.0, _bdrB := 0.0, _bdrA := 0.0
+    if (selARGB != _selLastARGB) {
+        _selA := ((selARGB >> 24) & 0xFF) / 255.0
+        _selR := (((selARGB >> 16) & 0xFF) / 255.0) * _selA
+        _selG := (((selARGB >> 8) & 0xFF) / 255.0) * _selA
+        _selB := ((selARGB & 0xFF) / 255.0) * _selA
+        _selLastARGB := selARGB
+    }
+    selR := _selR, selG := _selG, selB := _selB, selA := _selA
+    if (borderARGB != _selLastBdr) {
+        _bdrA := ((borderARGB >> 24) & 0xFF) / 255.0
+        _bdrR := (((borderARGB >> 16) & 0xFF) / 255.0) * _bdrA
+        _bdrG := (((borderARGB >> 8) & 0xFF) / 255.0) * _bdrA
+        _bdrB := ((borderARGB & 0xFF) / 255.0) * _bdrA
+        _selLastBdr := borderARGB
+    }
+    bdrR := _bdrR, bdrG := _bdrG, bdrB := _bdrB, bdrA := _bdrA
 
     ; BG-as-selection Resize mode: render at selection rect size so the shader fills the rect
     renderW := w, renderH := h
@@ -1071,29 +1105,39 @@ FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borde
         return
 
     ; Set selGlow/selIntensity right before render (shared-entry fix)
+    ; Single Map lookup (avoids Has + [] double lookup)
     hovIntensity := cfg.GUI_HoverSelectionIntensity
     if (gShader_Registry.Has(gFX_HoverEffect.key)) {
-        gShader_Registry[gFX_HoverEffect.key].selGlow := cfg.GUI_HoverSelectionGlow
-        gShader_Registry[gFX_HoverEffect.key].selIntensity := hovIntensity
+        entry := gShader_Registry[gFX_HoverEffect.key]
+        entry.selGlow := cfg.GUI_HoverSelectionGlow
+        entry.selIntensity := hovIntensity
     }
 
     baseTime := gFX_AmbientTime / 1000.0
-    if (gFX_ShaderTime.Has(gFX_HoverEffect.key)) {
-        t := gFX_ShaderTime[gFX_HoverEffect.key]
+    t := gFX_ShaderTime.Get(gFX_HoverEffect.key, 0)
+    if (t)
         baseTime := t.offset + t.carry + (gFX_AmbientTime / 1000.0)
-    }
     baseTime *= gFX_HoverEffect.speed
 
-    ; Decompose ARGB → premultiplied float4 RGBA
-    selA := ((selARGB >> 24) & 0xFF) / 255.0
-    selR := (((selARGB >> 16) & 0xFF) / 255.0) * selA
-    selG := (((selARGB >> 8) & 0xFF) / 255.0) * selA
-    selB := ((selARGB & 0xFF) / 255.0) * selA
-
-    bdrA := ((borderARGB >> 24) & 0xFF) / 255.0
-    bdrR := (((borderARGB >> 16) & 0xFF) / 255.0) * bdrA
-    bdrG := (((borderARGB >> 8) & 0xFF) / 255.0) * bdrA
-    bdrB := ((borderARGB & 0xFF) / 255.0) * bdrA
+    ; Decompose ARGB → premultiplied float4 RGBA (cached — config-stable values)
+    static _hovLastARGB := -1, _hovR := 0.0, _hovG := 0.0, _hovB := 0.0, _hovA := 0.0
+    static _hovLastBdr := -1, _hovBdrR := 0.0, _hovBdrG := 0.0, _hovBdrB := 0.0, _hovBdrA := 0.0
+    if (selARGB != _hovLastARGB) {
+        _hovA := ((selARGB >> 24) & 0xFF) / 255.0
+        _hovR := (((selARGB >> 16) & 0xFF) / 255.0) * _hovA
+        _hovG := (((selARGB >> 8) & 0xFF) / 255.0) * _hovA
+        _hovB := ((selARGB & 0xFF) / 255.0) * _hovA
+        _hovLastARGB := selARGB
+    }
+    selR := _hovR, selG := _hovG, selB := _hovB, selA := _hovA
+    if (borderARGB != _hovLastBdr) {
+        _hovBdrA := ((borderARGB >> 24) & 0xFF) / 255.0
+        _hovBdrR := (((borderARGB >> 16) & 0xFF) / 255.0) * _hovBdrA
+        _hovBdrG := (((borderARGB >> 8) & 0xFF) / 255.0) * _hovBdrA
+        _hovBdrB := ((borderARGB & 0xFF) / 255.0) * _hovBdrA
+        _hovLastBdr := borderARGB
+    }
+    bdrR := _hovBdrR, bdrG := _hovBdrG, bdrB := _hovBdrB, bdrA := _hovBdrA
 
     ; BG-as-hover Resize mode: render at hover rect size
     renderW := w, renderH := h

--- a/src/gui/gui_gdip.ahk
+++ b/src/gui/gui_gdip.ahk
@@ -71,20 +71,27 @@ D2D_PushRoundRectClipLayer(x, y, w, h, r) {
     NumPut("float", Float(x), "float", Float(y),
            "float", Float(x + w), "float", Float(y + h),
            "float", Float(r), "float", Float(r), rrBuf)
-    ; Release previous geometry, create new one
+    ; Cache geometry — only recreate when rounded rect parameters change.
+    ; Selection rect moves on Tab; hover rect moves on mouse move; both rare vs frame count.
     ; ID2D1Factory::CreateRoundedRectangleGeometry (vtable 6)
-    static _geomPtr := 0
-    if (_geomPtr) {
-        ObjRelease(_geomPtr)
-        _geomPtr := 0
+    static _geomPtr := 0, _gx := 0.0, _gy := 0.0, _gw := 0.0, _gh := 0.0, _gr := 0.0
+    fx := Float(x), fy := Float(y), fw := Float(x + w), fh := Float(y + h), fr := Float(r)
+    if (_geomPtr && fx = _gx && fy = _gy && fw = _gw && fh = _gh && fr = _gr) {
+        ; Reuse cached geometry — skip COM Create+Release
+    } else {
+        if (_geomPtr) {
+            ObjRelease(_geomPtr)
+            _geomPtr := 0
+        }
+        pGeom := 0
+        try {
+            ComCall(6, gD2D_Factory, "ptr", rrBuf, "ptr*", &pGeom, "hresult")
+        } catch {
+            return false
+        }
+        _geomPtr := pGeom
+        _gx := fx, _gy := fy, _gw := fw, _gh := fh, _gr := fr
     }
-    pGeom := 0
-    try {
-        ComCall(6, gD2D_Factory, "ptr", rrBuf, "ptr*", &pGeom, "hresult")
-    } catch {
-        return false
-    }
-    _geomPtr := pGeom
     ; D2D1_LAYER_PARAMETERS (72 bytes on x64): initialize constants once
     static lp := 0
     if (!lp) {
@@ -120,8 +127,12 @@ D2D_DrawTextLeft(text, x, y, w, h, brush, tf) {
     global D2D1_DRAW_TEXT_OPTIONS_CLIP
     if (!gD2D_RT || !tf)
         return
-    tf.SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING)
-    tf.SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR)
+    ; Alignment guard: skip 2 COM calls when alignment already set (hot path ~300+ calls/frame)
+    if (!tf.HasOwnProp("_a") || tf._a != 0) {
+        tf.SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING)
+        tf.SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR)
+        tf._a := 0
+    }
     static rect := Buffer(16)
     NumPut("float", Float(x), "float", Float(y),
            "float", Float(x + w), "float", Float(y + h), rect)
@@ -134,8 +145,12 @@ D2D_DrawTextCentered(text, x, y, w, h, brush, tf) {
     global D2D1_DRAW_TEXT_OPTIONS_CLIP
     if (!gD2D_RT || !tf)
         return
-    tf.SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER)
-    tf.SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER)
+    ; Alignment guard: skip 2 COM calls when alignment already set
+    if (!tf.HasOwnProp("_a") || tf._a != 1) {
+        tf.SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER)
+        tf.SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER)
+        tf._a := 1
+    }
     static rect := Buffer(16)
     NumPut("float", Float(x), "float", Float(y),
            "float", Float(x + w), "float", Float(y + h), rect)

--- a/src/gui/gui_math.ahk
+++ b/src/gui/gui_math.ahk
@@ -57,6 +57,11 @@ GUI_GetCachedLayout(scale) {
     cached.colY := Round(PAINT_COL_Y_DIP * scale)
     cached.colH := Round(PAINT_COL_H_DIP * scale)
     cached.hdrBlock := Round(GUI_HeaderBlockDip() * scale)
+    cached.hdrTextH := Round(20 * scale)
+    cached.footerH := Round(cfg.GUI_FooterHeightPx * scale)
+    cached.footerGap := Round(cfg.GUI_FooterGapTopPx * scale)
+    cached.selExpandX := Round(4 * scale)
+    cached.selExpandY := Round(2 * scale)
     cachedScale := scale
     return cached
 }

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -423,7 +423,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
     ; Header
     if (cfg.GUI_ShowHeader) {
         hdrY := y + hdrY4
-        hdrTextH := Round(20 * scale)
+        hdrTextH := cachedLayout.hdrTextH
         if (shadowP.enabled) {
             _FX_DrawTextLeftShadow("Title", textX, hdrY, textW, hdrTextH, gD2D_Res["brHdr"], gD2D_Res["tfHdr"], shadowBr, shadowP.offX, shadowP.offY)
             for _, col in cols {
@@ -444,8 +444,8 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
     footerH := 0
     footerGap := 0
     if (cfg.GUI_ShowFooter) {
-        footerH := Round(cfg.GUI_FooterHeightPx * scale)
-        footerGap := Round(cfg.GUI_FooterGapTopPx * scale)
+        footerH := cachedLayout.footerH
+        footerGap := cachedLayout.footerGap
     }
     availH := hPhys - My - contentTopY - footerH - footerGap
     if (availH < 0) {
@@ -513,8 +513,8 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
         brCol := gD2D_Res["brCol"], brColHi := gD2D_Res["brColHi"]
 
         ; Selection rect expansion (in physical px)
-        selExpandX := Round(4 * scale)
-        selExpandY := Round(2 * scale)
+        selExpandX := cachedLayout.selExpandX
+        selExpandY := cachedLayout.selExpandY
 
         ; ===== Selection highlight (drawn BEFORE row loop for correct Z-order) =====
         ; The highlight is a background element — text/icons draw on top.
@@ -713,9 +713,12 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
 ; ========================= ACTION BUTTONS =========================
 
 ; Get scaled action button metrics with minimums enforced
-; Returns: {size, gap, rad}
+; Returns: {size, gap, rad} — cached per scale
 GUI_GetActionBtnMetrics(scale) {
     global cfg
+    static cached := {size: 0, gap: 0, rad: 0}, cachedScale := 0.0
+    if (Abs(cachedScale - scale) < 0.001)
+        return cached
     size := Round(cfg.GUI_ActionBtnSizePx * scale)
     if (size < 12)
         size := 12
@@ -725,7 +728,9 @@ GUI_GetActionBtnMetrics(scale) {
     rad := Round(cfg.GUI_ActionBtnRadiusPx * scale)
     if (rad < 2)
         rad := 2
-    return {size: size, gap: gap, rad: rad}
+    cached := {size: size, gap: gap, rad: rad}
+    cachedScale := scale
+    return cached
 }
 
 ; Draw a single action button and update btnX position
@@ -794,14 +799,16 @@ _GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, scrollTop, count, sc
         return
     }
 
-    trackW := Round(cfg.GUI_ScrollBarWidthPx * scale)
-    if (trackW < 2) {
-        trackW := 2
+    static _sbTrackW := 0, _sbMarR := 0, _sbScale := 0.0
+    if (Abs(_sbScale - scale) >= 0.001) {
+        _sbTrackW := Round(cfg.GUI_ScrollBarWidthPx * scale)
+        if (_sbTrackW < 2) _sbTrackW := 2
+        _sbMarR := Round(cfg.GUI_ScrollBarMarginRightPx * scale)
+        if (_sbMarR < 0) _sbMarR := 0
+        _sbScale := scale
     }
-    marR := Round(cfg.GUI_ScrollBarMarginRightPx * scale)
-    if (marR < 0) {
-        marR := 0
-    }
+    trackW := _sbTrackW
+    marR := _sbMarR
 
     x := wPhys - marR - trackW
     y := contentTopY
@@ -847,35 +854,34 @@ _GUI_DrawFooter(wPhys, hPhys, scale) {
         return
     }
 
-    fh := Round(cfg.GUI_FooterHeightPx * scale)
-    if (fh < 1) {
-        fh := 1
+    ; Cache all footer metrics per scale (7 Round() calls → cached)
+    static _ftC := {fh:0, mx:0, my:0, fr:0, pad:0, arrowW:0, arrowPad:0, borderW:0}, _ftScale := 0.0
+    if (Abs(_ftScale - scale) >= 0.001) {
+        _ftC.fh := Round(cfg.GUI_FooterHeightPx * scale)
+        if (_ftC.fh < 1) _ftC.fh := 1
+        _ftC.mx := Round(cfg.GUI_MarginX * scale)
+        _ftC.my := Round(cfg.GUI_MarginY * scale)
+        _ftC.fr := Round(cfg.GUI_FooterBGRadius * scale)
+        if (_ftC.fr < 0) _ftC.fr := 0
+        _ftC.pad := Round(cfg.GUI_FooterPaddingX * scale)
+        if (_ftC.pad < 0) _ftC.pad := 0
+        _ftC.arrowW := Round(PAINT_ARROW_W_DIP * scale)
+        _ftC.arrowPad := Round(PAINT_ARROW_PAD_DIP * scale)
+        _ftC.borderW := Round(cfg.GUI_FooterBorderPx * scale)
+        _ftScale := scale
     }
-    mx := Round(cfg.GUI_MarginX * scale)
-    my := Round(cfg.GUI_MarginY * scale)
+    fh := _ftC.fh, mx := _ftC.mx, my := _ftC.my, fr := _ftC.fr
+    pad := _ftC.pad, arrowW := _ftC.arrowW, arrowPad := _ftC.arrowPad
 
     fx := mx
     fy := hPhys - my - fh
     fw := wPhys - 2 * mx
-    fr := Round(cfg.GUI_FooterBGRadius * scale)
-    if (fr < 0) {
-        fr := 0
-    }
 
     ; Draw footer background
     D2D_FillRoundRect(fx, fy, fw, fh, fr, D2D_GetCachedBrush(cfg.GUI_FooterBGARGB))
     if (cfg.GUI_FooterBorderPx > 0) {
-        D2D_StrokeRoundRect(fx + 0.5, fy + 0.5, fw - 1, fh - 1, fr, D2D_GetCachedBrush(cfg.GUI_FooterBorderARGB), Round(cfg.GUI_FooterBorderPx * scale))
+        D2D_StrokeRoundRect(fx + 0.5, fy + 0.5, fw - 1, fh - 1, fr, D2D_GetCachedBrush(cfg.GUI_FooterBorderARGB), _ftC.borderW)
     }
-
-    pad := Round(cfg.GUI_FooterPaddingX * scale)
-    if (pad < 0) {
-        pad := 0
-    }
-
-    ; Arrow dimensions
-    arrowW := Round(PAINT_ARROW_W_DIP * scale)
-    arrowPad := Round(PAINT_ARROW_PAD_DIP * scale)
 
     ; Hoist repeated gD2D_Res lookups
     tfFooter := gD2D_Res["tfFooter"]

--- a/src/lib/d2d_shader.ahk
+++ b/src/lib/d2d_shader.ahk
@@ -1311,9 +1311,8 @@ Shader_ReleaseInactive(activeNames) {
 ; Return the ID2D1Bitmap1 ptr for DrawImage. Returns 0 if not available.
 Shader_GetBitmap(name) {
     global gShader_Registry
-    if (!gShader_Registry.Has(name))
-        return 0
-    return gShader_Registry[name].bitmap
+    try return gShader_Registry[name].bitmap
+    return 0
 }
 
 ; Return the metadata for a registered shader, or 0 if not found.

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -155,6 +155,8 @@ global cfg := {
     GUI_ShowKillButton: false,
     GUI_ShowBlacklistButton: true,
     GUI_ShowFooter: true,
+    GUI_FooterHeightPx: 32,
+    GUI_FooterGapTopPx: 8,
     GUI_HoverPollIntervalMs: 100,
     DiagAltTabTooltips: false,
     DiagEventLog: false,  ; Disable event logging during tests


### PR DESCRIPTION
## Summary

- **Text alignment guards** (~50-200μs): Track last-set mode via `tf._a` property on DirectWrite text formats, skip redundant `SetTextAlignment`/`SetParagraphAlignment` COM calls (~300+/frame → ~1-2)
- **SoftRect effect caching** (~2.6μs): Cache effect objects + output images as globals, move border mode SetEnum to init, eliminate 10 Map lookups + 4 SetEnum per inner shadow call
- **ARGB decomposition caching** (~1.5-4.5μs): Static lastIn/lastOut for premultiplied float4 conversion in selection + hover shaders (config-stable values)
- **HDR correction caching** (~7μs when HDR on): Static cache for 3× exponentiation in `FX_HDRCorrectARGB`
- **Shader time Map.Get** (~1-1.5μs): Single `Map.Get(key, 0)` replaces `Has()` + `[]` double lookup in 4 hot paths
- **Layout metrics caching** (~2μs): Extend `GUI_GetCachedLayout` with header/footer/selection expand; cache footer (7 Round calls), scrollbar, action button metrics per scale
- **Geometry caching** (~0-10μs): Cache rounded rect geometry in `PushRoundRectClipLayer` by parameter tuple
- **Misc**: Static buffer in `D2D_ColorF`, pre-computed inner shadow alpha, cached registry entry refs, `Shader_GetBitmap` try/return

**Estimated savings**: ~60-100μs/frame typical, ~150-230μs/frame max config. At 240fps: 14-55ms/s recovered.

Closes #202

## Test plan

- [ ] `.\tests\test.ps1 --live` — full test suite
- [ ] Visual: selection highlight (shader + D2D fallback paths)
- [ ] Visual: hover highlight on mouse move
- [ ] Visual: inner shadow at top/bottom edges
- [ ] Visual: text shadow with correct offset
- [ ] Visual: footer text and arrows render correctly
- [ ] Visual: scrollbar when items exceed visible area
- [ ] Visual: BG-as-selection clip (if configured)
- [ ] `DiagPaintTimingLog` before/after comparison
- [ ] HDR verification (if HDR monitor available)

Generated with [Claude Code](https://claude.com/claude-code)