### PR TITLE
Fix option interaction edge cases in install/admin/update flows

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -488,6 +488,9 @@ if (g_AltTabbyMode = "install-to-pf") {
             "  - Insufficient disk space`n`n"
             "The original file has not been modified.`n`n"
             "Details: " e.Message, APP_NAME, "Iconx")
+        ; Relaunch source exe so user isn't left with nothing running
+        if (IsSet(state) && state.HasOwnProp("source") && FileExist(state.source))
+            try Run('"' state.source '"')
     }
     ExitApp()
 }

--- a/src/launcher/launcher_tray.ahk
+++ b/src/launcher/launcher_tray.ahk
@@ -541,6 +541,7 @@ ToggleAdminMode() {
 ; Reads file content to determine outcome: numeric = still in progress, string = result
 _AdminToggle_CheckComplete() {
     global g_AdminToggleInProgress, TEMP_ADMIN_TOGGLE_LOCK, g_AdminToggleStartTick, g_CachedAdminTaskActive
+    global g_NeedsAdminReload
     global ADMIN_TOGGLE_POLL_MS, ADMIN_TOGGLE_TIMEOUT_MS
     global TOOLTIP_DURATION_DEFAULT, APP_NAME
     global ALTTABBY_TASK_NAME, TIMING_TASK_READY_WAIT, TIMING_SUBPROCESS_LAUNCH, cfg, gConfigIniPath
@@ -548,6 +549,8 @@ _AdminToggle_CheckComplete() {
     if (!FileExist(TEMP_ADMIN_TOGGLE_LOCK)) {
         ; Lock file gone entirely - elevated instance crashed or was killed
         g_AdminToggleInProgress := false
+        g_NeedsAdminReload := true
+        AdminTask_InvalidateCache()
         TrayTip("Admin Mode", "Operation did not complete. The elevated process may have crashed.", "Icon!")
         return
     }
@@ -566,6 +569,8 @@ _AdminToggle_CheckComplete() {
         elapsed := A_TickCount - g_AdminToggleStartTick
         if (elapsed >= ADMIN_TOGGLE_TIMEOUT_MS) {
             g_AdminToggleInProgress := false
+            g_NeedsAdminReload := true
+            AdminTask_InvalidateCache()
             try FileDelete(TEMP_ADMIN_TOGGLE_LOCK)
             TrayTip("Admin Mode", "The admin mode change took too long. Please try again from the tray menu.", "Icon!")
             return

--- a/src/launcher/launcher_wizard.ahk
+++ b/src/launcher/launcher_wizard.ahk
@@ -107,7 +107,7 @@ _WizardSkip(*) {
 }
 
 _WizardApply(*) {
-    global g_WizardGui, g_WizardShuttingDown, cfg, gConfigIniPath
+    global g_WizardGui, g_WizardShuttingDown, cfg, gConfigIniPath, TEMP_WIZARD_STATE
     if (g_WizardShuttingDown)
         return
     g_WizardShuttingDown := true  ; lint-ignore: guard-try-finally — intentionally kept true; false only on UAC-cancel retry
@@ -130,7 +130,7 @@ _WizardApply(*) {
             "admin", admin,
             "autoUpdate", autoUpdate
         ))
-        choicesFile := A_Temp "\alttabby_wizard.json"
+        choicesFile := TEMP_WIZARD_STATE
         try FileDelete(choicesFile)
         FileAppend(choices, choicesFile, "UTF-8")
 
@@ -179,9 +179,9 @@ _WizardApply(*) {
 ; Called when --wizard-continue flag is passed (after elevation)
 ; Returns: "installed" if we should launch from new location, true if normal continue, false on error
 WizardContinue() {
-    global cfg, gConfigIniPath, ALTTABBY_TASK_NAME, TIMING_TASK_READY_WAIT
+    global cfg, gConfigIniPath, ALTTABBY_TASK_NAME, TIMING_TASK_READY_WAIT, TEMP_WIZARD_STATE
 
-    choicesFile := A_Temp "\alttabby_wizard.json"
+    choicesFile := TEMP_WIZARD_STATE
     if (!FileExist(choicesFile))
         return false
 

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -1045,9 +1045,14 @@ Update_ApplyCore(opts) {
 
         ; Update admin task if target has admin mode enabled
         if (!targetRunAsAdmin && AdminTaskExists()) {
-            ; Config says admin disabled but task exists (orphaned from previous install
-            ; whose config was overwritten). Clean it up.
-            try DeleteAdminTask()
+            ; Config says admin disabled but task exists — only delete if it belongs to
+            ; this installation (matching ID). Otherwise it's another user's task.
+            targetInstallId := ""
+            if (FileExist(targetConfigPath))
+                try targetInstallId := IniRead(targetConfigPath, "Setup", "InstallationId", "")
+            taskId := AdminTask_GetInstallationId()
+            if (targetInstallId = "" || taskId = "" || targetInstallId = taskId)
+                try DeleteAdminTask()
         } else if (targetRunAsAdmin && AdminTaskExists()) {
             targetInstallId := ""
             if (FileExist(targetConfigPath)) {


### PR DESCRIPTION
Closes #246

## Summary

- **Relaunch source exe after install-to-PF failure** — elevated instance now relaunches `state.source` in the catch block so the user isn't left with no running instance (matches existing `apply-update` pattern)
- **Invalidate admin task cache on toggle timeout/crash** — `_AdminToggle_CheckComplete` now sets `g_NeedsAdminReload` and calls `AdminTask_InvalidateCache()` in both the "lock gone" and timeout paths, so the tray checkmark reflects actual state on next open
- **Guard orphaned task cleanup with InstallationId check** — `Update_ApplyCore` now compares the admin task's ID against the target config's ID before deleting; a different user's task is left alone
- **Use TEMP_WIZARD_STATE constant** — replaced two hardcoded `A_Temp "\alttabby_wizard.json"` paths with the constant from `config_loader.ahk`

## Test plan

- [x] Static analysis (79 checks passed)
- [x] Full test suite (942 tests passed — unit, GUI, live, flight recorder)
- [ ] Manual: Launch from non-PF → tray → Install to PF → simulate failure → confirm source exe relaunches
- [ ] Manual: Enable admin → kill elevated process before result → confirm tray checkmark refreshes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)