### PR TITLE
Make 12 zero-external-caller public functions private

### DIFF
--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -108,7 +108,7 @@ Anim_GetValue(name, defaultVal := 0) {
     return defaultVal
 }
 
-Anim_CancelTween(name) {
+_Anim_CancelTween(name) {
     global gAnim_Tweens
     if (gAnim_Tweens.Has(name))
         gAnim_Tweens.Delete(name)
@@ -121,7 +121,7 @@ Anim_CancelAll() {
     gFX_AmbientTime := 0.0
     FX_ResetMouseVelocity()
     gAnim_HidePending := false
-    Anim_StopTimer()
+    _Anim_StopTimer()
 }
 
 _Anim_UpdateTweens() {
@@ -185,7 +185,7 @@ Anim_EnsureTimer() {
     SetTimer(_Anim_FrameLoop, -1)
 }
 
-Anim_StopTimer() {
+_Anim_StopTimer() {
     global gAnim_TimerRunning, gAnim_TimerPeriodOn
     global gAnim_QuitEvent, gAnim_pBoostClock, gAnim_BoostActive
     ; Signal quit event to unblock compositor clock wait immediately
@@ -328,7 +328,7 @@ _Anim_FrameLoop() {
         }
     }
 
-    Anim_StopTimer()
+    _Anim_StopTimer()
 }
 
 ; QPC spin-wait until next frame boundary. NtYieldExecution yields CPU timeslice
@@ -461,7 +461,7 @@ _Anim_DoActualHide() {
 
 Anim_StartSelectionSlide(prevSel, newSel, count) { ; lint-ignore: dead-param
     global gAnim_SelPrevIndex, gAnim_SelNewIndex
-    Anim_CancelTween("selSlide")
+    _Anim_CancelTween("selSlide")
     gAnim_SelPrevIndex := prevSel
     gAnim_SelNewIndex := newSel
     ; 0→1 tween: paint code lerps between prev and new Y positions

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -190,14 +190,14 @@ FX_GPU_Dispose() {
 ; Draw a soft rectangle using the primary chain (flood→crop→blur).
 ; x,y,w,h: rectangle in physical pixels. argb: fill color. blurStdDev: blur amount.
 ; offsetX/Y: additional translation (e.g., shadow offset).
-FX_DrawSoftRect(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
+_FX_DrawSoftRect(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
     global gD2D_RT, gFX_GPU, gFX_GPUOutput
     global FX_FLOOD_COLOR, FX_CROP_RECT, FX_BLUR_STDEV, FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT
 
     flood := gFX_GPU["flood"], crop := gFX_GPU["crop"], blur := gFX_GPU["blur"]
 
     ; HDR: gamma-correct the flood color CPU-side (avoids premultiplied alpha edge artifacts)
-    flood.SetColorF(FX_FLOOD_COLOR, FX_HDRCorrectARGB(argb))
+    flood.SetColorF(FX_FLOOD_COLOR, _FX_HDRCorrectARGB(argb))
 
     ; Configure crop to the rectangle bounds
     crop.SetRectF(FX_CROP_RECT, Float(x), Float(y), Float(x + w), Float(y + h))
@@ -219,14 +219,14 @@ FX_DrawSoftRect(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
 
 ; Draw a soft rectangle using the secondary chain (flood2→crop2→blur2).
 ; Allows drawing two different soft rects without reconfiguring the primary chain.
-FX_DrawSoftRect2(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
+_FX_DrawSoftRect2(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
     global gD2D_RT, gFX_GPU, gFX_GPUOutput
     global FX_FLOOD_COLOR, FX_CROP_RECT, FX_BLUR_STDEV, FX_BLUR_BORDER_MODE, D2D1_BORDER_SOFT
 
     flood2 := gFX_GPU["flood2"], crop2 := gFX_GPU["crop2"], blur2 := gFX_GPU["blur2"]
 
     ; HDR: gamma-correct the flood color CPU-side (avoids premultiplied alpha edge artifacts)
-    flood2.SetColorF(FX_FLOOD_COLOR, FX_HDRCorrectARGB(argb))
+    flood2.SetColorF(FX_FLOOD_COLOR, _FX_HDRCorrectARGB(argb))
     crop2.SetRectF(FX_CROP_RECT, Float(x), Float(y), Float(x + w), Float(y + h))
     crop2.SetEnum(1, D2D1_BORDER_SOFT)
     blur2.SetFloat(FX_BLUR_STDEV, blurStdDev)
@@ -249,12 +249,12 @@ FX_GPU_DrawInnerShadow(wPhys, hPhys, depth, alpha) {
     edgeAlpha := Round(alpha * 1.2)
     if (edgeAlpha > 255) edgeAlpha := 255
     topARGB := (edgeAlpha << 24) | 0x000000
-    FX_DrawSoftRect(0, -depth, wPhys, depth, topARGB, Float(depth * 0.8))
+    _FX_DrawSoftRect(0, -depth, wPhys, depth, topARGB, Float(depth * 0.8))
 
     ; Bottom
     botAlpha := Round(alpha * 0.9)
     botARGB := (botAlpha << 24) | 0x000000
-    FX_DrawSoftRect2(0, hPhys, wPhys, depth, botARGB, Float(depth * 0.8))
+    _FX_DrawSoftRect2(0, hPhys, wPhys, depth, botARGB, Float(depth * 0.8))
 }
 
 ; ========================= GPU HOVER =========================
@@ -277,11 +277,11 @@ FX_GPU_DrawHover(x, y, w, h, rad) {
 ; ========================= HDR COMPENSATION =========================
 
 ; Apply HDR gamma correction to an ARGB integer (CPU-side).
-; Called from FX_DrawSoftRect/FX_DrawSoftRect2 to gamma-correct the flood color
+; Called from _FX_DrawSoftRect/_FX_DrawSoftRect2 to gamma-correct the flood color
 ; before it enters the effect chain. This avoids the premultiplied alpha edge
 ; artifacts that occur when GammaTransfer is applied after GaussianBlur.
 ; Returns corrected ARGB. No-op when HDR inactive.
-FX_HDRCorrectARGB(argb) {
+_FX_HDRCorrectARGB(argb) {
     global gFX_HDRActive, cfg
     if (!gFX_HDRActive)
         return argb

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -580,7 +580,7 @@ _D2D_CleanupWaitableState() {
 ; Resize the swap chain buffers. NOT called during normal operation (Phase 2:
 ; swap chain created at max monitor size, visible region controlled by DComp clip).
 ; Retained for device loss recovery on a monitor larger than initial max.
-D2D_ResizeRenderTarget(wPhys, hPhys) {
+_D2D_ResizeRenderTarget(wPhys, hPhys) { ; lint-ignore: dead-function
     global gD2D_SwapChain, gD2D_RT, gD2D_BackBuffer
     global gD2D_SwapChainFlags, DXGI_FORMAT_UNKNOWN
     if (!gD2D_SwapChain)

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -994,8 +994,8 @@ _FX_BrushProps() {
 }
 
 ; Create a linear gradient brush. Caller keeps reference; COM __Delete releases.
-; For variable stop counts. Prefer FX_LinearGradient2/3 for fixed 2/3-stop cases.
-FX_LinearGradient(x1, y1, x2, y2, stops) {
+; For variable stop counts. Prefer _FX_LinearGradient2/3 for fixed 2/3-stop cases.
+_FX_LinearGradient(x1, y1, x2, y2, stops) {
     global gD2D_RT
     gsc := _FX_BuildStops(stops)
     if (!gsc)
@@ -1011,7 +1011,7 @@ FX_LinearGradient(x1, y1, x2, y2, stops) {
 ; 2-stop linear gradient — cached. Brushes keyed by stop identity (positions + colors).
 ; Cache self-invalidates when RT pointer changes (device loss). Repositioned per-frame
 ; via SetStartPoint/SetEndPoint (~0 cost vs ~4μs COM creation).
-FX_LinearGradient2(x1, y1, x2, y2, pos1, argb1, pos2, argb2) {
+_FX_LinearGradient2(x1, y1, x2, y2, pos1, argb1, pos2, argb2) {
     global gD2D_RT
     static cache := Map()
     static cachedRTPtr := 0
@@ -1053,8 +1053,8 @@ FX_LinearGradient2(x1, y1, x2, y2, pos1, argb1, pos2, argb2) {
     return br
 }
 
-; 3-stop linear gradient — cached. Same self-invalidating pattern as FX_LinearGradient2.
-FX_LinearGradient3(x1, y1, x2, y2, pos1, argb1, pos2, argb2, pos3, argb3) {
+; 3-stop linear gradient — cached. Same self-invalidating pattern as _FX_LinearGradient2.
+_FX_LinearGradient3(x1, y1, x2, y2, pos1, argb1, pos2, argb2, pos3, argb3) { ; lint-ignore: dead-function
     global gD2D_RT
     static cache := Map()
     static cachedRTPtr := 0
@@ -1111,7 +1111,7 @@ _FX_WriteStop(buf, off, pos, argb) {
 ; contentBounds clips the layer to (left, top, right, bottom). Opacity is applied
 ; uniformly when the layer is composited onto the render target.
 ; Static buffer — PushLayer consumes immediately, safe to reuse across calls.
-FX_LayerParams(left, top, right, bottom, opacity) {
+_FX_LayerParams(left, top, right, bottom, opacity) { ; lint-ignore: dead-function
     static buf := 0
     if (!buf) {
         buf := Buffer(72, 0)
@@ -1179,7 +1179,7 @@ _FX_GetShadowParams(fx, scale) {
 ; Draw gradient strips along window edges to create depth.
 ; Each edge is a linear gradient from dark at the edge to transparent inward.
 ; `alpha` controls edge darkness (0x15 = subtle, 0x38 = strong).
-_FX_DrawInnerShadow(wPhys, hPhys, depth, alpha) {
+_FX_DrawInnerShadow(wPhys, hPhys, depth, alpha) { ; lint-ignore: dead-function
     edgeARGB := (alpha << 24) | 0x000000
     botAlpha := Round(alpha * 0.85)
     botARGB := (botAlpha << 24) | 0x000000
@@ -1187,22 +1187,22 @@ _FX_DrawInnerShadow(wPhys, hPhys, depth, alpha) {
     sideARGB := (sideAlpha << 24) | 0x000000
 
     ; Top edge
-    topBr := FX_LinearGradient2(0, 0, 0, depth, 0.0, edgeARGB, 1.0, 0x00000000)
+    topBr := _FX_LinearGradient2(0, 0, 0, depth, 0.0, edgeARGB, 1.0, 0x00000000)
     if (topBr)
         D2D_FillRect(0, 0, wPhys, depth, topBr)
 
     ; Bottom edge
-    botBr := FX_LinearGradient2(0, hPhys - depth, 0, hPhys, 0.0, 0x00000000, 1.0, botARGB)
+    botBr := _FX_LinearGradient2(0, hPhys - depth, 0, hPhys, 0.0, 0x00000000, 1.0, botARGB)
     if (botBr)
         D2D_FillRect(0, hPhys - depth, wPhys, depth, botBr)
 
     ; Left edge
-    leftBr := FX_LinearGradient2(0, 0, depth, 0, 0.0, sideARGB, 1.0, 0x00000000)
+    leftBr := _FX_LinearGradient2(0, 0, depth, 0, 0.0, sideARGB, 1.0, 0x00000000)
     if (leftBr)
         D2D_FillRect(0, 0, depth, hPhys, leftBr)
 
     ; Right edge
-    rightBr := FX_LinearGradient2(wPhys - depth, 0, wPhys, 0, 0.0, 0x00000000, 1.0, sideARGB)
+    rightBr := _FX_LinearGradient2(wPhys - depth, 0, wPhys, 0, 0.0, 0x00000000, 1.0, sideARGB)
     if (rightBr)
         D2D_FillRect(wPhys - depth, 0, depth, hPhys, rightBr)
 }
@@ -1211,7 +1211,7 @@ _FX_DrawInnerShadow(wPhys, hPhys, depth, alpha) {
 
 ; Blend an ARGB color toward black by factor (0.0 = no change, 1.0 = pure black).
 ; Returns RGB only (caller handles alpha).
-FX_BlendToBlack(argb, factor) {
+_FX_BlendToBlack(argb, factor) { ; lint-ignore: dead-function
     r := (argb >> 16) & 0xFF
     g := (argb >> 8) & 0xFF
     b := argb & 0xFF

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -1033,7 +1033,7 @@ _GUI_ActivateItem(item) {
     return result
 }
 
-GUI_ClickActivate(item) {
+_GUI_ClickActivate(item) { ; lint-ignore: dead-function
     global gGUI_State, gGUI_DisplayItems, cfg
     global gAnim_HidePending
     Critical "On"

--- a/tests/check_batch_functions.ps1
+++ b/tests/check_batch_functions.ps1
@@ -296,6 +296,7 @@ foreach ($file in $allProjectFiles) {
             $raw = $lines[$i]
             if ($raw -match '^\s*;') { continue }
             $m = $script:RX_FUNC_DEF.Match($raw)
+            if (-not $m.Success) { $m = $script:RX_FUNC_DEF2.Match($raw) }
             if ($m.Success) {
                 $funcName = $m.Groups[1].Value
                 if (-not $BF_AHK_KEYWORDS.ContainsKey($funcName.ToLower())) {

--- a/tests/gui_tests_data.ahk
+++ b/tests/gui_tests_data.ahk
@@ -1008,7 +1008,7 @@ RunGUITests_Data() {
     GUI_AssertEq(items[1].isOnCurrentWorkspace, true, "WSPatch noop: isOnCurrentWorkspace still true")
 
     ; ============================================================
-    ; GUI_ClickActivate TESTS
+    ; _GUI_ClickActivate TESTS
     ; ============================================================
 
     ; ----- Test: ClickActivate with valid item transitions to IDLE -----
@@ -1022,7 +1022,7 @@ RunGUITests_Data() {
     GUI_AssertEq(gGUI_State, "ACTIVE", "ClickActivate setup: state is ACTIVE")
 
     clickItem := gGUI_DisplayItems[2]
-    GUI_ClickActivate(clickItem)
+    _GUI_ClickActivate(clickItem)
     GUI_AssertEq(gGUI_State, "IDLE", "ClickActivate: state returns to IDLE")
     GUI_AssertEq(gGUI_OverlayVisible, false, "ClickActivate: overlay hidden")
     GUI_AssertEq(gGUI_DisplayItems.Length, 0, "ClickActivate: DisplayItems cleared")
@@ -1036,7 +1036,7 @@ RunGUITests_Data() {
     GUI_AssertEq(gGUI_State, "ALT_PENDING", "ClickActivate guard: state is ALT_PENDING")
 
     fakeItem := { hwnd: 1000, title: "test", isOnCurrentWorkspace: true, workspaceName: "" }
-    GUI_ClickActivate(fakeItem)
+    _GUI_ClickActivate(fakeItem)
     GUI_AssertEq(gGUI_State, "ALT_PENDING", "ClickActivate guard: state unchanged (not ACTIVE)")
 
     ; ============================================================


### PR DESCRIPTION
## Summary

- Rename 12 public functions with zero cross-file callers to private (`_` prefix) across 5 GUI files
- Add `; lint-ignore: dead-function` to 6 intentionally-retained zero-caller utilities
- Fix pre-existing checker bug: `check_batch_functions.ps1` lib fast path now handles multi-line function definitions (unblocked `Shader_PreRender`)
- Update test reference in `gui_tests_data.ahk` for renamed `_GUI_ClickActivate`

Closes #218

## Test plan

- [x] All 79 static analysis checks pass (including dead-function and undefined-function checks)
- [x] 268/268 GUI tests pass (including `_GUI_ClickActivate` tests)
- [x] 570 unit tests pass
- [x] 59 live tests pass
- [x] No double-prefixed (`__`) names introduced (verified via grep)

Generated with [Claude Code](https://claude.com/claude-code)