### PR TITLE
Gate ungated diagnostic logs, remove duplicate log block

### DIFF
--- a/src/editors/config_editor.ahk
+++ b/src/editors/config_editor.ahk
@@ -49,10 +49,6 @@ ConfigEditor_Run(launcherHwnd := 0, forceNative := false) {
                 global LOG_PATH_WEBVIEW
                 try LogAppend(LOG_PATH_WEBVIEW, "WebView2 init failed, falling back to native: " e.Message)
             }
-            if (cfg.DiagWebViewLog) {
-                global LOG_PATH_WEBVIEW
-                try LogAppend(LOG_PATH_WEBVIEW, "WebView2 init failed, falling back to native: " e.Message)
-            }
             TrayTip("Using classic settings editor (WebView2 unavailable)", "Alt-Tabby", "Iconi")
         }
     }

--- a/src/gui/gui_bgimage.ahk
+++ b/src/gui/gui_bgimage.ahk
@@ -36,11 +36,13 @@ global gBGImg_GdipToken := 0      ; GDI+ startup token (one-shot for image file 
 ; Load image from config path. Called from FX_GPU_Init().
 BGImg_Init() {
     global cfg, gBGImg_Ready, gBGImg_CacheDirty, LOG_PATH_STORE
-    try LogAppend(LOG_PATH_STORE, "BGImg_Init: enabled=" cfg.BGImgEnabled " path='" cfg.BGImgImagePath "'")
+    if (cfg.DiagStoreLog)
+        try LogAppend(LOG_PATH_STORE, "BGImg_Init: enabled=" cfg.BGImgEnabled " path='" cfg.BGImgImagePath "'")
     if (!cfg.BGImgEnabled || cfg.BGImgImagePath = "")
         return
     _BGImg_LoadImage(cfg.BGImgImagePath)
-    try LogAppend(LOG_PATH_STORE, "BGImg_Init: after load, ready=" gBGImg_Ready)
+    if (cfg.DiagStoreLog)
+        try LogAppend(LOG_PATH_STORE, "BGImg_Init: after load, ready=" gBGImg_Ready)
     gBGImg_CacheDirty := true
 }
 
@@ -138,14 +140,17 @@ _BGImg_RebuildCache(wPhys, hPhys) {
         global LOG_PATH_STORE
 
         ; Dump the bp1 struct bytes for diagnostics
-        bp1Hex := ""
-        loop 32
-            bp1Hex .= Format("{:02X} ", NumGet(bp1, A_Index - 1, "uchar"))
-        try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: w=" wPhys " h=" hPhys " bp1=[" bp1Hex "]")
+        if (cfg.DiagStoreLog) {
+            bp1Hex := ""
+            loop 32
+                bp1Hex .= Format("{:02X} ", NumGet(bp1, A_Index - 1, "uchar"))
+            try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: w=" wPhys " h=" hPhys " bp1=[" bp1Hex "]")
+        }
 
         sizeU := D2D_SizeU(wPhys, hPhys)
         sizeVal := NumGet(sizeU, "int64")
-        try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: sizeU int64=" sizeVal " (w=" NumGet(sizeU, 0, "uint") " h=" NumGet(sizeU, 4, "uint") ")")
+        if (cfg.DiagStoreLog)
+            try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: sizeU int64=" sizeVal " (w=" NumGet(sizeU, 0, "uint") " h=" NumGet(sizeU, 4, "uint") ")")
 
         pCacheBmp := 0
         ; ID2D1DeviceContext::CreateBitmap1 (vtable 57)
@@ -158,14 +163,16 @@ _BGImg_RebuildCache(wPhys, hPhys) {
             try {
                 vtbl := NumGet(NumGet(gD2D_RT.ptr, "ptr"), 57 * A_PtrSize, "ptr")
                 hr2 := DllCall(vtbl, "ptr", gD2D_RT.ptr, "uint", wPhys, "uint", hPhys, "ptr", 0, "uint", 0, "ptr", bp1, "ptr*", &pCacheBmp, "int")
-                try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: DllCall fallback hr=" hr2 " pBmp=" pCacheBmp)
+                if (cfg.DiagStoreLog)
+                    try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: DllCall fallback hr=" hr2 " pBmp=" pCacheBmp)
             } catch as e2 {
                 try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: DllCall fallback also failed: " e2.Message)
             }
             if (!pCacheBmp)
                 throw cbErr
         }
-        try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: CreateBitmap1 OK pBmp=" pCacheBmp)
+        if (cfg.DiagStoreLog)
+            try LogAppend(LOG_PATH_STORE, "_BGImg_RebuildCache: CreateBitmap1 OK pBmp=" pCacheBmp)
         if (!pCacheBmp)
             return
         cacheBmp := ID2D1Bitmap1(pCacheBmp)
@@ -244,7 +251,8 @@ _BGImg_LoadImage(filePath) {
     global DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED, cfg
 
     global LOG_PATH_STORE
-    try LogAppend(LOG_PATH_STORE, "_BGImg_LoadImage: path='" filePath "' exists=" FileExist(filePath) " gD2D_RT=" (gD2D_RT ? "yes" : "no"))
+    if (cfg.DiagStoreLog)
+        try LogAppend(LOG_PATH_STORE, "_BGImg_LoadImage: path='" filePath "' exists=" FileExist(filePath) " gD2D_RT=" (gD2D_RT ? "yes" : "no"))
     if (!gD2D_RT || !FileExist(filePath))
         return
 
@@ -255,13 +263,15 @@ _BGImg_LoadImage(filePath) {
             si := Buffer(24, 0)
             NumPut("uint", 1, si, 0)  ; GdiplusVersion = 1
             hr := DllCall("gdiplus\GdiplusStartup", "ptr*", &gBGImg_GdipToken, "ptr", si, "ptr", 0)
-            try LogAppend(LOG_PATH_STORE, "_BGImg_LoadImage: GdiplusStartup hr=" hr " token=" gBGImg_GdipToken)
+            if (cfg.DiagStoreLog)
+                try LogAppend(LOG_PATH_STORE, "_BGImg_LoadImage: GdiplusStartup hr=" hr " token=" gBGImg_GdipToken)
         }
 
         ; Load via GDI+
         pBitmapGdip := 0
         gdipHr := DllCall("gdiplus\GdipCreateBitmapFromFile", "str", filePath, "ptr*", &pBitmapGdip, "int")
-        try LogAppend(LOG_PATH_STORE, "_BGImg_LoadImage: GdipCreateBitmapFromFile hr=" gdipHr " pBitmap=" pBitmapGdip)
+        if (cfg.DiagStoreLog)
+            try LogAppend(LOG_PATH_STORE, "_BGImg_LoadImage: GdipCreateBitmapFromFile hr=" gdipHr " pBitmap=" pBitmapGdip)
         if (!pBitmapGdip)
             throw Error("GDI+ failed to load: " filePath " hr=" gdipHr)
 
@@ -307,7 +317,8 @@ _BGImg_LoadImage(filePath) {
         sizeU := D2D_SizeU(imgW, imgH)
         bitmapProps := D2D_BitmapProps(96.0, 96.0, DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED)
         bitmap := gD2D_RT.CreateBitmap(sizeU, pixelBuf.Ptr, stride, bitmapProps)
-        try LogAppend(LOG_PATH_STORE, "_BGImg_LoadImage: D2D bitmap created, ptr=" (bitmap ? bitmap.ptr : 0) " w=" imgW " h=" imgH)
+        if (cfg.DiagStoreLog)
+            try LogAppend(LOG_PATH_STORE, "_BGImg_LoadImage: D2D bitmap created, ptr=" (bitmap ? bitmap.ptr : 0) " w=" imgW " h=" imgH)
 
         gBGImg_Bitmap := bitmap
         gBGImg_Width := imgW


### PR DESCRIPTION
## Summary

- Gate 10 non-error `LogAppend` calls in `gui_bgimage.ahk` with `cfg.DiagStoreLog` — zero disk I/O when diagnostics are OFF
- Move hex dump loop (32-byte struct trace) inside the guard — most expensive ungated work
- Remove duplicate `if (cfg.DiagWebViewLog)` block in `config_editor.ahk` (identical block copy-pasted)
- Error logs (`CreateBitmap1 FAILED`, `DllCall fallback also failed`, `BGImg cache rebuild failed`, `BGImg load failed`) remain correctly ungated

Closes #214

## Test plan

- [ ] Enable `DiagStoreLog` in config.ini, load a background image — verify all BGImg diagnostic lines appear in `tabby_store_error.log`
- [ ] Disable `DiagStoreLog`, load a background image — verify zero BGImg diagnostic lines in log
- [ ] Force a BGImg load failure (invalid path) — verify error log appears regardless of `DiagStoreLog` setting
- [ ] Launch config editor with WebView2 unavailable — verify single (not duplicate) fallback log line when `DiagWebViewLog` is enabled

Generated with [Claude Code](https://claude.com/claude-code)