### PR TITLE
Add profiler balance and map iteration mutation static checks

### DIFF
--- a/tests/check_batch_guards.ps1
+++ b/tests/check_batch_guards.ps1
@@ -1,6 +1,6 @@
 # check_batch_guards.ps1 - Batched guard/enforcement checks (batch A)
 # Checks that require shared preprocessing data ($sharedFuncDefs, $sharedLineData, $sharedSetCallbacksDefs).
-# Sub-checks: guard_try_finally, critical_leaks, critical_sections, callback_signatures, producer_error_boundary, callback_invocation_arity, paint_resize_ordering
+# Sub-checks: guard_try_finally, critical_leaks, critical_sections, callback_signatures, producer_error_boundary, callback_invocation_arity, paint_resize_ordering, profiler_balance
 # Shared file cache: all src/ files (excluding lib/) read once.
 #
 # Usage: powershell -File tests\check_batch_guards.ps1 [-SourceDir "path\to\src"]
@@ -1413,6 +1413,148 @@ $sw.Stop()
 [void]$subTimings.Add(@{ Name = "check_paint_resize_ordering"; DurationMs = [math]::Round($sw.Elapsed.TotalMilliseconds, 1) })
 
 # ============================================================
+# Sub-check 8: profiler_balance
+# Detects Profiler.Enter() without matching Profiler.Leave() before
+# return statements. Missing Leave corrupts the profiler stack —
+# all subsequent measurements are misattributed.
+# Suppress: ; lint-ignore: profiler-balance
+# ============================================================
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+$pbIssues = [System.Collections.ArrayList]::new()
+
+# Pre-filter: only files containing Profiler.Enter(
+$profilerFiles = [System.Collections.ArrayList]::new()
+foreach ($f in $allFiles) {
+    if ($fileCacheText[$f.FullName].IndexOf('Profiler.Enter(') -ge 0) {
+        [void]$profilerFiles.Add($f)
+    }
+}
+
+# Pre-compiled regex for profiler calls
+$script:RX_PROF_ENTER  = [regex]::new('Profiler\.Enter\(', 'Compiled')
+$script:RX_PROF_LEAVE  = [regex]::new('Profiler\.Leave\(\)', 'Compiled')
+
+foreach ($file in $profilerFiles) {
+    $lines = $fileCache[$file.FullName]
+    $relPath = $file.FullName.Replace("$projectRoot\", '')
+
+    $depth = 0
+    $inFunc = $false
+    $funcDepth = -1
+    $funcName = ""
+    $funcStartLine = 0
+    $hasEnter = $false
+    $enterLine = -1
+    # Collect return line indices and the function closing-brace line
+    $returnLines = [System.Collections.ArrayList]::new()
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $raw = $lines[$i]
+        $trimmed = $raw.TrimStart()
+        if ($trimmed.Length -eq 0 -or $trimmed[0] -eq ';') { continue }
+
+        $cleaned = BC_CleanLine $raw
+        if ($cleaned -eq '') { continue }
+
+        if (-not $inFunc -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
+            $fname = $Matches[1]
+            if (-not $BC_keywordSet.Contains($fname) -and $cleaned -match '\{') {
+                $inFunc = $true
+                $funcName = $fname
+                $funcDepth = $depth
+                $funcStartLine = $i
+                $hasEnter = $false
+                $enterLine = -1
+                [void]$returnLines.Clear()
+            }
+        }
+
+        $braces = BC_CountBraces $cleaned
+        $depth += $braces[0] - $braces[1]
+
+        if ($inFunc) {
+            if (-not $hasEnter -and $script:RX_PROF_ENTER.IsMatch($trimmed)) {
+                $hasEnter = $true
+                $enterLine = $i
+            }
+            if ($cleaned -match '(?i)^\s*return\b') { [void]$returnLines.Add($i) }
+
+            # Function end: closing brace at or below function depth
+            if ($depth -le $funcDepth) {
+                $funcEndLine = $i
+                $inFunc = $false
+                $funcDepth = -1
+
+                if ($hasEnter) {
+                    # Check each explicit return AFTER the Enter:
+                    # Profiler.Leave() must appear within the preceding
+                    # 5 non-blank/non-comment lines
+                    foreach ($retLine in $returnLines) {
+                        # Skip returns before the Enter (no Leave needed)
+                        if ($retLine -le $enterLine) { continue }
+                        if ($lines[$retLine] -match 'lint-ignore:\s*profiler-balance') { continue }
+                        $foundLeave = $false
+                        $lookback = 0
+                        for ($j = $retLine - 1; $j -ge $funcStartLine -and $lookback -lt 5; $j--) {
+                            $prev = $lines[$j].TrimStart()
+                            if ($prev.Length -eq 0 -or $prev[0] -eq ';') { continue }
+                            $lookback++
+                            if ($script:RX_PROF_LEAVE.IsMatch($prev)) { $foundLeave = $true; break }
+                        }
+                        if (-not $foundLeave) {
+                            [void]$pbIssues.Add([PSCustomObject]@{
+                                File = $relPath; Line = $retLine + 1; Function = $funcName
+                                Detail = "return without preceding Profiler.Leave()"
+                            })
+                        }
+                    }
+
+                    # Check implicit return (function closing brace):
+                    # Profiler.Leave(), return, or throw must appear within
+                    # the preceding 15 non-blank/non-comment lines
+                    if ($lines[$funcEndLine] -notmatch 'lint-ignore:\s*profiler-balance') {
+                        $foundLeave = $false
+                        $lookback = 0
+                        for ($j = $funcEndLine - 1; $j -ge $funcStartLine -and $lookback -lt 15; $j--) {
+                            $prev = $lines[$j].TrimStart()
+                            if ($prev.Length -eq 0 -or $prev[0] -eq ';') { continue }
+                            $lookback++
+                            if ($script:RX_PROF_LEAVE.IsMatch($prev)) { $foundLeave = $true; break }
+                            # return/throw = no implicit return reachable
+                            if ($prev -match '(?i)^\s*(?:return|throw)\b') { $foundLeave = $true; break }
+                        }
+                        if (-not $foundLeave) {
+                            [void]$pbIssues.Add([PSCustomObject]@{
+                                File = $relPath; Line = $funcEndLine + 1; Function = $funcName
+                                Detail = "implicit return (end of function) without preceding Profiler.Leave()"
+                            })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+if ($pbIssues.Count -gt 0) {
+    $anyFailed = $true
+    [void]$failOutput.AppendLine("")
+    [void]$failOutput.AppendLine("  FAIL: $($pbIssues.Count) Profiler.Enter/Leave imbalance(s) found.")
+    [void]$failOutput.AppendLine("  Missing Profiler.Leave() before return corrupts the profiler stack $([char]0x2014)")
+    [void]$failOutput.AppendLine("  all subsequent measurements are misattributed.")
+    [void]$failOutput.AppendLine("  Suppress: ; lint-ignore: profiler-balance")
+    $grouped = $pbIssues | Group-Object File
+    foreach ($group in $grouped | Sort-Object Name) {
+        [void]$failOutput.AppendLine("    $($group.Name):")
+        foreach ($issue in $group.Group | Sort-Object Line) {
+            [void]$failOutput.AppendLine("      Line $($issue.Line) in $($issue.Function)(): $($issue.Detail)")
+        }
+    }
+}
+$sw.Stop()
+[void]$subTimings.Add(@{ Name = "check_profiler_balance"; DurationMs = [math]::Round($sw.Elapsed.TotalMilliseconds, 1) })
+
+# ============================================================
 # Report
 # ============================================================
 $totalSw.Stop()
@@ -1420,7 +1562,7 @@ $totalSw.Stop()
 if ($anyFailed) {
     Write-Host $failOutput.ToString().TrimEnd()
 } else {
-    Write-Host "  PASS: All guard checks passed (callback_signatures, critical_leaks, critical_sections, producer_error_boundary, callback_invocation_arity, guard_try_finally, paint_resize_ordering)" -ForegroundColor Green
+    Write-Host "  PASS: All guard checks passed (callback_signatures, critical_leaks, critical_sections, producer_error_boundary, callback_invocation_arity, guard_try_finally, paint_resize_ordering, profiler_balance)" -ForegroundColor Green
 }
 
 Write-Host "  Timing: shared=$($sharedPassSw.ElapsedMilliseconds)ms total=$($totalSw.ElapsedMilliseconds)ms" -ForegroundColor Cyan

--- a/tests/check_batch_patterns.ps1
+++ b/tests/check_batch_patterns.ps1
@@ -1,6 +1,6 @@
 # check_batch_patterns.ps1 - Batched forbidden/outdated code pattern checks
 # Combines 5 pattern checks into one PowerShell process with shared file cache.
-# Sub-checks: code_patterns, logging_hygiene, v1_patterns, send_patterns, display_fields, viewer_columns, map_dot_access, dirty_tracking, direct_record_mutation, fr_guard, copydata_contract, scan_pairing, setcallbacks_wiring, cache_path_invariants, numeric_string_comparison
+# Sub-checks: code_patterns, logging_hygiene, v1_patterns, send_patterns, display_fields, viewer_columns, map_dot_access, dirty_tracking, direct_record_mutation, fr_guard, copydata_contract, scan_pairing, setcallbacks_wiring, cache_path_invariants, numeric_string_comparison, map_iteration_mutation
 #
 # Usage: powershell -File tests\check_batch_patterns.ps1 [-SourceDir "path\to\src"]
 # Exit codes: 0 = all pass, 1 = any check failed
@@ -1990,6 +1990,112 @@ $sw.Stop()
 [void]$subTimings.Add(@{ Name = "check_numeric_string_comparison"; DurationMs = [math]::Round($sw.Elapsed.TotalMilliseconds, 1) })
 
 # ============================================================
+# Sub-check 16: map_iteration_mutation
+# Detects .Delete(), .Push(), or [key]:= on the iteration source
+# variable inside a for loop body. AHK v2 doesn't throw — it
+# silently produces undefined iteration behavior.
+# Suppress: ; lint-ignore: map-iteration-mutation
+# ============================================================
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+$mimIssues = [System.Collections.ArrayList]::new()
+
+# Pre-compiled patterns
+# Capture full expression after 'in': variable name plus optional accessors like ["key"] or .prop
+$rxForIn = [regex]::new('(?i)^\s*for\s+[\w,\s]+\s+in\s+(\w+(?:\s*\[.*?\]|\s*\.\s*\w+)*)', 'Compiled')
+
+foreach ($file in $allFiles) {
+    $lines = $fileCache[$file.FullName]
+    $relPath = $file.FullName
+    if ($relPath.StartsWith($SourceDir)) {
+        $relPath = $relPath.Substring($SourceDir.Length).TrimStart('\', '/')
+    }
+
+    # Track active for-loop iteration sources with brace-depth scoping
+    # Stack of @{ Collection, Depth, StartLine }
+    $forStack = [System.Collections.ArrayList]::new()
+    $depth = 0
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        $raw = $lines[$i]
+        $trimmed = $raw.TrimStart()
+        if ($trimmed.Length -eq 0 -or $trimmed[0] -eq ';') { continue }
+
+        $cleaned = BP_Clean-Line $raw
+        if ($cleaned -eq '') { continue }
+
+        # Code with strings intact (only comments stripped) — used for collection name matching
+        $codePart = $raw
+        if ($codePart.IndexOf(';') -ge 0) {
+            $codePart = $script:RX_CMT_TAIL.Replace($codePart, '')
+        }
+
+        # Detect for...in loops (use codePart to preserve string content like ["key"])
+        $m = $rxForIn.Match($codePart)
+        if ($m.Success) {
+            $collection = $m.Groups[1].Value.Trim()
+            # Record the depth BEFORE counting this line's braces
+            [void]$forStack.Add(@{ Collection = $collection; Depth = $depth; StartLine = $i })
+        }
+
+        # Count braces (use cleaned line — strings already stripped)
+        $opens = 0; $closes = 0
+        foreach ($c in $cleaned.ToCharArray()) {
+            if ($c -eq '{') { $opens++ }
+            elseif ($c -eq '}') { $closes++ }
+        }
+        $depth += $opens - $closes
+
+        # Pop for-loops that have closed (depth returned to or below entry depth)
+        for ($s = $forStack.Count - 1; $s -ge 0; $s--) {
+            if ($depth -le $forStack[$s].Depth -and $i -gt $forStack[$s].StartLine) {
+                $forStack.RemoveAt($s)
+            }
+        }
+
+        # Check for mutations on any active for-loop's collection variable
+        if ($forStack.Count -gt 0) {
+            if ($raw -match 'lint-ignore:\s*map-iteration-mutation') { continue }
+
+            foreach ($entry in $forStack) {
+                $col = $entry.Collection
+                $colEsc = [regex]::Escape($col)
+                # Check: collection.Delete(, collection.Push(, etc. (use codePart for string-intact matching)
+                if ($codePart -match "(?<![.\w])${colEsc}\s*\.\s*(?:Delete|Push|Pop|InsertAt|RemoveAt)\s*\(") {
+                    # Safe pattern: Delete + break on next line (FIFO "pop first" idiom)
+                    $nextIdx = $i + 1
+                    while ($nextIdx -lt $lines.Count) {
+                        $nextTrimmed = $lines[$nextIdx].TrimStart()
+                        if ($nextTrimmed.Length -eq 0 -or $nextTrimmed[0] -eq ';') { $nextIdx++; continue }
+                        break
+                    }
+                    if ($nextIdx -lt $lines.Count -and $lines[$nextIdx].TrimStart() -match '(?i)^\s*break\b') { continue }
+
+                    [void]$mimIssues.Add("${relPath}:$($i+1): $col.Delete/Push/etc inside for-loop iterating $col $([char]0x2014) undefined behavior in AHK v2")
+                }
+                # Check: collection[...] := (use codePart for string-intact matching)
+                if ($codePart -match "(?<![.\w])${colEsc}\s*\[.*\]\s*:=") {
+                    [void]$mimIssues.Add("${relPath}:$($i+1): $col[key]:= inside for-loop iterating $col $([char]0x2014) undefined behavior in AHK v2")
+                }
+            }
+        }
+    }
+}
+
+if ($mimIssues.Count -gt 0) {
+    $anyFailed = $true
+    [void]$failOutput.AppendLine("")
+    [void]$failOutput.AppendLine("  FAIL: $($mimIssues.Count) map/array modification(s) during iteration.")
+    [void]$failOutput.AppendLine("  AHK v2 does not throw on concurrent modification $([char]0x2014) it silently misbehaves.")
+    [void]$failOutput.AppendLine("  Fix: collect into a temporary array first, then modify the original.")
+    [void]$failOutput.AppendLine("  Suppress: ; lint-ignore: map-iteration-mutation")
+    foreach ($issue in $mimIssues) {
+        [void]$failOutput.AppendLine("    $issue")
+    }
+}
+$sw.Stop()
+[void]$subTimings.Add(@{ Name = "check_map_iteration_mutation"; DurationMs = [math]::Round($sw.Elapsed.TotalMilliseconds, 1) })
+
+# ============================================================
 # Report
 # ============================================================
 $totalSw.Stop()
@@ -1997,7 +2103,7 @@ $totalSw.Stop()
 if ($anyFailed) {
     Write-Host $failOutput.ToString().TrimEnd()
 } else {
-    Write-Host "  PASS: All pattern checks passed (code_patterns, logging_hygiene, v1_patterns, send_patterns, display_fields, map_dot_access, dirty_tracking, direct_record_mutation, fr_guard, copydata_contract, scan_pairing, setcallbacks_wiring, cache_path_invariants, numeric_string_comparison)" -ForegroundColor Green
+    Write-Host "  PASS: All pattern checks passed (code_patterns, logging_hygiene, v1_patterns, send_patterns, display_fields, map_dot_access, dirty_tracking, direct_record_mutation, fr_guard, copydata_contract, scan_pairing, setcallbacks_wiring, cache_path_invariants, numeric_string_comparison, map_iteration_mutation)" -ForegroundColor Green
 }
 
 Write-Host "  Timing: total=$($totalSw.ElapsedMilliseconds)ms" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

- Add `profiler_balance` sub-check to `check_batch_guards.ps1` — detects `Profiler.Enter()` without matching `Profiler.Leave()` before return statements (corrupts profiler stack, misattributes all subsequent measurements)
- Add `map_iteration_mutation` sub-check to `check_batch_patterns.ps1` — detects `.Delete()`, `.Push()`, `[key]:=` on a collection while iterating it with `for` (AHK v2 silently produces undefined iteration behavior)
- Both checks are preventive (0 current violations) and include `; lint-ignore:` suppression support

## Test plan

- [x] Full static analysis suite passes (84 checks, was 82)
- [x] `profiler_balance` correctly detects violation when `Profiler.Leave()` is removed before a `return` in `_IP_Tick()`
- [x] `profiler_balance` does NOT flag returns before `Profiler.Enter()` (early-exit guards)
- [x] `map_iteration_mutation` correctly detects `.Delete()` on iteration source variable
- [x] `map_iteration_mutation` does NOT flag mutations on different sub-keys (`gCEN["FlatScrollPos"]` vs iterating `gCEN["FilteredIndices"]`)
- [x] `map_iteration_mutation` exempts "delete + break" FIFO pop idiom
- [x] Both checks restored to clean pass after removing test violations

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)