### PR TITLE
Fix UAC refusal gap and editor force-kill in option interactions

### DIFF
--- a/src/launcher/launcher_install.ahk
+++ b/src/launcher/launcher_install.ahk
@@ -415,7 +415,11 @@ _Launcher_CleanupStaleAdminTask(newPath) {
                     Setup_SetRunAsAdmin(false)
                 }
             } catch {
-                ; UAC refused - suppress future repair prompts since user was already warned
+                ; UAC refused - disable admin mode + suppress future repair prompts.
+                ; Without SetRunAsAdmin(false, true), a config with RunAsAdmin=true would
+                ; trigger the auto-repair path on next launch → extra UAC prompt before
+                ; the declined marker breaks the loop.
+                Setup_SetRunAsAdmin(false, true)
                 Setup_SetSuppressAdminRepairPrompt(true)
                 TrayTip("Admin Mode", "Could not disable Admin Mode.`nRepair prompts have been suppressed.", "Icon!")
             }

--- a/src/launcher/launcher_tray.ahk
+++ b/src/launcher/launcher_tray.ahk
@@ -623,7 +623,7 @@ _AdminToggle_CheckComplete() {
 }
 
 Tray_InstallToProgramFiles() {
-    global APP_NAME, ALTTABBY_INSTALL_DIR, TEMP_INSTALL_PF_STATE
+    global APP_NAME, ALTTABBY_INSTALL_DIR, ALTTABBY_INSTALL_EXE, TEMP_INSTALL_PF_STATE
     global g_UpdateCheckInProgress
 
     if (!A_IsCompiled || IsInProgramFiles())
@@ -647,7 +647,7 @@ Tray_InstallToProgramFiles() {
         return
 
     ; Self-elevate and exit (elevated instance handles install + relaunch)
-    targetPath := ALTTABBY_INSTALL_DIR "\AltTabby.exe"
+    targetPath := ALTTABBY_INSTALL_EXE
     if (Setup_ElevateWithState({
         stateFile: TEMP_INSTALL_PF_STATE,
         flag: "--install-to-pf",

--- a/src/launcher/launcher_wizard.ahk
+++ b/src/launcher/launcher_wizard.ahk
@@ -224,7 +224,7 @@ WizardContinue() {
 ; Internal: Apply wizard choices (called from both wizard and continuation)
 ; Returns the installed exe path if we installed to a different location, empty string otherwise
 _WizardApplyChoices(startMenu, startup, install, admin, autoUpdate) {
-    global cfg, gConfigIniPath, APP_NAME, ALTTABBY_INSTALL_DIR
+    global cfg, gConfigIniPath, APP_NAME, ALTTABBY_INSTALL_EXE
 
     ; Determine exe path
     exePath := A_ScriptFullPath
@@ -234,7 +234,7 @@ _WizardApplyChoices(startMenu, startup, install, admin, autoUpdate) {
     ; Step 1: Install to Program Files (if selected)
     ; Uses Update_ApplyCore() — same code path as tray/dashboard install and auto-update
     if (install) {
-        targetPath := ALTTABBY_INSTALL_DIR "\AltTabby.exe"
+        targetPath := ALTTABBY_INSTALL_EXE
         if (IsInProgramFiles()) {
             ; Already in Program Files
             installSucceeded := true

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -17,6 +17,7 @@ global ADMIN_TASK_ID_PATTERN := "\[ID:([A-Fa-f0-9]{8})\]"
 
 ; Install directory constant - uses localized Program Files path
 global ALTTABBY_INSTALL_DIR := A_ProgramFiles "\Alt-Tabby"
+global ALTTABBY_INSTALL_EXE := ALTTABBY_INSTALL_DIR "\AltTabby.exe"
 
 ; PE validation constants
 global PE_MIN_SIZE := 102400                ; 100KB minimum for valid AHK exe
@@ -52,10 +53,10 @@ IsAdminModeFullyActive() {
 ; Get the path to the installed exe (from config or well-known PF location)
 ; Returns empty string if no installation found
 Setup_GetInstalledPath() {
-    global cfg, ALTTABBY_INSTALL_DIR
+    global cfg, ALTTABBY_INSTALL_EXE
     if (cfg.HasOwnProp("SetupExePath") && cfg.SetupExePath != "")
         return cfg.SetupExePath
-    pfPath := ALTTABBY_INSTALL_DIR "\AltTabby.exe"
+    pfPath := ALTTABBY_INSTALL_EXE
     if (FileExist(pfPath))
         return pfPath
     return ""
@@ -1173,7 +1174,14 @@ Update_ApplyCore(opts) {
 ; Apply update: rename current exe, move new exe, relaunch
 ; Wrapper for auto-update flow - uses Update_ApplyCore with appropriate options
 _Update_ApplyAndRelaunch(newExePath, targetExePath) {
-    global g_PumpPID, g_GuiPID
+    global g_PumpPID, g_GuiPID, g_ConfigEditorPID, g_BlacklistEditorPID
+
+    ; Gracefully close any open editors before the force-kill sweep.
+    ; Editors have unsaved-changes prompts on WM_CLOSE — sending it first
+    ; gives the user a chance to save. Without this, the force sweep in
+    ; Update_ApplyCore silently kills editors via taskkill /F.
+    _Update_CloseEditors()
+
     Update_ApplyCore({
         sourcePath: newExePath,
         targetPath: targetExePath,
@@ -1184,6 +1192,40 @@ _Update_ApplyAndRelaunch(newExePath, targetExePath) {
         cleanupSourceOnFailure: true,
         killPids: {gui: g_GuiPID, pump: g_PumpPID}
     })
+}
+
+; Send WM_CLOSE to editor windows and wait briefly for them to close.
+; This allows unsaved-changes prompts to appear before the update's force-kill sweep.
+_Update_CloseEditors() {
+    global g_ConfigEditorPID, g_BlacklistEditorPID
+
+    editorsClosed := true
+    for pid in [g_ConfigEditorPID, g_BlacklistEditorPID] {
+        if (!pid || !ProcessExist(pid))
+            continue
+        editorsClosed := false
+        try {
+            hwnd := WinExist("ahk_pid " pid)
+            if (hwnd)
+                PostMessage(0x0010, 0, 0, , "ahk_id " hwnd)  ; WM_CLOSE
+        }
+    }
+
+    if (editorsClosed)
+        return
+
+    ; Wait up to 3s for editors to close (user may be saving)
+    deadline := A_TickCount + 3000
+    while (A_TickCount < deadline) {
+        allGone := true
+        if (g_ConfigEditorPID && ProcessExist(g_ConfigEditorPID))
+            allGone := false
+        if (g_BlacklistEditorPID && ProcessExist(g_BlacklistEditorPID))
+            allGone := false
+        if (allGone)
+            return
+        Sleep(200)
+    }
 }
 
 ; Called on startup to clean up old exe from previous update


### PR DESCRIPTION
## Summary

Deep audit of 30+ combinatorial option/launch-mode interactions. The codebase is exceptionally well defended — 16 scenarios validated as correctly handled, 9 of 10 UAC refusal points clean. Two low-severity bugs fixed:

- **Bug 1**: `_Launcher_CleanupStaleAdminTask` catch block (`launcher_install.ahk:417`) now calls `Setup_SetRunAsAdmin(false, true)` on UAC refusal, preventing an extra UAC prompt on next launch when config has stale `RunAsAdmin=true`
- **Bug 2**: `_Update_ApplyAndRelaunch` now sends WM_CLOSE to open editor windows before the force-kill sweep, allowing unsaved-changes prompts to appear (3s timeout)
- **DRY**: Extracted `ALTTABBY_INSTALL_EXE` constant replacing 3 inline `ALTTABBY_INSTALL_DIR "\AltTabby.exe"` expressions

Closes #260

## Test plan

- [x] Static analysis pre-gate: all 82 checks pass
- [x] Full test suite (`--live`): 971/971 tests pass
- [ ] Manual: verify `_Launcher_CleanupStaleAdminTask` catch block matches pattern at `launcher_main.ahk:536`
- [ ] Manual: grep confirms no remaining inline `ALTTABBY_INSTALL_DIR "\AltTabby.exe"` outside the constant definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)