### PR TITLE
Add edge-case tests for stats INI recovery and workspace membership

### DIFF
--- a/tests/test_unit_core_store.ahk
+++ b/tests/test_unit_core_store.ahk
@@ -1012,4 +1012,20 @@ RunUnitTests_CoreStore() {
 
     ; Cleanup
     WL_RemoveWindow([9201, 9202, 9203], true)
+
+    ; ============================================================
+    ; WL_IsOnCurrentWorkspace Edge Cases
+    ; ============================================================
+    Log("`n--- WL_IsOnCurrentWorkspace Edge Cases ---")
+
+    ; Both empty: non-komorebi windows (empty wsName) are always "on current"
+    AssertEq(WL_IsOnCurrentWorkspace("", ""), true, "IsOnCurrentWS: both empty = on current")
+    ; Empty workspace name always on current (non-komorebi window)
+    AssertEq(WL_IsOnCurrentWorkspace("", "Main"), true, "IsOnCurrentWS: empty wsName = on current")
+    ; Exact match
+    AssertEq(WL_IsOnCurrentWorkspace("Main", "Main"), true, "IsOnCurrentWS: exact match")
+    ; Different workspace
+    AssertEq(WL_IsOnCurrentWorkspace("Other", "Main"), false, "IsOnCurrentWS: different workspace")
+    ; Case sensitivity (AHK string comparison is case-insensitive by default)
+    AssertEq(WL_IsOnCurrentWorkspace("main", "Main"), true, "IsOnCurrentWS: case-insensitive match")
 }

--- a/tests/test_unit_stats.ahk
+++ b/tests/test_unit_stats.ahk
@@ -296,6 +296,52 @@ RunUnitTests_Stats() {
     try FileDelete(testStatsBak)
 
     ; ============================================================
+    ; Corrupted INI Recovery Tests
+    ; ============================================================
+    Log("`n--- Stats Corrupted INI Recovery Tests ---")
+
+    ; Test: Non-numeric values in stats.ini default to 0 instead of crashing
+    Log("Testing corrupted INI: non-numeric values handled gracefully...")
+    try {
+        cfg.StatsTrackingEnabled := true
+        STATS_INI_PATH := testStatsPath
+        try FileDelete(testStatsPath)
+        try FileDelete(testStatsBak)
+
+        ; Write a mix of corrupted and valid values
+        IniWrite("abc", testStatsPath, "Lifetime", "TotalAltTabs")  ; Non-numeric
+        IniWrite("42", testStatsPath, "Lifetime", "TotalQuickSwitches")  ; Valid
+        IniWrite("", testStatsPath, "Lifetime", "TotalTabSteps")  ; Empty string
+        IniWrite("-5", testStatsPath, "Lifetime", "PeakWindowsInSession")  ; Negative (valid integer)
+        IniWrite("2", testStatsPath, "Lifetime", "TotalSessions")  ; Valid
+        IniWrite("complete", testStatsPath, "Lifetime", "_FlushStatus")
+
+        gStats_Lifetime := Map()
+        gStats_Session := Map()
+        gStats_Session["startTick"] := A_TickCount
+        gStats_Session["peakWindows"] := 0
+        Stats_Init()
+
+        ; Non-numeric "abc" should default to 0 (Integer() throws, catch sets val=0)
+        AssertEq(gStats_Lifetime.Get("TotalAltTabs", -1), 0, "Corrupted INI: 'abc' defaults to 0")
+        ; Valid value loads normally
+        AssertEq(gStats_Lifetime.Get("TotalQuickSwitches", -1), 42, "Corrupted INI: valid '42' loads")
+        ; Empty string should default to 0 (Integer("") throws)
+        AssertEq(gStats_Lifetime.Get("TotalTabSteps", -1), 0, "Corrupted INI: empty string defaults to 0")
+        ; Negative integer is valid (Integer("-5") = -5)
+        AssertEq(gStats_Lifetime.Get("PeakWindowsInSession", -1), -5, "Corrupted INI: negative '-5' loads as -5")
+        ; TotalSessions incremented by 1 on init (2+1=3)
+        AssertEq(gStats_Lifetime.Get("TotalSessions", -1), 3, "Corrupted INI: TotalSessions=2+1=3")
+        Log("PASS: Corrupted INI values handled gracefully")
+        TestPassed++
+    } catch as e {
+        Log("FAIL: Corrupted INI recovery crashed: " e.Message)
+        TestErrors++
+    }
+    try FileDelete(testStatsPath)
+    try FileDelete(testStatsBak)
+
+    ; ============================================================
     ; Dirty Flag & State Gate Tests
     ; ============================================================
     Log("`n--- Stats Dirty Flag & State Gate Tests ---")


### PR DESCRIPTION
## Summary

- Add corrupted INI recovery test to `test_unit_stats.ahk` — verifies `Stats_Init` handles non-numeric (`"abc"`), empty, and negative values gracefully (defaults to 0 instead of crashing)
- Add `WL_IsOnCurrentWorkspace` edge case assertions to `test_unit_core_store.ahk` — both-empty params, case sensitivity, exact match, different workspace

Closes #256

## Test plan

- [x] All 982 tests pass (`.\tests\test.ps1 --live`)
- [x] Unit/Core/Store: 203/203 (5 new assertions)
- [x] Unit/Stats: 36/36 (1 new test block with 5 assertions)
- [x] Pre-gate: all 82 static analysis checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)