### PR TITLE
Fix stale acrylic backdrop after workspace switch

### DIFF
--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -60,6 +60,38 @@ _GUI_ApplyConfigBackdrop() {
     }
 }
 
+; Force DWM to re-sample the acrylic/glass backdrop after a workspace switch.
+; Komorebi cloaks/uncloaks windows asynchronously — when the workspace event
+; fires, cloaking is still in flight. A delayed geometry nudge (SetWindowPos
+; +1px/-1px) forces DWM to re-evaluate the backdrop area after the desktop
+; has settled. The DComp clip rect masks the transient 1px, so no visual
+; artifact. (#235)
+GUI_RefreshBackdrop() {
+    global cfg
+    SetTimer(_GUI_BackdropNudge, -cfg.AltTabBackdropRefreshDelayMs)
+}
+
+_GUI_BackdropNudge() {
+    global gGUI_BaseH, gGUI_Revealed, gGUI_OverlayVisible
+    global SWP_NOZORDER, SWP_NOOWNERZORDER, SWP_NOACTIVATE
+    if (!gGUI_BaseH || !gGUI_Revealed || !gGUI_OverlayVisible)
+        return
+
+    rect := Buffer(16, 0)
+    if (!DllCall("user32\GetWindowRect", "ptr", gGUI_BaseH, "ptr", rect.Ptr))
+        return
+    x := NumGet(rect, 0, "int")
+    y := NumGet(rect, 4, "int")
+    w := NumGet(rect, 8, "int") - x
+    h := NumGet(rect, 12, "int") - y
+
+    flags := SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE
+    DllCall("user32\SetWindowPos", "ptr", gGUI_BaseH, "ptr", 0,
+        "int", x, "int", y, "int", w, "int", h + 1, "uint", flags, "int")
+    DllCall("user32\SetWindowPos", "ptr", gGUI_BaseH, "ptr", 0,
+        "int", x, "int", y, "int", w, "int", h, "uint", flags, "int")
+}
+
 ; ========================= CORNER STYLE =========================
 
 ; Apply DWM corner preference from config.

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -504,8 +504,10 @@ GUI_HandleWorkspaceSwitch() {
     ; Repaint if overlay is visible.  GUI_Repaint handles resize internally
     ; with deferred SetWindowPos (right before ULW) so DWM can't present a
     ; frame with the resized acrylic base but stale overlay content.
-    if (gGUI_OverlayVisible)
+    if (gGUI_OverlayVisible) {
         GUI_Repaint()
+        GUI_RefreshBackdrop()  ; Force DWM to re-sample acrylic for new workspace (#235)
+    }
     Profiler.Leave() ; @profile
 }
 

--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -83,6 +83,10 @@ global gConfigRegistry := [
      min: 0, max: 500,
      d: "Wait time after workspace switch (ms). When activating a window on a different komorebi workspace, we wait this long for the workspace to stabilize before activating the window. Increase if windows fail to activate on slow systems."},
 
+    {s: "AltTab", k: "BackdropRefreshDelayMs", g: "AltTabBackdropRefreshDelayMs", t: "int", default: 250,
+     min: 50, max: 1000,
+     d: "Delay (ms) before forcing DWM to re-sample the acrylic backdrop after a workspace switch. Komorebi cloaking is asynchronous — this delay lets the desktop settle before the refresh. Increase if the acrylic still shows stale content after switching workspaces."},
+
     {type: "subsection", section: "AltTab", name: "Activation Retry",
      desc: "When the selected window is gone, retry the next MRU window"},
 

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -211,6 +211,10 @@ GUI_HideOverlay() {
 Win_ApplyAcrylic(hWnd, argbColor) {
 }
 
+; DWM backdrop refresh mock (#235)
+GUI_RefreshBackdrop() {
+}
+
 ; GDI+ icon cache invalidation mock
 Gdip_InvalidateIconCache(hwnd) {
     global gGdip_IconCache


### PR DESCRIPTION
## Summary
- Fixes stale acrylic/shader backdrop when switching workspaces with the overlay open and no row count change
- Non-resize paint path only called `D2D_Present()` — no `SetWindowPos` or `D2D_Commit` to trigger DWM backdrop re-sampling
- Adds delayed `SetWindowPos` geometry nudge (+1/-1px) after workspace switch, timed to fire after komorebi's async cloaking settles
- New config `[AltTab] BackdropRefreshDelayMs` (default 250, range 50–1000) for tuning

## Approaches tried and rejected
- **SWCA re-application**: DWM treats re-applying same policy as no-op
- **DwmFlush**: Waits for current composition but doesn't force backdrop re-sample
- **SWP_FRAMECHANGED**: Unproven for SWCA backdrop invalidation

Closes #235

## Test plan
- [x] All 932 tests pass (unit, GUI, live, flight recorder)
- [x] Manual: open overlay with shader + acrylic, switch workspaces (dark→light bg) — backdrop updates correctly
- [ ] Manual: test with different `BackdropRefreshDelayMs` values (50, 250, 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)