### PR TITLE
Fix option interaction bugs: wizard admin reset, rollback message, orphaned task

### DIFF
--- a/src/launcher/launcher_wizard.ahk
+++ b/src/launcher/launcher_wizard.ahk
@@ -302,6 +302,7 @@ _WizardApplyChoices(startMenu, startup, install, admin, autoUpdate) {
         } else {
             ; Install was requested but failed - don't create task pointing to temp location
             ThemeMsgBox("Admin mode requires successful installation.`nPlease try again or enable admin mode later from the tray menu.", APP_NAME, "Iconx")
+            admin := false  ; Prevent Step 3 (line 312) from writing RunAsAdmin=true
         }
     }
 

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -1044,7 +1044,11 @@ Update_ApplyCore(opts) {
         targetRunAsAdmin := ReadIniBool(targetConfigPath, "Setup", "RunAsAdmin")
 
         ; Update admin task if target has admin mode enabled
-        if (targetRunAsAdmin && AdminTaskExists()) {
+        if (!targetRunAsAdmin && AdminTaskExists()) {
+            ; Config says admin disabled but task exists (orphaned from previous install
+            ; whose config was overwritten). Clean it up.
+            try DeleteAdminTask()
+        } else if (targetRunAsAdmin && AdminTaskExists()) {
             targetInstallId := ""
             if (FileExist(targetConfigPath)) {
                 try targetInstallId := IniRead(targetConfigPath, "Setup", "InstallationId", "")
@@ -1153,7 +1157,11 @@ Update_ApplyCore(opts) {
         else if (FileExist(targetPath))
             ThemeMsgBox("The update could not be applied. The file may be locked by antivirus or another process.`n`nDetails: " e.Message, "Update Error", "Iconx")
         else
-            ThemeMsgBox("The update failed and the previous version could not be restored.`nPlease reinstall Alt-Tabby.`n`nDetails: " e.Message, "Alt-Tabby Critical", "Iconx")
+            ThemeMsgBox("The update failed and the previous version could not be restored.`n"
+                "A backup may exist at:`n" backupPath "`n`n"
+                "Try renaming this file back to the original name.`n"
+                "If that fails, please reinstall Alt-Tabby.`n`n"
+                "Details: " e.Message, "Alt-Tabby Critical", "Iconx")
     }
 }
 


### PR DESCRIPTION
## Summary

- **Bug 1:** Wizard resets `admin := false` when PF install fails, preventing stale `RunAsAdmin=true` in config
- **Bug 2:** Update rollback critical error now mentions the `.old` backup path for manual recovery
- **Bug 3:** `Update_ApplyCore` cleans up orphaned admin task when config overwrite disables admin mode

## Context

Deep audit of combinatorial interactions between installation options, launch modes, admin state, and user journeys. All UAC refusal paths verified clean, DRY assessment shows codebase already well-consolidated.

## Test plan

- [ ] Static analysis passes (pre-existing failures in `gui_effects.ahk` / `gui_paint.ahk` are unrelated)
- [ ] Manual trace: wizard with all boxes checked → PF install failure → verify `RunAsAdmin=false` in config
- [ ] Manual trace: install-to-PF over existing admin install with source `RunAsAdmin=false` → verify task cleaned up
- [ ] Code review: rollback error message includes `.old` backup path

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)