### PR TITLE
Reduce latency on hot paths: cache bypass, guard housekeeping

### DIFF
--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -37,6 +37,9 @@ global _WEH_PendingFocusHwnd := 0         ; Set by callback, processed by batch
 ; Z-order tracking: only events that change Z-order should trigger full winenum scan
 ; NAMECHANGE and LOCATIONCHANGE fire frequently but don't affect Z — skip them
 global _WEH_PendingZNeeded := Map()       ; hwnd -> true if Z-affecting event received
+; PERF: Track LOCATIONCHANGE separately — only these events can change monitor placement.
+; Skip monitor probe (Win_GetMonitorHandle + Win_GetMonitorLabel) for NAMECHANGE-only updates.
+global _WEH_PendingLocChange := Map()     ; hwnd -> true if LOCATIONCHANGE received
 global _WEH_MruFallbackActive := false   ; True when MRU_Lite is running as WEH backoff fallback
 
 ; Fast-path one-shot wrapper: calls ProcessBatch without killing the periodic timer.
@@ -194,7 +197,7 @@ WinEventHook_IsRunning() {
 ;   0x800B = EVENT_OBJECT_LOCATIONCHANGE
 ;   0x800C = EVENT_OBJECT_NAMECHANGE
 _WEH_WinEventProc(hWinEventHook, event, hwnd, idObject, idChild, idEventThread, dwmsEventTime) { ; lint-ignore: dead-param
-    global _WEH_PendingHwnds, _WEH_ShellWindow, _WEH_PendingFocusHwnd, _WEH_PendingZNeeded
+    global _WEH_PendingHwnds, _WEH_ShellWindow, _WEH_PendingFocusHwnd, _WEH_PendingZNeeded, _WEH_PendingLocChange
     global cfg, gWS_Store
 
     try {  ; Error boundary: DllCall callback — unhandled throw = undefined Win32 behavior
@@ -295,6 +298,10 @@ _WEH_WinEventProc(hWinEventHook, event, hwnd, idObject, idChild, idEventThread, 
         _WEH_PendingZNeeded[hwnd] := true
     }
 
+    ; Flag LOCATIONCHANGE — only these can change monitor placement
+    if (event = 0x800B)
+        _WEH_PendingLocChange[hwnd] := true
+
     Profiler.Leave() ; @profile
     Critical "Off"
 
@@ -319,7 +326,7 @@ _WEH_WinEventProc(hWinEventHook, event, hwnd, idObject, idChild, idEventThread, 
 
 ; Process queued events in batches
 _WEH_ProcessBatch() {
-    global _WEH_PendingHwnds, WinEventHook_DebounceMs, _WEH_PendingZNeeded
+    global _WEH_PendingHwnds, WinEventHook_DebounceMs, _WEH_PendingZNeeded, _WEH_PendingLocChange
     global gWEH_LastFocusHwnd, _WEH_PendingFocusHwnd
     global _WEH_IdleTicks, _WEH_IdleThreshold, _WEH_TimerOn, WinEventHook_BatchMs
     global cfg, gWS_Meta, gKSub_MruSuppressUntilTick, gWS_Store, gWS_OnStoreChanged
@@ -457,15 +464,16 @@ _WEH_ProcessBatch() {
             superseded := (_WEH_PendingFocusHwnd != 0 && _WEH_PendingFocusHwnd != pendingProbeHwnd)
             Critical "Off"
             if (!superseded) {
-                WL_UpsertWindow([probe], "winevent_focus_add")
+                ; PERF: Batch new window + old focus clear into single UpsertWindow call
+                ; (single rev bump instead of two separate bumps)
+                records := [probe]
+                if (pendingPrevFocus && pendingPrevFocus != pendingProbeHwnd)
+                    records.Push(Map("hwnd", pendingPrevFocus, "isFocused", false))
+                WL_UpsertWindow(records, "winevent_focus_add")
                 if (logEnabled)
                     _WEH_DiagLog("  ADDED TO STORE: '" SubStr(probeTitle, 1, 30) "' with MRU tick")
 
-                ; Clear focus on previous window
                 Critical "On"
-                if (pendingPrevFocus && pendingPrevFocus != pendingProbeHwnd) {
-                    WL_UpdateFields(pendingPrevFocus, { isFocused: false }, "winevent_mru")
-                }
                 gWEH_LastFocusHwnd := pendingProbeHwnd
                 Critical "Off"
                 focusProcessed := true
@@ -532,13 +540,16 @@ _WEH_ProcessBatch() {
         idx++
     }
 
-    ; RACE FIX: Snapshot Z flags before cleanup (needed for conditional enqueue below)
+    ; RACE FIX: Snapshot Z + location flags before cleanup (needed for conditional logic below)
     ; Then remove processed items atomically
     Critical "On"
     zSnapshot := Map()
+    locSnapshot := Map()
     for _, hwnd in toProcess {
         if (_WEH_PendingZNeeded.Has(hwnd))
             zSnapshot[hwnd] := true
+        if (_WEH_PendingLocChange.Has(hwnd))
+            locSnapshot[hwnd] := true
     }
     for _, arr in [destroyed, hidden, toProcess] {
         for _, h in arr {
@@ -546,6 +557,8 @@ _WEH_ProcessBatch() {
                 _WEH_PendingHwnds.Delete(h)
             if (_WEH_PendingZNeeded.Has(h))
                 _WEH_PendingZNeeded.Delete(h)
+            if (_WEH_PendingLocChange.Has(h))
+                _WEH_PendingLocChange.Delete(h)
         }
     }
     Critical "Off"
@@ -595,7 +608,7 @@ _WEH_ProcessBatch() {
         for _, hwnd in toProcess {
             if (gWS_Store.Has(hwnd + 0)) {
                 ; Lightweight path: window already in store — skip immutable fields
-                result := _WEH_UpdateExisting(hwnd)
+                result := _WEH_UpdateExisting(hwnd, locSnapshot.Has(hwnd))
                 if (result = -1)
                     ineligibleHwnds.Push(hwnd)
                 else if (IsObject(result)) {
@@ -713,7 +726,7 @@ _WEH_ProbeWindow(hwnd) {
 ; Skips immutable fields (class, PID) - only fetches title + vis/min/cloak.
 ; Returns: Object patch (success), -1 (ineligible/destroyed), false (skipped/error)
 ; Caller batches patches and calls WL_BatchUpdateFields once for the whole batch.
-_WEH_UpdateExisting(hwnd) {
+_WEH_UpdateExisting(hwnd, hasLocationChange := true) {
     Profiler.Enter("_WEH_UpdateExisting") ; @profile
     global gWS_Store
     ; Check window still exists
@@ -755,12 +768,17 @@ _WEH_UpdateExisting(hwnd) {
         return -1
     }
 
-    ; Stamp monitor identity (detects cross-monitor moves via LOCATIONCHANGE)
-    hMon := Win_GetMonitorHandle(hwnd)
+    ; PERF: Only probe monitor on LOCATIONCHANGE — NAMECHANGE can't move a window.
+    ; Saves ~50-100μs per NAMECHANGE-only update (Win_GetMonitorHandle + Win_GetMonitorLabel).
+    patch := { title: title, isCloaked: isCloaked, isMinimized: isMin, isVisible: isVisible }
+    if (hasLocationChange) {
+        hMon := Win_GetMonitorHandle(hwnd)
+        patch.monitorHandle := hMon
+        patch.monitorLabel := Win_GetMonitorLabel(hMon)
+    }
 
     ; Return patch Object — caller collects into batch
     Profiler.Leave() ; @profile
-    return { title: title, isCloaked: isCloaked, isMinimized: isMin, isVisible: isVisible,
-             monitorHandle: hMon, monitorLabel: Win_GetMonitorLabel(hMon) }
+    return patch
 }
 

--- a/src/gui/gui_input.ahk
+++ b/src/gui/gui_input.ahk
@@ -93,7 +93,7 @@ _GUI_MoveSelection(delta) {
 ; NOTE: No Critical "Off" here — callers may hold Critical (e.g., interceptor's TAB_STEP).
 ; AHK v2 Critical is thread-level, so "Off" here would leak and break the caller's protection.
 GUI_RecalcHover() {
-    global gGUI_OverlayH, gGUI_HoverRow, gGUI_HoverBtn
+    global gGUI_OverlayH, gGUI_HoverRow, gGUI_HoverBtn, gGUI_ScrollTop
 
     if (!gGUI_OverlayH) {
         return false
@@ -109,6 +109,15 @@ GUI_RecalcHover() {
 
     x := NumGet(pt, 0, "Int")
     y := NumGet(pt, 4, "Int")
+
+    ; PERF: Skip recalc when mouse hasn't moved AND scroll hasn't changed.
+    ; Tab press changes gGUI_ScrollTop, which changes row-under-cursor.
+    static lastX := -99999, lastY := -99999, lastScroll := -1
+    if (x = lastX && y = lastY && gGUI_ScrollTop = lastScroll)
+        return false
+    lastX := x
+    lastY := y
+    lastScroll := gGUI_ScrollTop
 
     ; Check if mouse is inside the GUI window bounds
     ; If outside, clear hover state

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -282,13 +282,17 @@ _GUI_OnProducerRevChanged(isStructural := true) {
                 GUI_PatchCosmeticUpdates()
         }
 
-        ; Check bypass mode on every focus change regardless of state.
+        ; Check bypass mode on foreground hwnd change regardless of state.
         ; Previously gated to ACTIVE-only, which caused a deadlock: bypass
         ; disabled Tab hooks, and only ACTIVE state (requires Tab) could clear it.
+        ; PERF: Cache result per hwnd — avoids cross-process WinGetProcessName + WinGetPos
+        ; on every producer callback (was 0.5-2ms × 5-20×/sec).
+        static lastBypassHwnd := 0, lastBypassResult := false
         fgHwnd := DllCall("GetForegroundWindow", "Ptr")
-        if (fgHwnd) {
-            shouldBypass := INT_ShouldBypassWindow(fgHwnd)
-            INT_SetBypassMode(shouldBypass)
+        if (fgHwnd && fgHwnd != lastBypassHwnd) {
+            lastBypassHwnd := fgHwnd
+            lastBypassResult := INT_ShouldBypassWindow(fgHwnd)
+            INT_SetBypassMode(lastBypassResult)
         }
 
         ; Re-assert Tab hotkey is enabled when bypass is off.
@@ -380,6 +384,13 @@ _GUI_StartValidateExistence() {
 
 _GUI_ValidateExistenceTick() {
     Profiler.Enter("_GUI_ValidateExistenceTick") ; @profile
+    global gGUI_State
+    ; PERF: Skip during overlay session — per-window DllCalls cost 1-3ms for 30 windows.
+    ; Display list is frozen during ACTIVE anyway; validation can wait.
+    if (gGUI_State = "ACTIVE" || gGUI_State = "ALT_PENDING") {
+        Profiler.Leave() ; @profile
+        return
+    }
     static _errCount := 0  ; Error boundary: consecutive error tracking
     static _backoffUntil := 0  ; Tick-based cooldown for exponential backoff
     if (A_TickCount < _backoffUntil) {
@@ -405,7 +416,11 @@ _GUI_StartHousekeeping() {
 }
 
 _GUI_Housekeeping() {
-    global cfg, LOG_PATH_STORE
+    global cfg, LOG_PATH_STORE, gGUI_State
+    ; PERF: Skip during overlay session — cache pruning + log rotation + reassert
+    ; cost 5-15ms combined; defer until user finishes Alt-Tab
+    if (gGUI_State = "ACTIVE" || gGUI_State = "ALT_PENDING")
+        return
     try {
     ; Cache pruning
     _GUI_TryHousekeep(KomorebiSub_PruneStaleCache, "KomorebiSub_PruneStaleCache", LOG_PATH_STORE)

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -741,7 +741,8 @@ _GUI_ShowOverlayWithFrozen() {
         return
     }
 
-    Win_DwmFlush()
+    ; PERF: DwmFlush removed — Present(0,0) already submitted the frame to the swap chain,
+    ; and Anim_StartTween handles the fade-in. DwmFlush was adding 0-16ms vsync wait.
 
     ; Start hover polling (fallback for WM_MOUSELEAVE)
     GUI_StartHoverPolling()

--- a/tests/check_batch_patterns.ps1
+++ b/tests/check_batch_patterns.ps1
@@ -407,7 +407,7 @@ $CHECKS = @(
         File     = "gui\gui_main.ahk"
         Function = "_GUI_OnProducerRevChanged"
         Desc     = "Bypass evaluation runs in all GUI states, not just ACTIVE (issue #91)"
-        Patterns = @("INT_SetBypassMode(shouldBypass)", "INT_ShouldBypassWindow(fgHwnd)")
+        Patterns = @("INT_SetBypassMode(lastBypassResult)", "INT_ShouldBypassWindow(fgHwnd)")
     },
     @{
         Id       = "config_validation_completeness_loader"


### PR DESCRIPTION
## Summary

- **Cache bypass detection** per foreground hwnd — `INT_ShouldBypassWindow()` was calling cross-process `WinGetProcessName()` + `WinGetPos` on every producer callback (0.5-2ms × 5-20×/sec). Now cached and only re-evaluated when foreground hwnd changes.
- **Remove DwmFlush** after first paint in show sequence — `Present(0,0)` already submitted the frame, animation tween handles fade-in. Saves 0-16ms vsync wait per show.
- **Guard housekeeping + ValidateExistence** during ACTIVE/ALT_PENDING — defers cache pruning, log rotation, and per-window DllCalls until overlay session ends.
- **Track LOCATIONCHANGE separately** in WinEventHook — skip `Win_GetMonitorHandle`/`Win_GetMonitorLabel` for NAMECHANGE-only updates (~50-100μs saved per event).
- **Batch new-focus add + old-focus clear** into single `WL_UpsertWindow` call — eliminates double rev bump when new window gains focus.
- **Cache mouse position + scroll offset** in `GUI_RecalcHover` — skip 3 DllCalls + action detection when nothing changed.

Closes #228

## Test plan

- [x] Static analysis passes (no new failures; `Shader_PreRender` is pre-existing on main)
- [ ] `.\tests\test.ps1 --live` passes (blocked by pre-existing `Shader_PreRender` failure on main)
- [ ] Manual: Alt-Tab shows overlay without visual artifacts (DwmFlush removal)
- [ ] Manual: Bypass mode still activates for fullscreen games
- [ ] Manual: Housekeeping resumes after overlay dismissal (stats flush, cache pruning)
- [ ] Flight recorder: verify `FR_EV_FOCUS` and `FR_EV_STATE` timing unchanged

Generated with [Claude Code](https://claude.com/claude-code)