### PR TITLE
Speed up query tools by 46% (~4.6s total savings)

### DIFF
--- a/tools/bench_query.ps1
+++ b/tools/bench_query.ps1
@@ -1,0 +1,69 @@
+# bench_query.ps1 - Benchmark query tools
+#
+# Runs each of the slowest query tools 3 times, captures "Completed in Xms"
+# from output, and reports min/avg/max.
+#
+# Usage:
+#   powershell -File tools/bench_query.ps1
+
+param(
+    [int]$Iterations = 3
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Define the benchmark targets with representative arguments
+$benchmarks = @(
+    @{ Name = "query_visibility";           Cmd = "powershell -File `"$PSScriptRoot\query_visibility.ps1`"" }
+    @{ Name = "query_callchain";            Cmd = "powershell -File `"$PSScriptRoot\query_callchain.ps1`" GUI_Repaint" }
+    @{ Name = "query_impact";               Cmd = "powershell -File `"$PSScriptRoot\query_impact.ps1`" GUI_Repaint" }
+    @{ Name = "query_function_visibility";  Cmd = "powershell -File `"$PSScriptRoot\query_function_visibility.ps1`" -Discover" }
+    @{ Name = "query_timers";               Cmd = "powershell -File `"$PSScriptRoot\query_timers.ps1`"" }
+    @{ Name = "query_messages";             Cmd = "powershell -File `"$PSScriptRoot\query_messages.ps1`"" }
+)
+
+# Extract milliseconds from "Completed in Xms" output
+$rxCompleted = [regex]::new('Completed in (\d+)ms')
+
+Write-Host ""
+Write-Host "  === Query Tool Benchmark ($Iterations iterations) ===" -ForegroundColor Cyan
+Write-Host ""
+
+$results = @()
+
+foreach ($bench in $benchmarks) {
+    $times = @()
+    Write-Host "  $($bench.Name)..." -NoNewline -ForegroundColor White
+
+    for ($i = 0; $i -lt $Iterations; $i++) {
+        $output = & cmd /c $bench.Cmd 2>&1 | Out-String
+        $m = $rxCompleted.Match($output)
+        if ($m.Success) {
+            $times += [int]$m.Groups[1].Value
+        } else {
+            Write-Host " ERROR (no timing in output)" -ForegroundColor Red
+            Write-Host $output -ForegroundColor DarkGray
+            break
+        }
+    }
+
+    if ($times.Count -eq $Iterations) {
+        $min = ($times | Measure-Object -Minimum).Minimum
+        $max = ($times | Measure-Object -Maximum).Maximum
+        $avg = [math]::Round(($times | Measure-Object -Average).Average)
+        Write-Host " min=$($min)ms  avg=$($avg)ms  max=$($max)ms" -ForegroundColor Green
+        $results += @{ Name = $bench.Name; Min = $min; Avg = $avg; Max = $max; Times = $times }
+    }
+}
+
+# Summary table
+Write-Host ""
+Write-Host "  === Summary ===" -ForegroundColor Cyan
+Write-Host "  $("Tool".PadRight(32)) $("Min".PadLeft(6))  $("Avg".PadLeft(6))  $("Max".PadLeft(6))" -ForegroundColor White
+Write-Host "  $("-" * 58)" -ForegroundColor DarkGray
+
+foreach ($r in $results) {
+    $color = if ($r.Avg -gt 1000) { "Yellow" } elseif ($r.Avg -gt 500) { "White" } else { "Green" }
+    Write-Host "  $($r.Name.PadRight(32)) $("$($r.Min)ms".PadLeft(6))  $("$($r.Avg)ms".PadLeft(6))  $("$($r.Max)ms".PadLeft(6))" -ForegroundColor $color
+}
+Write-Host ""

--- a/tools/query_callchain.ps1
+++ b/tools/query_callchain.ps1
@@ -60,6 +60,8 @@ $pass1Sw = [System.Diagnostics.Stopwatch]::StartNew()
 $funcRegistry = @{}
 # fileCache: filePath -> string[] (lazy-split lines)
 $fileCache = @{}
+# cleanedCache: filePath -> string[] (cleaned lines, parallel to fileCache)
+$cleanedCache = @{}
 
 foreach ($file in $srcFiles) {
     $text = [System.IO.File]::ReadAllText($file.FullName)
@@ -67,10 +69,18 @@ foreach ($file in $srcFiles) {
     $fileCache[$file.FullName] = $lines
     $relPath = $file.FullName.Replace("$projectRoot\", '')
 
+    # Pre-clean all lines and cache for Pass 2 reuse
+    $lineCount = $lines.Count
+    $cleaned_arr = [string[]]::new($lineCount)
+    for ($i = 0; $i -lt $lineCount; $i++) {
+        $cleaned_arr[$i] = Clean-Line $lines[$i]
+    }
+    $cleanedCache[$file.FullName] = $cleaned_arr
+
     $depth = 0
 
-    for ($i = 0; $i -lt $lines.Count; $i++) {
-        $cleaned = Clean-Line $lines[$i]
+    for ($i = 0; $i -lt $lineCount; $i++) {
+        $cleaned = $cleaned_arr[$i]
         if ($cleaned -eq '') { continue }
 
         # Function definition at file scope (depth 0)
@@ -143,6 +153,7 @@ $hasCallbackKeyword = $false
 
 foreach ($file in $srcFiles) {
     $lines = $fileCache[$file.FullName]
+    $cleaned_arr = $cleanedCache[$file.FullName]
 
     $depth = 0
     $inFunc = $false
@@ -152,7 +163,7 @@ foreach ($file in $srcFiles) {
         [System.StringComparer]::OrdinalIgnoreCase)
 
     for ($i = 0; $i -lt $lines.Count; $i++) {
-        $cleaned = Clean-Line $lines[$i]
+        $cleaned = $cleaned_arr[$i]
         if ($cleaned -eq '') { continue }
 
         # Track function boundaries

--- a/tools/query_function_visibility.ps1
+++ b/tools/query_function_visibility.ps1
@@ -79,6 +79,8 @@ $pass1Sw = [System.Diagnostics.Stopwatch]::StartNew()
 $funcDefs = @{}
 $fileCache = @{}
 $fileCacheText = @{}
+# cleanedCache: filePath -> string[] (cleaned lines, parallel to fileCache)
+$cleanedCache = @{}
 
 foreach ($file in $srcFiles) {
     $text = [System.IO.File]::ReadAllText($file.FullName)
@@ -91,10 +93,18 @@ foreach ($file in $srcFiles) {
     $fileCache[$file.FullName] = $lines
     $relPath = $file.FullName.Replace("$projectRoot\", '')
 
+    # Pre-clean all lines and cache for Pass 2 reuse
+    $lineCount = $lines.Count
+    $cleaned_arr = [string[]]::new($lineCount)
+    for ($ci = 0; $ci -lt $lineCount; $ci++) {
+        $cleaned_arr[$ci] = Clean-Line $lines[$ci]
+    }
+    $cleanedCache[$file.FullName] = $cleaned_arr
+
     $depth = 0
 
-    for ($i = 0; $i -lt $lines.Count; $i++) {
-        $cleaned = Clean-Line $lines[$i]
+    for ($i = 0; $i -lt $lineCount; $i++) {
+        $cleaned = $cleaned_arr[$i]
         if ($cleaned -eq '') { continue }
 
         # Function definition at file scope (depth 0)
@@ -154,7 +164,8 @@ if (-not $Query) {
     $privateFuncRegex = $null
     if ($privateFuncKeys.Count -gt 0) {
         $escapedNames = @($privateFuncKeys | ForEach-Object { [regex]::Escape($funcDefs[$_].Name) })
-        $privateFuncRegex = [regex]::new('(?i)(?:' + ($escapedNames -join '|') + ')', 'Compiled, IgnoreCase')
+        # No 'Compiled' — JIT-compiling an 812-way alternation is a ~1800ms net loss vs interpreted
+        $privateFuncRegex = [regex]::new('(?i)(?:' + ($escapedNames -join '|') + ')', 'IgnoreCase')
     }
 
     # Pre-compile per-line reference pattern (avoids recompilation per line)
@@ -172,6 +183,7 @@ if (-not $Query) {
         if ($privateFuncRegex -and -not $privateFuncRegex.IsMatch($fileCacheText[$file.FullName])) { continue }
 
         $lines = $fileCache[$file.FullName]
+        $cleaned_arr = $cleanedCache[$file.FullName]
         $relPath = $file.FullName.Replace("$projectRoot\", '')
 
         $depth = 0
@@ -182,7 +194,7 @@ if (-not $Query) {
             [System.StringComparer]::OrdinalIgnoreCase)
 
         for ($i = 0; $i -lt $lines.Count; $i++) {
-            $cleaned = Clean-Line $lines[$i]
+            $cleaned = $cleaned_arr[$i]
             if ($cleaned -eq '') { continue }
 
             # Track function context for reporting
@@ -274,9 +286,18 @@ if ($Query) {
 
         # Lazy line splitting: only split files that pass pre-filter and weren't split in Pass 1
         if (-not $fileCache.ContainsKey($file.FullName)) {
-            $fileCache[$file.FullName] = Split-Lines $fileCacheText[$file.FullName]
+            $qSplitLines = Split-Lines $fileCacheText[$file.FullName]
+            $fileCache[$file.FullName] = $qSplitLines
+            # Also build cleaned cache for lazily-split files
+            $qLineCount = $qSplitLines.Count
+            $qCleanedArr = [string[]]::new($qLineCount)
+            for ($qci = 0; $qci -lt $qLineCount; $qci++) {
+                $qCleanedArr[$qci] = Clean-Line $qSplitLines[$qci]
+            }
+            $cleanedCache[$file.FullName] = $qCleanedArr
         }
         $qLines = $fileCache[$file.FullName]
+        $qCleanedLines = $cleanedCache[$file.FullName]
 
         $relPath = $file.FullName.Replace("$projectRoot\", '')
 
@@ -286,7 +307,7 @@ if ($Query) {
         $qCurFunc = ""
 
         for ($qi = 0; $qi -lt $qLines.Count; $qi++) {
-            $cleaned = Clean-Line $qLines[$qi]
+            $cleaned = $qCleanedLines[$qi]
             if ($cleaned -eq '') { continue }
 
             $mFD3 = $script:RX_FUNC_DEF.Match($cleaned)

--- a/tools/query_impact.ps1
+++ b/tools/query_impact.ps1
@@ -53,6 +53,12 @@ $funcFile = $null
 $funcRegistry = @{}
 $globalDecl = @{}
 $fileCache = @{}
+# cleanedCache: filePath -> string[] (cleaned lines, parallel to fileCache)
+$cleanedCache = @{}
+# fileCacheText: filePath -> raw text (avoids re-reading in Steps 2/4/5)
+$fileCacheText = @{}
+# boundaryCache: filePath -> boundary map (avoids re-building in Steps 4/5)
+$boundaryCache = @{}
 
 $MUTATING_METHODS = 'Push|Pop|Delete|InsertAt|RemoveAt|Set|Clear'
 
@@ -60,14 +66,23 @@ foreach ($file in $srcFiles) {
     $text = [System.IO.File]::ReadAllText($file.FullName)
     $lines = Split-Lines $text
     $fileCache[$file.FullName] = $lines
+    $fileCacheText[$file.FullName] = $text
     $relPath = $file.FullName.Replace("$projectRoot\", '')
+
+    # Pre-clean all lines and cache for later step reuse
+    $lineCount = $lines.Count
+    $cleaned_arr = [string[]]::new($lineCount)
+    for ($ci = 0; $ci -lt $lineCount; $ci++) {
+        $cleaned_arr[$ci] = Clean-Line $lines[$ci]
+    }
+    $cleanedCache[$file.FullName] = $cleaned_arr
 
     $depth = 0
     $inFunc = $false
     $funcDepth = -1
 
-    for ($i = 0; $i -lt $lines.Count; $i++) {
-        $cleaned = Clean-Line $lines[$i]
+    for ($i = 0; $i -lt $lineCount; $i++) {
+        $cleaned = $cleaned_arr[$i]
         if ($cleaned -eq '') { continue }
 
         # Collect file-scope globals
@@ -186,18 +201,20 @@ $escaped = [regex]::Escape($funcDef.Name)
 $rxRef = [regex]::new("(?<![.\w])$escaped(?=\s*[\(,\)\s\.\[]|`$)", 'Compiled, IgnoreCase')
 
 foreach ($file in $srcFiles) {
-    $text = [System.IO.File]::ReadAllText($file.FullName)
+    $text = $fileCacheText[$file.FullName]
     if ($text.IndexOf($funcDef.Name, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
 
     $lines = $fileCache[$file.FullName]
+    $cleaned_arr = $cleanedCache[$file.FullName]
     $relPath = $file.FullName.Replace("$projectRoot\", '')
     $bounds = Build-FuncBoundaryMap $lines
+    $boundaryCache[$file.FullName] = $bounds
 
     for ($i = 0; $i -lt $lines.Count; $i++) {
         # Skip the definition line itself
         if ($file.FullName -eq $funcDef.File -and ($i + 1) -eq $funcDef.Line) { continue }
 
-        $cleaned = Clean-Line $lines[$i]
+        $cleaned = $cleaned_arr[$i]
         if ($cleaned -eq '') { continue }
 
         if ($rxRef.IsMatch($cleaned)) {
@@ -282,12 +299,18 @@ foreach ($gw in $globalsWritten) {
         [System.StringComparer]::OrdinalIgnoreCase)
 
     foreach ($file in $srcFiles) {
-        $text = [System.IO.File]::ReadAllText($file.FullName)
+        $text = $fileCacheText[$file.FullName]
         if ($text.IndexOf($gName, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
 
         $lines = $fileCache[$file.FullName]
+        $cleaned_arr = $cleanedCache[$file.FullName]
         $relPath = $file.FullName.Replace("$projectRoot\", '')
-        $bounds = Build-FuncBoundaryMap $lines
+        if ($boundaryCache.ContainsKey($file.FullName)) {
+            $bounds = $boundaryCache[$file.FullName]
+        } else {
+            $bounds = Build-FuncBoundaryMap $lines
+            $boundaryCache[$file.FullName] = $bounds
+        }
 
         # Check if any function in this file declares global <gName>
         $inFunc = $false
@@ -297,7 +320,7 @@ foreach ($gw in $globalsWritten) {
         $depth = 0
 
         for ($i = 0; $i -lt $lines.Count; $i++) {
-            $cleaned = Clean-Line $lines[$i]
+            $cleaned = $cleaned_arr[$i]
             if ($cleaned -eq '') { continue }
 
             if (-not $inFunc) {
@@ -373,17 +396,23 @@ if ($Deep -and $callers.Count -gt 0) {
         $rxCallerRef = [regex]::new("(?<![.\w])$escapedCaller(?=\s*[\(,\)\s\.\[]|`$)", 'IgnoreCase')
 
         foreach ($file in $srcFiles) {
-            $text = [System.IO.File]::ReadAllText($file.FullName)
+            $text = $fileCacheText[$file.FullName]
             if ($text.IndexOf($callerDef.Name, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
 
             $lines = $fileCache[$file.FullName]
+            $cleaned_arr = $cleanedCache[$file.FullName]
             $relPath = $file.FullName.Replace("$projectRoot\", '')
-            $bounds = Build-FuncBoundaryMap $lines
+            if ($boundaryCache.ContainsKey($file.FullName)) {
+                $bounds = $boundaryCache[$file.FullName]
+            } else {
+                $bounds = Build-FuncBoundaryMap $lines
+                $boundaryCache[$file.FullName] = $bounds
+            }
 
             for ($i = 0; $i -lt $lines.Count; $i++) {
                 if ($file.FullName -eq $callerDef.File -and ($i + 1) -eq $callerDef.Line) { continue }
 
-                $cleaned = Clean-Line $lines[$i]
+                $cleaned = $cleaned_arr[$i]
                 if ($cleaned -eq '') { continue }
 
                 if ($rxCallerRef.IsMatch($cleaned)) {

--- a/tools/query_visibility.ps1
+++ b/tools/query_visibility.ps1
@@ -47,8 +47,9 @@ foreach ($file in $srcFiles) {
     $relPath = $file.FullName.Replace("$projectRoot\", '')
 
     $depth = 0
+    $lineCount = $lines.Count
 
-    for ($i = 0; $i -lt $lines.Count; $i++) {
+    for ($i = 0; $i -lt $lineCount; $i++) {
         $cleaned = Clean-Line $lines[$i]
         if ($cleaned -eq '') { continue }
 
@@ -86,10 +87,11 @@ $results = [System.Collections.ArrayList]::new()
 foreach ($def in $funcDefs) {
     $escaped = [regex]::Escape($def.Name)
     $pattern = "(?<![.\w])$escaped(?=\s*[\(,\)\s\.\[]|$)"
-    $def.CompiledRegex = [regex]::new($pattern, 'Compiled, IgnoreCase')
+    # No 'Compiled' — JIT-compiling 458 regexes each tested against ~72 files is a ~1600ms net loss
+    $def.CompiledRegex = [regex]::new($pattern, 'IgnoreCase')
 }
 
-# Pre-build per-file word sets for O(1) name lookup (replaces IndexOf pre-filter)
+# Pre-build per-file word sets for O(1) name lookup (IndexOf is ~2x slower due to substring false positives hitting regex)
 $fileWordSets = @{}
 foreach ($file in $srcFiles) {
     $words = [System.Collections.Generic.HashSet[string]]::new(


### PR DESCRIPTION
## Summary

- **Cache cleaned lines** between passes in query_callchain, query_impact, query_function_visibility — eliminates ~42K redundant `Clean-Line` calls per tool
- **Cache file text + boundary maps** in query_impact — eliminates ~60 redundant `ReadAllText` calls and repeated `Build-FuncBoundaryMap` across Steps 2/4/5
- **Remove `Compiled` flag** from 812-way alternation regex in query_function_visibility (-1800ms) and 458 per-function regexes in query_visibility (-1600ms) — JIT cost far exceeds amortized benefit with only ~72 files
- **Add `bench_query.ps1`** for reproducible before/after measurement

| Tool | Before | After | Savings |
|------|--------|-------|---------|
| query_visibility | 2492ms | 904ms | -64% |
| query_function_visibility | 3303ms | 1136ms | -66% |
| query_impact | 1534ms | 1101ms | -28% |
| query_callchain | 1416ms | 1021ms | -28% |

Rejected: IndexOf pre-filter replacing HashSets in query_visibility (measured ~2x regression due to substring false positives).

## Test plan

- [x] `tools/bench_query.ps1` — all 4 tools faster, no regressions in timers/messages
- [x] Static analysis pre-gate passes (79/79 checks)
- [x] Spot-checked output of all modified tools (query_visibility, query_callchain, query_impact, query_function_visibility -Discover/-Check/query mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)