### PR TITLE
Add error logging to silent catch blocks

### DIFF
--- a/src/shared/config_loader.ahk
+++ b/src/shared/config_loader.ahk
@@ -607,6 +607,7 @@ _CL_EnsureArraySections(path, changes) {
         FileMove(tempPath, path, true)
     } catch as e {
         try FileDelete(tempPath)
+        try LogAppend(LOG_PATH_STORE, "config merge write error: " e.Message " path=" path)
     }
 }
 
@@ -950,8 +951,9 @@ CL_DeleteSections(sectionNames) {
             FileDelete(tempPath)
         FileAppend(newContent, tempPath, "UTF-8")
         FileMove(tempPath, gConfigIniPath, true)
-    } catch {
+    } catch as e {
         try FileDelete(tempPath)
+        try LogAppend(LOG_PATH_STORE, "config cleanup write error: " e.Message)
     }
 }
 

--- a/src/shared/file_watcher.ahk
+++ b/src/shared/file_watcher.ahk
@@ -19,6 +19,7 @@ FileWatch_Start(filePath, callback, debounceMs := 300) {
         w._dirWatcher := DirectoryWatcher(dirPath, _FileWatch_OnChange.Bind(w), 0x19)
     } catch as e {
         ; Parent directory doesn't exist or access denied — continue without watching
+        try LogAppend(IsSet(LOG_PATH_STORE) ? LOG_PATH_STORE : A_Temp "\tabby_store_error.log", "FileWatch_Start failed for " filePath ": " e.Message)
         return w
     }
     w.DefineProp("Stop", { call: _FileWatch_Stop })


### PR DESCRIPTION
## Summary

- Added `LogAppend` to three silent catch blocks that swallowed errors with no trace
- `config_loader.ahk`: config migration write failure (`_CL_MergeConfigFromSource`) and orphan key cleanup failure (`_CL_CleanupOrphanedKeys`)
- `file_watcher.ahk`: `DirectoryWatcher` init failure in `FileWatch_Start`
- All use always-on error logging to `LOG_PATH_STORE` — same contract as other catch blocks throughout the codebase

Closes #263

## Test plan

- [x] Full test suite passes (982/982 tests — unit, GUI, live, flight recorder)
- [ ] Manual: make `config.ini` read-only, launch app, confirm error appears in `%TEMP%\tabby_store_error.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)