### PR TITLE
Optimize HLSL shaders: hoist loop invariants, deduplicate selection utilities

### DIFF
--- a/src/shaders/alt_tabby_common.hlsl
+++ b/src/shaders/alt_tabby_common.hlsl
@@ -68,3 +68,10 @@ float4 AT_PostProcess(float3 col, float a) {
     a *= opacity;
     return float4(col * a, a);
 }
+
+// Rounded rect SDF: returns signed distance (negative = inside).
+// Used by selection shaders for border/fill masking.
+float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
+    float2 d = abs(p - center) - halfSize + radius;
+    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
+}

--- a/src/shaders/aurora.hlsl
+++ b/src/shaders/aurora.hlsl
@@ -4,29 +4,30 @@
 float4 PSMain(PSInput input) : SV_Target {
     float2 uv = input.uv;
     float aspect = resolution.x / resolution.y;
+    float aspectFactor = aspect / max(aspect, 1.0);
     float2 center = float2(0.5, 0.5);
 
     float t = time * 0.15;
 
     // Three blobs with elliptical orbits (different phase, eccentricity)
     float2 p1 = center + float2(
-        0.25 * sin(t * 1.1 + 0.0) * aspect / max(aspect, 1.0),
+        0.25 * sin(t * 1.1 + 0.0) * aspectFactor,
         0.20 * cos(t * 0.9 + 1.5)
     );
     float2 p2 = center + float2(
-        0.22 * sin(t * 0.8 + 2.1) * aspect / max(aspect, 1.0),
+        0.22 * sin(t * 0.8 + 2.1) * aspectFactor,
         0.28 * cos(t * 1.2 + 0.8)
     );
     float2 p3 = center + float2(
-        0.30 * sin(t * 0.7 + 4.0) * aspect / max(aspect, 1.0),
+        0.30 * sin(t * 0.7 + 4.0) * aspectFactor,
         0.18 * cos(t * 1.05 + 3.2)
     );
 
     // Adjust UV for aspect ratio
-    float2 auv = float2(uv.x * aspect / max(aspect, 1.0), uv.y);
-    float2 ap1 = float2(p1.x * aspect / max(aspect, 1.0), p1.y);
-    float2 ap2 = float2(p2.x * aspect / max(aspect, 1.0), p2.y);
-    float2 ap3 = float2(p3.x * aspect / max(aspect, 1.0), p3.y);
+    float2 auv = float2(uv.x * aspectFactor, uv.y);
+    float2 ap1 = float2(p1.x * aspectFactor, p1.y);
+    float2 ap2 = float2(p2.x * aspectFactor, p2.y);
+    float2 ap3 = float2(p3.x * aspectFactor, p3.y);
 
     // Soft distance fields
     float d1 = smoothstep(0.35, 0.0, length(auv - ap1));

--- a/src/shaders/cosmic_fbm_noise.hlsl
+++ b/src/shaders/cosmic_fbm_noise.hlsl
@@ -119,10 +119,10 @@ float sin1d(float p) { return sin(p * TWOPI) * 0.25 + 0.25; }
 static const float D2R = PI_VAL / 180.0;
 static const float OC = 15.0;
 
-float3 Oilnoise(float2 pos, float3 RGB, float sinTime) {
+float3 Oilnoise(float2 pos, float3 RGB, float sinTime, float oilBase) {
     float2 q = (float2)1.0;
     float result = 0.0;
-    float t = time * 0.1 + ((0.25 + 0.05 * sin(time * 0.1)) / (length(pos.xy) + 0.07)) * 2.2;
+    float t = time * 0.1 + (oilBase / (length(pos.xy) + 0.07)) * 2.2;
     float si, co;
     sincos(t, si, co);
     float2x2 ma = float2x2(co, si, -si, co);
@@ -137,7 +137,6 @@ float3 Oilnoise(float2 pos, float3 RGB, float sinTime) {
     for (float i = 0.0; i < OC; i++) {
         pos = mul(pos, rot30);
 
-        q = pos * s + tm;
         q = pos * s + aPos + tm;
         q = cos(q);
         q = mul(q, ma);
@@ -166,6 +165,8 @@ float4 PSMain(PSInput input) : SV_Target {
 
     float st_time, ct_time;
     sincos(time, st_time, ct_time);
+    float sinT01 = sin(time * 0.1);
+    float oilBase = 0.25 + 0.05 * sinT01;
     uv2.x += 0.1 * ct_time;
     uv2.y += 0.1 * st_time;
     uv.y *= resolution.y / resolution.x;
@@ -199,7 +200,7 @@ float4 PSMain(PSInput input) : SV_Target {
     float2 st = (fragCoord / resolution.xy);
     st.x = ((st.x - 0.5) * (resolution.x / resolution.y)) + 0.5;
 
-    float t2 = time * 0.1 + ((0.25 + 0.05 * sin(time * 0.1)) / (length(uv3.xy) + 0.57)) * 25.2;
+    float t2 = time * 0.1 + (oilBase / (length(uv3.xy) + 0.57)) * 25.2;
     float si, co;
     sincos(t2, si, co);
     float2x2 ma = float2x2(co, si, -si, co);
@@ -210,7 +211,7 @@ float4 PSMain(PSInput input) : SV_Target {
 
     float2 pix = 1.0 / resolution.xy;
     float2 aaST = st + pix * float2(1.5, 0.5);
-    col2 += Oilnoise(aaST, rgb, st_time);
+    col2 += Oilnoise(aaST, rgb, st_time, oilBase);
 
     float scale = 5.0;
     uv *= scale;

--- a/src/shaders/fbm_noise.hlsl
+++ b/src/shaders/fbm_noise.hlsl
@@ -23,12 +23,14 @@ float noise(in float2 p) {
 float fbm(float2 p) {
     float f = 0.0;
     float gat = 0.0;
+    float la = 1.0;
+    float ga = 0.5;
 
-    for (float octave = 0.; octave < 5.; ++octave) {
-        float la = exp2(octave);
-        float ga = exp2(-(octave + 1.));
+    for (int octave = 0; octave < 5; ++octave) {
         f += ga * noise(la * p);
         gat += ga;
+        la *= 2.0;
+        ga *= 0.5;
     }
 
     f = f / gat;

--- a/src/shaders/kaleidoscope_tunnel.hlsl
+++ b/src/shaders/kaleidoscope_tunnel.hlsl
@@ -30,13 +30,14 @@ float tex(float2 p, float z) {
     p = foldRotate(p, 8.0);
     float2 q = (frac(p / 10.0) - 0.5) * 10.0;
     static const float2x2 rotPIover4 = float2x2(0.7071068, 0.7071068, -0.7071068, 0.7071068);
+    float2x2 rotZ = rot(PI * 0.25 * z);
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 2; j++) {
             q = abs(q) - 0.25;
             q = mul(rotPIover4, q);
         }
         q = abs(q) - float2(1.0, 1.5);
-        q = mul(rot(PI * 0.25 * z), q);
+        q = mul(rotZ, q);
         q = foldRotate(q, 3.0);
     }
     float d = sdRect(q, float2(1.0, 1.0));
@@ -80,21 +81,30 @@ float4 PSMain(PSInput input) : SV_Target {
     #define INTERVAL 3.0
     #define INTENSITY (float3)((NN * INTERVAL - t) / (NN * INTERVAL))
 
+    // Precompute loop-invariant glsl_mod values and time-scaled vectors
+    float mod1 = glsl_mod(time - INTERVAL * 0.75, INTERVAL);
+    float mod2 = glsl_mod(time + INTERVAL * 0.5, INTERVAL);
+    float mod3 = glsl_mod(time - INTERVAL * 0.25, INTERVAL);
+    float mod4 = glsl_mod(time, INTERVAL);
+    float2 drift1 = float2(0.2, -0.2) * time;
+    float2 drift2 = float2(-0.2, -0.2) * time;
+    float modRing = glsl_mod(time * 30.0, 90.0);
+
     for (int i = 0; i < N; i++) {
         float t;
         float ii = float(N - i);
-        t = ii * INTERVAL - glsl_mod(time - INTERVAL * 0.75, INTERVAL);
-        col = lerp(col, INTENSITY, dirt(glsl_mod(uv * max(0.0, t) * 0.1 + float2(0.2, -0.2) * time, 1.2), 3.5));
+        t = ii * INTERVAL - mod1;
+        col = lerp(col, INTENSITY, dirt(glsl_mod(uv * max(0.0, t) * 0.1 + drift1, 1.2), 3.5));
 
-        t = ii * INTERVAL - glsl_mod(time + INTERVAL * 0.5, INTERVAL);
+        t = ii * INTERVAL - mod2;
         col = lerp(col, INTENSITY * float3(0.7, 0.8, 1.0) * 1.3, tex(uv * max(0.0, t), 4.45));
 
-        t = ii * INTERVAL - glsl_mod(time - INTERVAL * 0.25, INTERVAL);
-        col = lerp(col, INTENSITY, dirt(glsl_mod(uv * max(0.0, t) * 0.1 + float2(-0.2, -0.2) * time, 1.2), 3.5));
+        t = ii * INTERVAL - mod3;
+        col = lerp(col, INTENSITY, dirt(glsl_mod(uv * max(0.0, t) * 0.1 + drift2, 1.2), 3.5));
 
-        t = ii * INTERVAL - glsl_mod(time, INTERVAL);
+        t = ii * INTERVAL - mod4;
         float r = length(uv * 2.0 * max(0.0, t));
-        float rr = sm(-24.0, 0.0, r - glsl_mod(time * 30.0, 90.0), 10.0);
+        float rr = sm(-24.0, 0.0, r - modRing, 10.0);
         col = lerp(col, lerp(INTENSITY, INTENSITY * float3(0.7, 0.5, 1.0) * 3.0, rr), tex(uv * 2.0 * max(0.0, t), 0.27 + 2.0 * rr));
     }
 

--- a/src/shaders/mouse/spotlight.hlsl
+++ b/src/shaders/mouse/spotlight.hlsl
@@ -77,7 +77,8 @@ float4 PSMain(PSInput input) : SV_Target {
     float noisyRadius = baseRadius * (0.9 + edgeNoise * 0.2);
 
     // Main light cone
-    float light = smoothstep(noisyRadius, noisyRadius * 0.2, ellipseDist);
+    float nrInner = noisyRadius * 0.2;
+    float light = smoothstep(noisyRadius, nrInner, ellipseDist);
 
     // Penumbra: soft outer ring (the "almost lit" zone)
     float penumbra = smoothstep(noisyRadius * 1.4, noisyRadius * 0.8, ellipseDist);
@@ -94,8 +95,8 @@ float4 PSMain(PSInput input) : SV_Target {
     caustic = caustic * caustic * 0.15 * light;
 
     // Chromatic fringe at penumbra edge
-    float fringeR = smoothstep(noisyRadius * 1.08, noisyRadius * 0.2, ellipseDist);
-    float fringeB = smoothstep(noisyRadius * 0.92, noisyRadius * 0.2, ellipseDist);
+    float fringeR = smoothstep(noisyRadius * 1.08, nrInner, ellipseDist);
+    float fringeB = smoothstep(noisyRadius * 0.92, nrInner, ellipseDist);
 
     // Color: warm spotlight with natural tint
     float3 col = float3(

--- a/src/shaders/playing_with_fbm.hlsl
+++ b/src/shaders/playing_with_fbm.hlsl
@@ -60,7 +60,8 @@ float4 PSMain(PSInput input) : SV_Target
     float2x2 rot = float2x2(_rc, -_rs, _rs, _rc);
     uv = mul(rot, uv) * 16.0 * (_rs + 1.5);
 
-    float f = fbm(float3(uv, time) + fbm(float3(uv, time) + fbm(float3(uv, time)))) * 0.5 + 0.5;
+    float3 uvt = float3(uv, time);
+    float f = fbm(uvt + fbm(uvt + fbm(uvt))) * 0.5 + 0.5;
 
     float3 col, col2;
     col = (float3)fbm(float3(uv * f * 0.3, time * 0.75));

--- a/src/shaders/selection/aurora_sel.hlsl
+++ b/src/shaders/selection/aurora_sel.hlsl
@@ -1,10 +1,5 @@
 // Aurora Selection — Prismatic: color-shifting border glow cycling through hues, subtle rainbow reflections
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float3 hue2rgb(float h) {
     float r = abs(h * 6.0 - 3.0) - 1.0;
     float g = 2.0 - abs(h * 6.0 - 2.0);
@@ -62,11 +57,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderCol3, saturate(borderA));
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/selection/circuit.hlsl
+++ b/src/shaders/selection/circuit.hlsl
@@ -1,10 +1,5 @@
 // Circuit Selection — Pulse of light orbiting the border like a live circuit trace
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float3 hue2rgb(float h) {
     float r = abs(h * 6.0 - 3.0) - 1.0;
     float g = 2.0 - abs(h * 6.0 - 2.0);
@@ -96,11 +91,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderMix, saturate(boostedBorderA));
     a = max(a, boostedBorderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/selection/fire_border.hlsl
+++ b/src/shaders/selection/fire_border.hlsl
@@ -1,10 +1,5 @@
 // Fire Border Selection — Flames licking along the edges of the selection
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float hash(float2 p) {
     return frac(sin(dot(p, float2(127.1, 311.7))) * 43758.5453);
 }
@@ -106,11 +101,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderMix, saturate(borderA));
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/selection/glass.hlsl
+++ b/src/shaders/selection/glass.hlsl
@@ -1,11 +1,5 @@
 // Glass — Polished glass panel: soft drop shadow, subtle gradient fill, clean border, ambient glow breathe
 
-// Rounded rect SDF: returns signed distance (negative = inside)
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float4 PSMain(PSInput input) : SV_Target {
     float2 pixelPos = input.uv * resolution;
 
@@ -60,10 +54,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderCol3, borderA);
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, a);
 }

--- a/src/shaders/selection/gradient_orbit.hlsl
+++ b/src/shaders/selection/gradient_orbit.hlsl
@@ -1,10 +1,5 @@
 // Gradient Orbit Selection — Moving gradient that smoothly rotates around the border
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float3 hue2rgb(float h) {
     float r = abs(h * 6.0 - 3.0) - 1.0;
     float g = 2.0 - abs(h * 6.0 - 2.0);
@@ -76,11 +71,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderMix, saturate(borderA));
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/selection/lava.hlsl
+++ b/src/shaders/selection/lava.hlsl
@@ -1,10 +1,5 @@
 // Lava Selection — Flowing molten lava with glowing cracks
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float hash(float2 p) {
     return frac(sin(dot(p, float2(127.1, 311.7))) * 43758.5453);
 }
@@ -95,11 +90,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderMix, saturate(borderA));
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/selection/lightning.hlsl
+++ b/src/shaders/selection/lightning.hlsl
@@ -1,10 +1,5 @@
 // Lightning Selection — Electric arcs crackling across the border
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float hash(float2 p) {
     return frac(sin(dot(p, float2(127.1, 311.7))) * 43758.5453);
 }
@@ -92,11 +87,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderMix, saturate(borderA));
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/selection/plasma.hlsl
+++ b/src/shaders/selection/plasma.hlsl
@@ -1,10 +1,5 @@
 // Plasma Selection — Vivid morphing plasma blobs with bold color
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float4 PSMain(PSInput input) : SV_Target {
     float2 px = input.uv * resolution;
     float2 rc = selRect.xy + selRect.zw * 0.5;
@@ -59,11 +54,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderMix, saturate(borderA));
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/selection/rain.hlsl
+++ b/src/shaders/selection/rain.hlsl
@@ -1,10 +1,5 @@
 // Rain Selection — Diagonal rain streaks falling through the selection
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float hash(float n) {
     return frac(sin(n) * 43758.5453);
 }
@@ -70,11 +65,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderMix, saturate(borderA));
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/selection/smoke.hlsl
+++ b/src/shaders/selection/smoke.hlsl
@@ -1,10 +1,5 @@
 // Smoke Selection — Rising wisps of ethereal smoke curling through the selection
 
-float roundedRectSDF(float2 p, float2 center, float2 halfSize, float radius) {
-    float2 d = abs(p - center) - halfSize + radius;
-    return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0) - radius;
-}
-
 float hash(float2 p) {
     return frac(sin(dot(p, float2(127.1, 311.7))) * 43758.5453);
 }
@@ -75,11 +70,5 @@ float4 PSMain(PSInput input) : SV_Target {
     col = lerp(col, borderColor.rgb, saturate(borderA));
     a = max(a, borderA);
 
-    // Post-process: darken + desaturate
-    float lum = dot(col, float3(0.299, 0.587, 0.114));
-    col = lerp(col, (float3)lum, desaturate);
-    col *= (1.0 - darken);
-
-    a = saturate(a);
-    return float4(col * a, a) * opacity;
+    return AT_PostProcess(col, saturate(a));
 }

--- a/src/shaders/tileable_water_caustic.hlsl
+++ b/src/shaders/tileable_water_caustic.hlsl
@@ -15,12 +15,13 @@ float4 PSMain(PSInput input) : SV_Target {
     float2 i = p;
     float c = 1.0;
     float inten = 0.005;
+    float2 pInten = p * inten;
 
     for (int n = 0; n < MAX_ITER; n++)
     {
         float t = stime * (1.0 - (3.5 / float(n + 1)));
         i = p + float2(cos(t - i.x) + sin(t + i.y), sin(t - i.y) + cos(t + i.x));
-        float2 cv = float2(p.x / (sin(i.x + t) / inten), p.y / (cos(i.y + t) / inten));
+        float2 cv = pInten / float2(sin(i.x + t), cos(i.y + t));
         c += rsqrt(dot(cv, cv));
     }
     c /= float(MAX_ITER);

--- a/src/shaders/worley_noise_waters.hlsl
+++ b/src/shaders/worley_noise_waters.hlsl
@@ -8,9 +8,10 @@ float noise(float2 p) {
 
 float worley(float2 p) {
     float d = 1e30;
+    float2 fp = floor(p);
     for (int xo = -1; xo <= 1; ++xo) {
         for (int yo = -1; yo <= 1; ++yo) {
-            float2 tp = floor(p) + float2(xo, yo);
+            float2 tp = fp + float2(xo, yo);
             d = min(d, length2(p - tp - noise(tp)));
         }
     }


### PR DESCRIPTION
## Summary

- **Loop-invariant hoisting** in 5 background shaders: `glsl_mod`/drift vectors in kaleidoscope_tunnel, `rot()` matrix in tex() inner loop, `exp2()` → iterative multiply in fbm_noise, `p*inten` division in tileable_water_caustic, `floor(p)` in worley_noise_waters
- **Dead code & duplicate transcendental removal** in cosmic_fbm_noise: removed dead assignment (line overwritten immediately), hoisted shared `sin(time*0.1)` into `oilBase` parameter
- **Repeated subexpression extraction** in aurora (`aspectFactor`), spotlight (`nrInner`), playing_with_fbm (`uvt`)
- **Selection shader dedup**: moved `roundedRectSDF()` to `alt_tabby_common.hlsl` (10 copies → 1), replaced manual 4-line post-process blocks with `AT_PostProcess(col, saturate(a))` in all 10 selection shaders

19 files changed, 64 insertions, 149 deletions. All 182 shaders compile successfully.

Closes #254

## Test plan

- [ ] Run `tools/shader_bundle.ps1` — all 182 shaders compile (verified)
- [ ] Visual check: kaleidoscope_tunnel, fbm_noise, cosmic_fbm_noise, tileable_water_caustic, aurora, worley_noise_waters, playing_with_fbm — output identical to before
- [ ] Visual check: spotlight mouse effect — output identical
- [ ] Visual check: all 10 selection effects (glass, circuit, aurora_sel, fire_border, gradient_orbit, lava, lightning, plasma, rain, smoke) — output identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)