### PR TITLE
Fix dashboard label bugs and polish user-facing strings

### DIFF
--- a/src/editors/blacklist_editor.ahk
+++ b/src/editors/blacklist_editor.ahk
@@ -92,13 +92,13 @@ _BE_CreateGui() {
 
     ; Title tab
     tabs.UseTab("Title Patterns")
-    gBE_Gui.AddText("x20 y90 w550", "Title patterns - match window titles (e.g., '*Calculator*', 'Notepad'):")
+    gBE_Gui.AddText("x20 y90 w550", "Title patterns — match window titles (e.g., '*Calculator*', 'Notepad'):")
     gBE_TitleEdit := gBE_Gui.AddEdit("vTitleEdit x20 y115 w550 h250 +Multi +WantReturn +VScroll")
     Theme_ApplyToControl(gBE_TitleEdit, "Edit", themeEntry)
 
     ; Class tab
     tabs.UseTab("Class Patterns")
-    gBE_Gui.AddText("x20 y90 w550", "Class patterns - match window class names (e.g., 'Notepad', 'Chrome_*'):")
+    gBE_Gui.AddText("x20 y90 w550", "Class patterns — match window class names (e.g., 'Notepad', 'Chrome_*'):")
     gBE_ClassEdit := gBE_Gui.AddEdit("vClassEdit x20 y115 w550 h250 +Multi +WantReturn +VScroll")
     Theme_ApplyToControl(gBE_ClassEdit, "Edit", themeEntry)
 

--- a/src/launcher/launcher_about.ahk
+++ b/src/launcher/launcher_about.ahk
@@ -107,7 +107,7 @@ ShowDashboardDialog() {
 
     ; Install to Program Files (action or status label)
     if (A_IsCompiled && !IsInProgramFiles()) {
-        g_DashControls.installPFBtn := dg.AddButton("x640 y107 w115 h26", "Install to PF...")
+        g_DashControls.installPFBtn := dg.AddButton("x640 y107 w115 h26", "Install...")
         g_DashControls.installPFBtn.OnEvent("Click", (*) => Tray_InstallToProgramFiles())
         Theme_ApplyToControl(g_DashControls.installPFBtn, "Button", themeEntry)
     } else if (A_IsCompiled) {
@@ -240,7 +240,7 @@ ShowDashboardDialog() {
 
     ; GUI row (core — red when not running)
     subY += 30
-    _Dash_AddSubprocessRow(dg, themeEntry, dot, &subY, "gui", "GUI", g_GuiPID, true, _Dash_OnGuiBtn)
+    _Dash_AddSubprocessRow(dg, themeEntry, dot, &subY, "gui", "Overlay", g_GuiPID, true, _Dash_OnGuiBtn)
 
     ; Config Editor row (optional — grey when not running)
     subY += 30
@@ -330,11 +330,11 @@ ShowDashboardDialog() {
         escalateTip := A_IsAdmin ? "Restart without administrator elevation" : "Restart with administrator elevation (UAC prompt)"
         Dash_SetTip(hTT, btnEscalate, escalateTip)
         Dash_SetTip(hTT, g_DashControls.pumpText
-            , "The Enrichment Pump resolves window icons and process`n"
-            . "names asynchronously in a subprocess via named pipe IPC")
+            , "Background process that resolves window icons`n"
+            . "and application names")
         Dash_SetTip(hTT, g_DashControls.guiText
             , "The Alt+Tab overlay — handles keyboard hooks,`n"
-            . "window selection, and rendering")
+            . "window selection, and display")
         Dash_SetTip(hTT, g_DashControls.configText
             , "Editor subprocess for modifying config.ini settings")
         Dash_SetTip(hTT, g_DashControls.blacklistText
@@ -358,8 +358,8 @@ ShowDashboardDialog() {
         guiRunning := LauncherUtils_IsRunning(g_GuiPID)
         configRunning := LauncherUtils_IsRunning(g_ConfigEditorPID)
         blacklistRunning := LauncherUtils_IsRunning(g_BlacklistEditorPID)
-        Dash_SetTip(hTT, g_DashControls.pumpBtn, pumpRunning ? "Stop and restart the EnrichmentPump" : "Start the EnrichmentPump")
-        Dash_SetTip(hTT, g_DashControls.guiBtn, guiRunning ? "Stop and restart the GUI overlay" : "Start the GUI overlay")
+        Dash_SetTip(hTT, g_DashControls.pumpBtn, pumpRunning ? "Stop and restart the Enrichment Pump" : "Start the Enrichment Pump")
+        Dash_SetTip(hTT, g_DashControls.guiBtn, guiRunning ? "Stop and restart the overlay" : "Start the overlay")
         Dash_SetTip(hTT, g_DashControls.configBtn, configRunning ? "Restart the configuration editor" : "Open the configuration editor")
         Dash_SetTip(hTT, g_DashControls.blacklistBtn, blacklistRunning ? "Restart the blacklist editor" : "Open the blacklist editor")
         Dash_SetTip(hTT, g_DashControls.viewerBtn, _Dash_IsViewerOpen() ? "Close the debug viewer window" : "Open the debug viewer window")
@@ -544,9 +544,9 @@ Dash_Refresh() {
     }
 
     ; Subprocess labels + buttons
-    g_DashControls.pumpText.Value := "Pump: " (pumpRunning ? "Running (PID " g_PumpPID ")" : "Not running")
+    g_DashControls.pumpText.Value := "Enrichment Pump: " (pumpRunning ? "Running (PID " g_PumpPID ")" : "Not running")
     g_DashControls.pumpBtn.Text := pumpRunning ? "Restart" : "Launch"
-    g_DashControls.guiText.Value := "GUI: " (guiRunning ? "Running (PID " g_GuiPID ")" : "Not running")
+    g_DashControls.guiText.Value := "Overlay: " (guiRunning ? "Running (PID " g_GuiPID ")" : "Not running")
     g_DashControls.guiBtn.Text := guiRunning ? "Restart" : "Launch"
     g_DashControls.configText.Value := "Config Editor: " (configRunning ? "Running (PID " g_ConfigEditorPID ")" : "Not running")
     g_DashControls.configBtn.Text := configRunning ? "Restart" : "Launch"
@@ -587,7 +587,7 @@ Dash_Refresh() {
     if (g_DashControls.HasOwnProp("hTooltip") && g_DashControls.hTooltip) {
         hTT := g_DashControls.hTooltip
         _Dash_UpdateTip(hTT, g_DashControls.pumpBtn, pumpRunning ? "Stop and restart the Enrichment Pump" : "Start the Enrichment Pump")
-        _Dash_UpdateTip(hTT, g_DashControls.guiBtn, guiRunning ? "Stop and restart the GUI overlay" : "Start the GUI overlay")
+        _Dash_UpdateTip(hTT, g_DashControls.guiBtn, guiRunning ? "Stop and restart the overlay" : "Start the overlay")
         _Dash_UpdateTip(hTT, g_DashControls.configBtn, configRunning ? "Restart the configuration editor" : "Open the configuration editor")
         _Dash_UpdateTip(hTT, g_DashControls.blacklistBtn, blacklistRunning ? "Restart the blacklist editor" : "Open the blacklist editor")
         _Dash_UpdateTip(hTT, g_DashControls.viewerBtn, viewerOpen ? "Close the debug viewer window" : "Open the debug viewer window")
@@ -738,7 +738,7 @@ _Dash_IsViewerOpen() {
     if (!LauncherUtils_IsRunning(g_GuiPID))
         return false
     DetectHiddenWindows(false)
-    result := WinExist("WindowList Viewer ahk_pid " g_GuiPID) ? true : false
+    result := WinExist("Alt-Tabby Window Viewer ahk_pid " g_GuiPID) ? true : false
     DetectHiddenWindows(true)
     return result
 }

--- a/src/viewer/viewer.ahk
+++ b/src/viewer/viewer.ahk
@@ -190,7 +190,7 @@ _Viewer_CreateGui() {
     global gViewer_WSBtn, gViewer_MinBtn, gViewer_CloakBtn
     global gViewer_GuiEntry, gViewer_LVHeaderHwnd, gViewer_Columns
 
-    gViewer_Gui := Gui("+Resize +AlwaysOnTop", "WindowList Viewer")
+    gViewer_Gui := Gui("+Resize +AlwaysOnTop", "Alt-Tabby Window Viewer")
     GUI_AntiFlashPrepare(gViewer_Gui, Theme_GetBgColor())
     gViewer_Gui.SetFont("s9", "Segoe UI")
     gViewer_GuiEntry := Theme_ApplyToGui(gViewer_Gui)


### PR DESCRIPTION
## Summary

- Fix pump label reverting from "Enrichment Pump:" to "Pump:" after any dashboard refresh event
- Align subprocess naming: dashboard now says "Overlay" matching the tray menu (was "GUI")
- Fix tooltip spacing bug: "EnrichmentPump" → "Enrichment Pump" on initial render
- Replace "Install to PF..." abbreviation with clearer "Install..."
- Normalize blacklist editor tab descriptions to use em dash consistently
- Rename viewer window title from "WindowList Viewer" to "Alt-Tabby Window Viewer"
- Simplify pump tooltip from IPC jargon to plain English

## Test plan

- [x] All 971 tests pass (unit, GUI, live, flight recorder)
- [ ] Open dashboard → verify "Enrichment Pump" label stays consistent after subprocess restart
- [ ] Verify tray Diagnostics and dashboard use matching names ("Overlay", "Enrichment Pump")
- [ ] Hover pump row → verify tooltip says "Enrichment Pump" (with space) on first render
- [ ] Open blacklist editor → all three tab descriptions use em dash (—)
- [ ] Open viewer → title bar says "Alt-Tabby Window Viewer"

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)