### PR TITLE
Fix multi-line function signature blindness in query tools

### DIFF
--- a/.claude/skills/review-comments/SKILL.md
+++ b/.claude/skills/review-comments/SKILL.md
@@ -16,7 +16,7 @@ Grep all `.ahk` files in `src/` for comments (lines containing `;` after code, o
 
 ### What to cross-reference
 
-- **Function names** — comment says "calls _FooBar()" or "see _FooBar" — does `_FooBar` still exist? Use `query_function_visibility.ps1` to check.
+- **Function names** — comment says "calls _FooBar()" or "see _FooBar" — does `_FooBar` still exist? Use `query_function_visibility.ps1` to check. Use `query_impact.ps1` to validate comment references to affected functions.
 - **Global variable names** — comment references `gSomeGlobal` — does it still exist? Use `query_global_ownership.ps1` to check.
 - **File names** — comment says "see gui_store.ahk" or "defined in old_file.ahk" — does that file still exist? Use glob to check.
 - **Config keys** — comment references a config key name — does it still exist in the registry? Use `query_config.ps1` to check.

--- a/.claude/skills/review-function-visibility/SKILL.md
+++ b/.claude/skills/review-function-visibility/SKILL.md
@@ -21,6 +21,7 @@ Enter planning mode. Audit function visibility boundaries for cleanup opportunit
 |---------|---------|
 | `query_function_visibility.ps1 <funcName>` | Where defined, public/private, all callers |
 | `query_interface.ps1 <file>` | Public/private function ratios for a file |
+| `query_impact.ps1 <funcName>` | Blast radius of making a function public (downstream callers/readers) |
 
 ## What to Look For
 

--- a/.claude/skills/review-option-interaction/SKILL.md
+++ b/.claude/skills/review-option-interaction/SKILL.md
@@ -41,7 +41,7 @@ Before testing combinations, build a current inventory by reading the code. Thes
 
 ## Step 2 — Test Combinatorial Paths
 
-For each pair/group of options, trace the user journey through the code. Use `query_callchain.ps1` to follow how config option reads flow through functions across files:
+For each pair/group of options, trace the user journey through the code. Use `query_callchain.ps1` to follow how config option reads flow through functions across files. Use `query_ipc.ps1` to check cross-process message flows that can trigger option interactions:
 
 - How does feature X behave when run as admin vs not admin?
 - What happens if UAC is refused at each elevation prompt?

--- a/.claude/skills/review-resource-leaks/SKILL.md
+++ b/.claude/skills/review-resource-leaks/SKILL.md
@@ -72,7 +72,7 @@ Data structures that grow over time without pruning:
 Split by resource type for independent parallel exploration:
 
 - **D2D / GDI+** — `src/gui/gui_paint.ahk`, `src/gui/gui_overlay.ahk`, `src/gui/gui_gdip.ahk`, any file using `D2D_*` functions. Some `Gdip_*` may remain in `src/lib/` but the paint pipeline is D2D now
-- **Win32 handles** — `src/core/` producers, `src/shared/ipc_pipe.ahk`, DllCall-heavy files. Use `query_function_visibility.ps1` to trace cleanup call chains — verify every Create/Open has a corresponding Close/Delete reachable from all callers.
+- **Win32 handles** — `src/core/` producers, `src/shared/ipc_pipe.ahk`, DllCall-heavy files. Use `query_function_visibility.ps1` to trace cleanup call chains and `query_callchain.ps1 -Reverse` to find all callers that should reach cleanup — verify every Create/Open has a corresponding Close/Delete reachable from all callers.
 - **Timers** — use `query_timers.ps1` to inventory all timers, then check each for proper cleanup
 - **Pipe IPC** — `src/shared/ipc_pipe.ahk`, `src/pump/` files
 - **Data growth** — `src/shared/window_list.ahk` (window store), icon/process caches

--- a/tools/_query_helpers.ps1
+++ b/tools/_query_helpers.ps1
@@ -87,11 +87,10 @@ function Build-FuncBoundaryMap {
             if ($script:AHK_KEYWORDS_SET.Contains($candidate)) { continue }
             $hasBody = $Lines[$j].Contains('{')
             if (-not $hasBody) {
-                for ($k = $j + 1; $k -lt [Math]::Min($j + 3, $Lines.Count); $k++) {
+                for ($k = $j + 1; $k -lt [Math]::Min($j + 10, $Lines.Count); $k++) {
                     $next = $Lines[$k].Trim()
-                    if ($next -eq '') { continue }
-                    if ($next -eq '{' -or $next.StartsWith('{')) { $hasBody = $true }
-                    break
+                    if ($next -eq '' -or $next.StartsWith(';')) { continue }
+                    if ($next.Contains('{')) { $hasBody = $true; break }
                 }
             }
             if ($hasBody) { [void]$bounds.Add(@{ Name = $candidate; Line = $j }) }

--- a/tools/query_callchain.ps1
+++ b/tools/query_callchain.ps1
@@ -89,19 +89,30 @@ foreach ($file in $srcFiles) {
             if ($m.Success) {
                 $fname = $m.Groups[1].Value
                 $fkey = $fname.ToLower()
-                if (-not $AHK_KEYWORDS_SET.Contains($fkey) -and $cleaned.Contains('{')) {
-                    if (-not $funcRegistry.ContainsKey($fkey)) {
-                        $funcRegistry[$fkey] = @{
-                            Name    = $fname
-                            File    = $file.FullName
-                            RelPath = $relPath
-                            Line    = ($i + 1)
+                if (-not $AHK_KEYWORDS_SET.Contains($fkey)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
+                    }
+                    if ($hasBody) {
+                        if (-not $funcRegistry.ContainsKey($fkey)) {
+                            $funcRegistry[$fkey] = @{
+                                Name    = $fname
+                                File    = $file.FullName
+                                RelPath = $relPath
+                                Line    = ($i + 1)
+                            }
                         }
                     }
                 }
             }
         }
 
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
         if ($depth -lt 0) { $depth = 0 }
     }
@@ -172,19 +183,30 @@ foreach ($file in $srcFiles) {
             if ($m.Success) {
                 $fname = $m.Groups[1].Value
                 $fkey = $fname.ToLower()
-                if (-not $AHK_KEYWORDS_SET.Contains($fkey) -and $cleaned.Contains('{')) {
-                    $inFunc = $true
-                    $funcDepth = $depth
-                    $curFuncKey = $fkey
-                    $seen.Clear()
+                if (-not $AHK_KEYWORDS_SET.Contains($fkey)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
+                    }
+                    if ($hasBody) {
+                        $inFunc = $true
+                        $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                        $curFuncKey = $fkey
+                        $seen.Clear()
 
-                    if (-not $callGraph.ContainsKey($curFuncKey)) {
-                        $callGraph[$curFuncKey] = [System.Collections.ArrayList]::new()
+                        if (-not $callGraph.ContainsKey($curFuncKey)) {
+                            $callGraph[$curFuncKey] = [System.Collections.ArrayList]::new()
+                        }
                     }
                 }
             }
         }
 
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
         if ($depth -lt 0) { $depth = 0 }
 

--- a/tools/query_function.ps1
+++ b/tools/query_function.ps1
@@ -62,87 +62,98 @@ foreach ($file in $srcFiles) {
         if (-not $inFunc -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
             $fname = $Matches[1]
             $fkey = $fname.ToLower()
-            if (-not $AHK_KEYWORDS_SET.Contains($fkey) -and $cleaned.Contains('{')) {
-                $inFunc = $true
-                $funcDepth = $depth
-
-                # Check if this is our target function (case-insensitive)
-                if ($fname -ieq $FuncName) {
-                    # Extract params from raw line
-                    $params = ""
-                    if ($lines[$i] -match '\(([^)]*)\)') {
-                        $params = $Matches[1].Trim()
+            if (-not $AHK_KEYWORDS_SET.Contains($fkey)) {
+                $hasBody = $cleaned.Contains('{')
+                if (-not $hasBody) {
+                    for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                        $peek = $lines[$la].Trim()
+                        if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                        if ($peek.Contains('{')) { $hasBody = $true; break }
                     }
+                }
+                if ($hasBody) {
+                    $inFunc = $true
+                    $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
 
-                    $startLine = $i
-                    $startDepth = $depth
+                    # Check if this is our target function (case-insensitive)
+                    if ($fname -ieq $FuncName) {
+                        # Extract params from raw line
+                        $params = ""
+                        if ($lines[$i] -match '\(([^)]*)\)') {
+                            $params = $Matches[1].Trim()
+                        }
 
-                    # Walk backwards to capture leading comment block
-                    $commentLines = @()
-                    $ci = $i - 1
-                    while ($ci -ge 0) {
-                        $cTrimmed = $lines[$ci].TrimStart()
-                        if ($cTrimmed -match '^\s*;') {
-                            # Comment line — prepend
-                            $commentLines = @($lines[$ci]) + $commentLines
-                            $ci--
-                        } elseif ($cTrimmed -eq '') {
-                            # Blank line — skip over it (might separate comment groups)
-                            # But only if there's a comment above it
-                            if ($ci -gt 0 -and $lines[$ci - 1].TrimStart() -match '^\s*;') {
+                        $startLine = $i
+                        $startDepth = $depth
+
+                        # Walk backwards to capture leading comment block
+                        $commentLines = @()
+                        $ci = $i - 1
+                        while ($ci -ge 0) {
+                            $cTrimmed = $lines[$ci].TrimStart()
+                            if ($cTrimmed -match '^\s*;') {
+                                # Comment line — prepend
                                 $commentLines = @($lines[$ci]) + $commentLines
                                 $ci--
+                            } elseif ($cTrimmed -eq '') {
+                                # Blank line — skip over it (might separate comment groups)
+                                # But only if there's a comment above it
+                                if ($ci -gt 0 -and $lines[$ci - 1].TrimStart() -match '^\s*;') {
+                                    $commentLines = @($lines[$ci]) + $commentLines
+                                    $ci--
+                                } else {
+                                    break
+                                }
                             } else {
                                 break
                             }
-                        } else {
-                            break
                         }
-                    }
-                    if ($commentLines.Count -gt 0) {
-                        $startLine = $ci + 1
-                    }
-
-                    # Now find the end of this function
-                    $funcBody = @($commentLines) + @($lines[$i])
-                    $currentDepth = $depth + $braceOpen - $braceClose
-
-                    for ($j = $i + 1; $j -lt $lines.Count; $j++) {
-                        $funcBody += $lines[$j]
-                        $jCleaned = Clean-Line $lines[$j]
-                        if ($jCleaned -ne '') {
-                            $currentDepth += ($jCleaned.Length - $jCleaned.Replace('{','').Length) - ($jCleaned.Length - $jCleaned.Replace('}','').Length)
+                        if ($commentLines.Count -gt 0) {
+                            $startLine = $ci + 1
                         }
-                        if ($currentDepth -le $startDepth) {
-                            # Function closed
+
+                        # Now find the end of this function
+                        $funcBody = @($commentLines) + @($lines[$i])
+                        $currentDepth = $depth + $braceOpen - $braceClose
+
+                        for ($j = $i + 1; $j -lt $lines.Count; $j++) {
+                            $funcBody += $lines[$j]
+                            $jCleaned = Clean-Line $lines[$j]
+                            if ($jCleaned -ne '') {
+                                $currentDepth += ($jCleaned.Length - $jCleaned.Replace('{','').Length) - ($jCleaned.Length - $jCleaned.Replace('}','').Length)
+                            }
+                            if ($currentDepth -le $startDepth) {
+                                # Function closed
+                                $found = @{
+                                    Name      = $fname
+                                    Params    = $params
+                                    RelPath   = $relPath
+                                    StartLine = $startLine + 1
+                                    EndLine   = $j + 1
+                                    Body      = $funcBody
+                                }
+                                break
+                            }
+                        }
+
+                        # If we hit EOF without closing, still capture what we have
+                        if (-not $found) {
                             $found = @{
                                 Name      = $fname
                                 Params    = $params
                                 RelPath   = $relPath
                                 StartLine = $startLine + 1
-                                EndLine   = $j + 1
+                                EndLine   = $lines.Count
                                 Body      = $funcBody
                             }
-                            break
                         }
+                        break
                     }
-
-                    # If we hit EOF without closing, still capture what we have
-                    if (-not $found) {
-                        $found = @{
-                            Name      = $fname
-                            Params    = $params
-                            RelPath   = $relPath
-                            StartLine = $startLine + 1
-                            EndLine   = $lines.Count
-                            Body      = $funcBody
-                        }
-                    }
-                    break
                 }
             }
         }
 
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += $braceOpen - $braceClose
         if ($depth -lt 0) { $depth = 0 }
 

--- a/tools/query_function_visibility.ps1
+++ b/tools/query_function_visibility.ps1
@@ -115,13 +115,23 @@ foreach ($file in $srcFiles) {
             if ($depth -eq 0 -and $mPriv.Success) {
                 $fname = $mPriv.Groups[1].Value
                 $fkey = $fname.ToLower()
-                if (-not $AHK_KEYWORDS_SET.Contains($fkey) -and $cleaned.Contains('{')) {
-                    if (-not $funcDefs.ContainsKey($fkey)) {
-                        $funcDefs[$fkey] = @{
-                            Name    = $fname
-                            File    = $file.FullName
-                            RelPath = $relPath
-                            Line    = ($i + 1)
+                if (-not $AHK_KEYWORDS_SET.Contains($fkey)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
+                    }
+                    if ($hasBody) {
+                        if (-not $funcDefs.ContainsKey($fkey)) {
+                            $funcDefs[$fkey] = @{
+                                Name    = $fname
+                                File    = $file.FullName
+                                RelPath = $relPath
+                                Line    = ($i + 1)
+                            }
                         }
                     }
                 }
@@ -132,19 +142,30 @@ foreach ($file in $srcFiles) {
         $mFD = $script:RX_FUNC_DEF.Match($cleaned)
         if ($Query -and -not $queryDef -and $depth -eq 0 -and $mFD.Success) {
             $fn = $mFD.Groups[1].Value
-            if ($fn.ToLower() -eq $queryKey -and -not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
-                $queryDef = @{
-                    Name    = $fn
-                    File    = $file.FullName
-                    RelPath = $relPath
-                    Line    = ($i + 1)
+            if ($fn.ToLower() -eq $queryKey -and -not $AHK_KEYWORDS_SET.Contains($fn)) {
+                $hasBody = $cleaned.Contains('{')
+                if (-not $hasBody) {
+                    for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                        $peek = $lines[$la].Trim()
+                        if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                        if ($peek.Contains('{')) { $hasBody = $true; break }
+                    }
                 }
-                if ($lines[$i] -match '\(([^)]*)\)') {
-                    $queryParams = $Matches[1].Trim()
+                if ($hasBody) {
+                    $queryDef = @{
+                        Name    = $fn
+                        File    = $file.FullName
+                        RelPath = $relPath
+                        Line    = ($i + 1)
+                    }
+                    if ($lines[$i] -match '\(([^)]*)\)') {
+                        $queryParams = $Matches[1].Trim()
+                    }
                 }
             }
         }
 
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
         if ($depth -lt 0) { $depth = 0 }
     }
@@ -201,13 +222,24 @@ if (-not $Query) {
             $mFD2 = $script:RX_FUNC_DEF.Match($cleaned)
             if (-not $inFunc -and $mFD2.Success) {
                 $fn = $mFD2.Groups[1].Value
-                if (-not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
-                    $inFunc = $true
-                    $funcDepth = $depth
-                    $funcName = $fn
+                if (-not $AHK_KEYWORDS_SET.Contains($fn)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
+                    }
+                    if ($hasBody) {
+                        $inFunc = $true
+                        $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                        $funcName = $fn
+                    }
                 }
             }
 
+            if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
             $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
             if ($depth -lt 0) { $depth = 0 }
 
@@ -313,13 +345,24 @@ if ($Query) {
             $mFD3 = $script:RX_FUNC_DEF.Match($cleaned)
             if (-not $qInFunc -and $mFD3.Success) {
                 $fn = $mFD3.Groups[1].Value
-                if (-not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
-                    $qInFunc = $true
-                    $qFuncDepth = $qDepth
-                    $qCurFunc = $fn
+                if (-not $AHK_KEYWORDS_SET.Contains($fn)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $qi + 1; $la -lt [Math]::Min($qi + 10, $qLines.Count); $la++) {
+                            $peek = $qLines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
+                    }
+                    if ($hasBody) {
+                        $qInFunc = $true
+                        $qFuncDepth = if ($cleaned.Contains('{')) { $qDepth } else { -2 }
+                        $qCurFunc = $fn
+                    }
                 }
             }
 
+            if ($qInFunc -and $qFuncDepth -eq -2 -and $cleaned.Contains('{')) { $qFuncDepth = $qDepth }
             $qDepth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
             if ($qDepth -lt 0) { $qDepth = 0 }
 

--- a/tools/query_global_ownership.ps1
+++ b/tools/query_global_ownership.ps1
@@ -139,13 +139,24 @@ if ($Query) {
             # Track function boundaries
             if (-not $inFunc -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
                 $fname = $Matches[1]
-                if (-not $AHK_KEYWORDS_SET.Contains($fname) -and $cleaned.Contains('{')) {
-                    $inFunc = $true
-                    $funcDepth = $depth
-                    $funcName = $fname
+                if (-not $AHK_KEYWORDS_SET.Contains($fname)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
+                    }
+                    if ($hasBody) {
+                        $inFunc = $true
+                        $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                        $funcName = $fname
+                    }
                 }
             }
 
+            if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
             $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
 
             if ($inFunc -and $depth -le $funcDepth) {
@@ -329,12 +340,23 @@ foreach ($file in $srcFiles) {
 
         if (-not $inFunc -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
             $fname = $Matches[1]
-            if (-not $AHK_KEYWORDS_SET.Contains($fname) -and $cleaned.Contains('{')) {
-                $inFunc = $true
-                $funcDepth = $depth
+            if (-not $AHK_KEYWORDS_SET.Contains($fname)) {
+                $hasBody = $cleaned.Contains('{')
+                if (-not $hasBody) {
+                    for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                        $peek = $lines[$la].Trim()
+                        if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                        if ($peek.Contains('{')) { $hasBody = $true; break }
+                    }
+                }
+                if ($hasBody) {
+                    $inFunc = $true
+                    $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                }
             }
         }
 
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += $delta
 
         if ($inFunc -and $depth -le $funcDepth) {
@@ -466,13 +488,24 @@ foreach ($file in $srcFiles) {
 
         if (-not $inFunc -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
             $fname = $Matches[1]
-            if (-not $AHK_KEYWORDS_SET.Contains($fname) -and $cleaned.Contains('{')) {
-                $inFunc = $true
-                $funcDepth = $depth
-                $funcName = $fname
+            if (-not $AHK_KEYWORDS_SET.Contains($fname)) {
+                $hasBody = $cleaned.Contains('{')
+                if (-not $hasBody) {
+                    for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                        $peek = $lines[$la].Trim()
+                        if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                        if ($peek.Contains('{')) { $hasBody = $true; break }
+                    }
+                }
+                if ($hasBody) {
+                    $inFunc = $true
+                    $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                    $funcName = $fname
+                }
             }
         }
 
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += $delta
 
         if ($inFunc -and $depth -le $funcDepth) {

--- a/tools/query_impact.ps1
+++ b/tools/query_impact.ps1
@@ -112,24 +112,34 @@ foreach ($file in $srcFiles) {
             if ($m.Success) {
                 $fname = $m.Groups[1].Value
                 $fkey = $fname.ToLower()
-                if (-not $AHK_KEYWORDS_SET.Contains($fkey) -and $cleaned.Contains('{')) {
-                    $inFunc = $true
-                    $funcDepth = $depth
-
-                    if (-not $funcRegistry.ContainsKey($fkey)) {
-                        $funcRegistry[$fkey] = @{
-                            Name    = $fname
-                            File    = $file.FullName
-                            RelPath = $relPath
-                            Line    = ($i + 1)
+                if (-not $AHK_KEYWORDS_SET.Contains($fkey)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
                         }
                     }
+                    if ($hasBody) {
+                        $inFunc = $true
+                        $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
 
-                    # If this is our target function, start capturing body
-                    if ($fkey -eq $FuncName.ToLower() -and -not $funcDef) {
-                        $funcDef = $funcRegistry[$fkey]
-                        $funcFile = $file.FullName
-                        $funcBodyStartIdx = $i
+                        if (-not $funcRegistry.ContainsKey($fkey)) {
+                            $funcRegistry[$fkey] = @{
+                                Name    = $fname
+                                File    = $file.FullName
+                                RelPath = $relPath
+                                Line    = ($i + 1)
+                            }
+                        }
+
+                        # If this is our target function, start capturing body
+                        if ($fkey -eq $FuncName.ToLower() -and -not $funcDef) {
+                            $funcDef = $funcRegistry[$fkey]
+                            $funcFile = $file.FullName
+                            $funcBodyStartIdx = $i
+                        }
                     }
                 }
             }
@@ -137,6 +147,7 @@ foreach ($file in $srcFiles) {
 
         $braceOpen = $cleaned.Length - $cleaned.Replace('{','').Length
         $braceClose = $cleaned.Length - $cleaned.Replace('}','').Length
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += $braceOpen - $braceClose
         if ($depth -lt 0) { $depth = 0 }
 
@@ -327,15 +338,26 @@ foreach ($gw in $globalsWritten) {
                 $fm = $script:_rxFuncDef.Match($cleaned)
                 if ($fm.Success) {
                     $fn = $fm.Groups[1].Value
-                    if (-not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
-                        $inFunc = $true
-                        $funcDepth = $depth
-                        $curFunc = $fn
-                        $curFuncDeclaresGlobal = $false
+                    if (-not $AHK_KEYWORDS_SET.Contains($fn)) {
+                        $hasBody = $cleaned.Contains('{')
+                        if (-not $hasBody) {
+                            for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                                $peek = $lines[$la].Trim()
+                                if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                                if ($peek.Contains('{')) { $hasBody = $true; break }
+                            }
+                        }
+                        if ($hasBody) {
+                            $inFunc = $true
+                            $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                            $curFunc = $fn
+                            $curFuncDeclaresGlobal = $false
+                        }
                     }
                 }
             }
 
+            if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
             $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
             if ($depth -lt 0) { $depth = 0 }
 

--- a/tools/query_instrumentation.ps1
+++ b/tools/query_instrumentation.ps1
@@ -58,18 +58,28 @@ foreach ($dir in $scopeDirs) {
             # Function definition at file scope
             if (-not $inFunc -and $depthBefore -eq 0 -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
                 $fname = $Matches[1]
-                if (-not $AHK_KEYWORDS_SET.Contains($fname) -and $cleaned.Contains('{')) {
-                    $isPrivate = $fname.StartsWith('_')
-                    $currentFunc = [PSCustomObject]@{
-                        Name = $fname
-                        File = $relPath
-                        Dir = $dir
-                        Line = ($i + 1)
-                        Private = $isPrivate
-                        Instrumented = $false
+                if (-not $AHK_KEYWORDS_SET.Contains($fname)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
                     }
-                    $inFunc = $true
-                    $funcDepth = $depthBefore
+                    if ($hasBody) {
+                        $isPrivate = $fname.StartsWith('_')
+                        $currentFunc = [PSCustomObject]@{
+                            Name = $fname
+                            File = $relPath
+                            Dir = $dir
+                            Line = ($i + 1)
+                            Private = $isPrivate
+                            Instrumented = $false
+                        }
+                        $inFunc = $true
+                        $funcDepth = if ($cleaned.Contains('{')) { $depthBefore } else { -2 }
+                    }
                 }
             }
 
@@ -80,6 +90,7 @@ foreach ($dir in $scopeDirs) {
                 }
             }
 
+            if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
             $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
             if ($depth -lt 0) { $depth = 0 }
 

--- a/tools/query_interface.ps1
+++ b/tools/query_interface.ps1
@@ -60,22 +60,32 @@ for ($i = 0; $i -lt $lines.Count; $i++) {
     # Function definition at file scope
     if (-not $inFunc -and $depth -eq 0 -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
         $fname = $Matches[1]
-        if ((-not $AHK_KEYWORDS_SET.Contains($fname)) -and $cleaned.Contains('{')) {
-            # Extract params
-            $params = ""
-            if ($lines[$i] -match '\(([^)]*)\)') {
-                $params = $Matches[1].Trim()
+        if (-not $AHK_KEYWORDS_SET.Contains($fname)) {
+            $hasBody = $cleaned.Contains('{')
+            if (-not $hasBody) {
+                for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                    $peek = $lines[$la].Trim()
+                    if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                    if ($peek.Contains('{')) { $hasBody = $true; break }
+                }
             }
+            if ($hasBody) {
+                # Extract params
+                $params = ""
+                if ($lines[$i] -match '\(([^)]*)\)') {
+                    $params = $Matches[1].Trim()
+                }
 
-            $entry = @{ Name = $fname; Params = $params; Line = ($i + 1) }
-            if ($fname.StartsWith('_')) {
-                [void]$privateFuncs.Add($entry)
-            } else {
-                [void]$publicFuncs.Add($entry)
+                $entry = @{ Name = $fname; Params = $params; Line = ($i + 1) }
+                if ($fname.StartsWith('_')) {
+                    [void]$privateFuncs.Add($entry)
+                } else {
+                    [void]$publicFuncs.Add($entry)
+                }
+
+                $inFunc = $true
+                $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
             }
-
-            $inFunc = $true
-            $funcDepth = $depth
         }
     }
 
@@ -94,6 +104,7 @@ for ($i = 0; $i -lt $lines.Count; $i++) {
         }
     }
 
+    if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
     $depth += $braceOpen - $braceClose
     if ($depth -lt 0) { $depth = 0 }
 

--- a/tools/query_mutations.ps1
+++ b/tools/query_mutations.ps1
@@ -70,13 +70,24 @@ foreach ($file in $srcFiles) {
             $m = $script:_rxFuncDef.Match($cleaned)
             if ($m.Success) {
                 $fn = $m.Groups[1].Value
-                if (-not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
-                    $inFunc = $true
-                    $funcDepth = $depth
+                if (-not $AHK_KEYWORDS_SET.Contains($fn)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
+                    }
+                    if ($hasBody) {
+                        $inFunc = $true
+                        $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                    }
                 }
             }
         }
 
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
         if ($depth -lt 0) { $depth = 0 }
 
@@ -180,15 +191,26 @@ foreach ($file in $srcFiles) {
             $m = $script:_rxFuncDef.Match($cleaned)
             if ($m.Success) {
                 $fn = $m.Groups[1].Value
-                if (-not $AHK_KEYWORDS_SET.Contains($fn) -and $cleaned.Contains('{')) {
-                    $inFunc = $true
-                    $funcDepth = $depth
-                    $funcName = $fn
-                    $funcStartIdx = $i
+                if (-not $AHK_KEYWORDS_SET.Contains($fn)) {
+                    $hasBody = $cleaned.Contains('{')
+                    if (-not $hasBody) {
+                        for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                            $peek = $lines[$la].Trim()
+                            if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                            if ($peek.Contains('{')) { $hasBody = $true; break }
+                        }
+                    }
+                    if ($hasBody) {
+                        $inFunc = $true
+                        $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                        $funcName = $fn
+                        $funcStartIdx = $i
+                    }
                 }
             }
         }
 
+        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
         $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
         if ($depth -lt 0) { $depth = 0 }
 

--- a/tools/query_visibility.ps1
+++ b/tools/query_visibility.ps1
@@ -56,13 +56,23 @@ foreach ($file in $srcFiles) {
         # Function definition at file scope (depth 0), public only (no _ prefix)
         if ($depth -eq 0 -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
             $fname = $Matches[1]
-            if (-not $AHK_KEYWORDS_SET.Contains($fname) -and -not $fname.StartsWith('_') -and $cleaned.Contains('{')) {
-                [void]$funcDefs.Add(@{
-                    Name    = $fname
-                    File    = $file.FullName
-                    RelPath = $relPath
-                    Line    = ($i + 1)
-                })
+            if (-not $AHK_KEYWORDS_SET.Contains($fname) -and -not $fname.StartsWith('_')) {
+                $hasBody = $cleaned.Contains('{')
+                if (-not $hasBody) {
+                    for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
+                        $peek = $lines[$la].Trim()
+                        if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
+                        if ($peek.Contains('{')) { $hasBody = $true; break }
+                    }
+                }
+                if ($hasBody) {
+                    [void]$funcDefs.Add(@{
+                        Name    = $fname
+                        File    = $file.FullName
+                        RelPath = $relPath
+                        Line    = ($i + 1)
+                    })
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Fix 9 query tools that failed to parse multi-line function signatures (where `{` is on a later line than the function name)
- Add inline 10-line look-ahead at 17 sites to detect `{` on continuation lines, with `$funcDepth = -2` sentinel to prevent premature function-exit in depth tracking
- Expand `Build-FuncBoundaryMap` in `_query_helpers.ps1` with consistent look-ahead
- Add query tool cross-references to 4 review skills (`review-option-interaction`, `review-comments`, `review-function-visibility`, `review-resource-leaks`)

Closes #244

## Test plan

- [x] `query_global_ownership cfg` → `declared: src\shared\config_loader.ahk:43` (was incorrectly `d2d_shader.ahk:1075`)
- [x] `query_global_ownership gShader_FrameCount` → still correct at `d2d_shader.ahk:21`
- [x] `query_function Shader_PreRender` → finds multi-line function
- [x] `query_function_visibility Shader_PreRender` → reports all 4 callers
- [x] All 942 tests pass (79 static analysis + 575 unit + 271 GUI + 32 flight recorder + live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)