### PR TITLE
Restore bidirectional resize ordering for BG image stability

### DIFF
--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -147,10 +147,17 @@ GUI_Repaint() {
     if (FX_HasActiveShaders())
         Anim_EnsureTimer()
 
-    ; Phase 2: Track whether resize is needed. Actual resize is atomic after
-    ; Present — SetClip + SetWindowPos + Commit all take effect on the same
-    ; compositor frame. No bidirectional ordering needed.
+    ; Bidirectional resize: SetWindowPos pumps STA and CANNOT be made atomic
+    ; with DComp Commit / DXGI Present.  During the STA pump a VSync can
+    ; fire, compositing an intermediate frame.  The strategy ensures the HWND
+    ; is always ≤ content size during the race window so the smaller boundary
+    ; hides any overflow:
+    ;   Shrink: SetWindowPos FIRST → HWND clips old content cleanly
+    ;   Grow:   SetWindowPos LAST  → old HWND clips new content cleanly
+    ; DComp SetClipRect + Commit + Present stay adjacent (no STA pump between
+    ; them) and always land on the same compositor frame.  (#177, #234)
     needsResize := (rowsChanged && gGUI_Revealed)
+    isGrowing := (needsResize && rowsDesired > oldRows)
     if (needsResize) {
         if (gFR_Enabled)
             FR_Record(FR_EV_PAINT_RESIZE, oldRows, rowsDesired, phW, phH)
@@ -160,6 +167,10 @@ GUI_Repaint() {
         global gGUI_HoverRow, gGUI_HoverBtn
         gGUI_HoverRow := 0
         gGUI_HoverBtn := ""
+        ; Shrink: resize HWND before paint.  During STA pump, old content is
+        ; shown clipped by the smaller HWND — no stale-pixel exposure.
+        if (!isGrowing && phW > 0 && phH > 0)
+            Win_SetPosPhys(gGUI_BaseH, phX, phY, phW, phH)
     }
     if (diagTiming)
         tResize := QPC() - t1
@@ -216,6 +227,14 @@ GUI_Repaint() {
                 global gAnim_FrameTimeDisplay
                 gAnim_FrameTimeDisplay := QPC() - tPaintWork
                 D2D_ReleaseBackBuffer()
+
+                ; DComp clip + Commit + Present: no STA pump between them,
+                ; guaranteed to land on the same compositor frame.
+                if (needsResize && phW > 0 && phH > 0) {
+                    D2D_SetClipRect(phW, phH)
+                    D2D_Commit()
+                }
+
                 D2D_Present()
             } catch as e {
                 D2D_ReleaseBackBuffer()
@@ -237,14 +256,10 @@ GUI_Repaint() {
         }
     }
 
-    ; Phase 2: Atomic resize after Present — paint already rendered at new
-    ; dimensions within the oversized swap chain buffer.  SetClip + SetWindowPos
-    ; + Commit are batched by DComp, all take effect on the same compositor frame.
-    if (needsResize && phW > 0 && phH > 0) {
-        D2D_SetClipRect(phW, phH)
+    ; Grow: resize HWND AFTER present + commit.  During STA pump, new content
+    ; is shown clipped by the old (smaller) HWND — clean transition.
+    if (isGrowing && phW > 0 && phH > 0)
         Win_SetPosPhys(gGUI_BaseH, phX, phY, phW, phH)
-        D2D_Commit()
-    }
 
     ; ===== TIMING: Reveal =====
     if (diagTiming)


### PR DESCRIPTION
## Summary

- Phase 2 (#177) incorrectly assumed `SetClipRect + SetWindowPos + Commit` could be atomic. `SetWindowPos` is Win32 (not DComp) and pumps the STA message loop — a VSync during the pump composes a frame with mismatched HWND geometry vs DComp clip, visible as the BG image at the wrong position during resize.
- Restores the pre-Phase-2 bidirectional resize strategy adapted for DComp clip: shrink the HWND *before* paint, grow *after* Present. In both directions the HWND is always ≤ content size during the race window, so the smaller boundary clips any overflow cleanly.
- `SetClipRect + Commit + Present` stay adjacent with no STA pump between them — guaranteed same compositor frame.

See [#177 post-mortem](https://github.com/cwilliams5/Alt-Tabby/issues/177#issuecomment-4027851471) for full analysis of the Win32/DComp atomicity constraint.

## Test plan

- [ ] Small BG image, Fixed mode, bottom-right alignment
- [ ] Shrink: overlay open with 8+ items → switch to workspace with ~4 items — BG image stays anchored
- [ ] Grow: overlay open with ~4 items → switch to workspace with 8+ items — BG image stays anchored
- [ ] Rapid workspace switching (back and forth while overlay is open)
- [ ] No-resize case: overlay open, no workspace switch — no regression

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)