### PR TITLE
Include src/lib/ in query tool scans to report all actual callers

### DIFF
--- a/tools/query_callchain.ps1
+++ b/tools/query_callchain.ps1
@@ -48,8 +48,8 @@ if (-not (Test-Path $SourceDir)) {
 }
 $projectRoot = (Resolve-Path "$SourceDir\..").Path
 
-# === Collect source files (exclude lib/) ===
-$srcFiles = Get-AhkSourceFiles $SourceDir
+# === Collect source files (include lib/ — query tool reports all callers) ===
+$srcFiles = Get-AhkSourceFiles $SourceDir -IncludeLib
 
 # ============================================================
 # Pass 1: Build function registry

--- a/tools/query_config.ps1
+++ b/tools/query_config.ps1
@@ -152,9 +152,9 @@ if ($Usage) {
     Write-Host "  cfg.$propertyName" -ForegroundColor White
     Write-Host "    defined:  [$($found.S)] $($found.K)  $typeInfo  $defaultInfo" -ForegroundColor DarkGray
 
-    # Search src/ (excluding src/lib/) for cfg.<propertyName>
+    # Search src/ (including src/lib/) for cfg.<propertyName>
     $srcPath = Join-Path $projectRoot "src"
-    $srcFiles = Get-AhkSourceFiles $srcPath
+    $srcFiles = Get-AhkSourceFiles $srcPath -IncludeLib
 
     $needle = "cfg.$propertyName"
     $hitCount = 0

--- a/tools/query_function_visibility.ps1
+++ b/tools/query_function_visibility.ps1
@@ -44,8 +44,11 @@ if (-not (Test-Path $SourceDir)) {
 }
 $projectRoot = (Resolve-Path "$SourceDir\..").Path
 
-# === Collect source files (exclude lib/) ===
+# === Collect source files ===
+# Enforcement modes exclude src/lib/ (coding standards don't apply to third-party code)
+# Query mode includes src/lib/ to report all actual callers
 $srcFiles = Get-AhkSourceFiles $SourceDir
+$queryFiles = if ($Query) { Get-AhkSourceFiles $SourceDir -IncludeLib } else { $srcFiles }
 
 if ($Query) {
     # Query mode: silent startup, output only the answer
@@ -80,7 +83,7 @@ $funcDefs = @{}
 $fileCache = @{}
 $fileCacheText = @{}
 
-foreach ($file in $srcFiles) {
+foreach ($file in $queryFiles) {
     $text = [System.IO.File]::ReadAllText($file.FullName)
     $fileCacheText[$file.FullName] = $text
 
@@ -268,7 +271,7 @@ if ($Query) {
     $callers = [System.Collections.ArrayList]::new()
     $escaped = [regex]::Escape($funcDef.Name)
 
-    foreach ($file in $srcFiles) {
+    foreach ($file in $queryFiles) {
         # Pre-filter: skip files that don't contain the function name at all
         if ($fileCacheText[$file.FullName].IndexOf($funcDef.Name, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
 

--- a/tools/query_global_ownership.ps1
+++ b/tools/query_global_ownership.ps1
@@ -67,8 +67,11 @@ if (-not (Test-Path $SourceDir)) {
 $projectRoot = (Resolve-Path "$SourceDir\..").Path
 $manifestPath = Join-Path $projectRoot "ownership.manifest"
 
-# === Collect source files (exclude lib/) ===
+# === Collect source files ===
+# Enforcement modes exclude src/lib/ (coding standards don't apply to third-party code)
+# Query mode includes src/lib/ to report all actual readers/writers
 $srcFiles = Get-AhkSourceFiles $SourceDir
+$queryFiles = if ($Query) { Get-AhkSourceFiles $SourceDir -IncludeLib } else { $srcFiles }
 
 if ($Query) {
     # Query mode: silent startup, output only the answer
@@ -118,7 +121,7 @@ if ($Query) {
     $qReaders = [System.Collections.Generic.HashSet[string]]::new(
         [System.StringComparer]::OrdinalIgnoreCase)
 
-    foreach ($file in $srcFiles) {
+    foreach ($file in $queryFiles) {
         $text = [System.IO.File]::ReadAllText($file.FullName)
 
         # IndexOf pre-filter: skip files that don't contain the query string

--- a/tools/query_impact.ps1
+++ b/tools/query_impact.ps1
@@ -38,8 +38,8 @@ if (-not (Test-Path $SourceDir)) {
 }
 $projectRoot = (Resolve-Path "$SourceDir\..").Path
 
-# === Collect source files (exclude lib/) ===
-$srcFiles = Get-AhkSourceFiles $SourceDir
+# === Collect source files (include lib/ — query tool reports all callers) ===
+$srcFiles = Get-AhkSourceFiles $SourceDir -IncludeLib
 
 # ============================================================
 # Step 1: Locate function definition + extract body

--- a/tools/query_ipc.ps1
+++ b/tools/query_ipc.ps1
@@ -111,7 +111,8 @@ $sendTernaryRx = [regex]::new("\?\s*$constName\b")
 $sendTailRx = [regex]::new(":\s*$constName\s*$")
 
 # === Scan source files for references ===
-$allFiles = Get-AhkSourceFiles $srcDir
+# Include lib/ — query tool reports all senders/handlers
+$allFiles = Get-AhkSourceFiles $srcDir -IncludeLib
 
 $sends = [System.Collections.ArrayList]::new()
 $handles = [System.Collections.ArrayList]::new()

--- a/tools/query_messages.ps1
+++ b/tools/query_messages.ps1
@@ -102,7 +102,8 @@ function Resolve-HexConstant {
 }
 
 # === Scan source files ===
-$allFiles = Get-AhkSourceFiles $srcDir
+# Include lib/ — query tool reports all message handlers/senders
+$allFiles = Get-AhkSourceFiles $srcDir -IncludeLib
 
 # Collect all message references
 $entries = [System.Collections.ArrayList]::new()

--- a/tools/query_mutations.ps1
+++ b/tools/query_mutations.ps1
@@ -39,8 +39,8 @@ if (-not (Test-Path $SourceDir)) {
 }
 $projectRoot = (Resolve-Path "$SourceDir\..").Path
 
-# === Collect source files (exclude lib/) ===
-$srcFiles = Get-AhkSourceFiles $SourceDir
+# === Collect source files (include lib/ — query tool reports all mutations) ===
+$srcFiles = Get-AhkSourceFiles $SourceDir -IncludeLib
 
 $MUTATING_METHODS = 'Push|Pop|Delete|InsertAt|RemoveAt|Set|Clear'
 

--- a/tools/query_timers.ps1
+++ b/tools/query_timers.ps1
@@ -19,8 +19,8 @@ $sw = [System.Diagnostics.Stopwatch]::StartNew()
 $projectRoot = Split-Path $PSScriptRoot -Parent
 $srcDir = Join-Path $projectRoot "src"
 
-# === Collect source files (exclude lib/) ===
-$allFiles = Get-AhkSourceFiles $srcDir
+# === Collect source files (include lib/ — query tool reports all timers) ===
+$allFiles = Get-AhkSourceFiles $srcDir -IncludeLib
 
 # Pre-compile hot-loop regex
 $setTimerCheckRx = [regex]::new('\bSetTimer\s*[\(,]')

--- a/tools/query_visibility.ps1
+++ b/tools/query_visibility.ps1
@@ -25,8 +25,8 @@ $totalSw = [System.Diagnostics.Stopwatch]::StartNew()
 $srcDir = (Resolve-Path "$PSScriptRoot\..\src").Path
 $projectRoot = (Resolve-Path "$srcDir\..").Path
 
-# === Collect source files (exclude lib/) ===
-$srcFiles = Get-AhkSourceFiles $srcDir
+# === Collect source files (include lib/ — query tool reports all callers) ===
+$srcFiles = Get-AhkSourceFiles $srcDir -IncludeLib
 
 Write-Host ""
 Write-Host "  Scanning $($srcFiles.Count) source files..." -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

- Query tools excluded `src/lib/` and falsely reported 0 callers for functions called from lib files (e.g. `ResourceLoadToBuffer` has 4 callers in `d2d_shader.ahk`)
- 10 query tools updated to use `-IncludeLib` — the switch already existed in `Get-AhkSourceFiles`, just wasn't being used
- Dual-mode tools (`query_function_visibility`, `query_global_ownership`) only include lib in query mode; enforcement modes unchanged

## Test plan

- [x] `query_function_visibility ResourceLoadToBuffer` now shows 4 callers in `src\lib\d2d_shader.ahk`
- [x] `query_function_visibility -Check` still reports 67 files (excludes lib)
- [x] `query_callchain ResourceLoadToBuffer -Reverse` finds 3 lib callers
- [x] `query_visibility` scans 81 files (was 67), `ResourceLoadToBuffer` no longer falsely flagged

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)