### PR TITLE
Fix test quality: golden values and dead code removal

### DIFF
--- a/tests/test_live_features.ahk
+++ b/tests/test_live_features.ahk
@@ -307,36 +307,31 @@ RunLiveTests_Features() {
                 Log("PASS: Stats snapshot includes derived fields")
                 TestPassed++
 
-                ; Verify formula: QuickSwitchPct — expected from known inputs (3 / (7+3) * 100)
-                expectedQuickPct := Round(3 / (7 + 3) * 100, 1)
+                ; Verify derived values against hardcoded golden values (inputs: AT=7, QS=3, TS=15, C=2)
                 quickPct := snapshot.DerivedQuickSwitchPct
-                if (quickPct = expectedQuickPct) {
-                    Log("PASS: DerivedQuickSwitchPct = " quickPct " (matches formula)")
+                if (quickPct = 30.0) {
+                    Log("PASS: DerivedQuickSwitchPct = " quickPct)
                     TestPassed++
                 } else {
-                    Log("FAIL: DerivedQuickSwitchPct = " quickPct " (expected " expectedQuickPct ")")
+                    Log("FAIL: DerivedQuickSwitchPct = " quickPct " (expected 30.0)")
                     TestErrors++
                 }
 
-                ; Verify formula: CancelRate — expected from known inputs (2 / (7+2) * 100)
-                expectedCancelRate := Round(2 / (7 + 2) * 100, 1)
                 cancelRate := snapshot.DerivedCancelRate
-                if (cancelRate = expectedCancelRate) {
-                    Log("PASS: DerivedCancelRate = " cancelRate " (matches formula)")
+                if (cancelRate = 22.2) {
+                    Log("PASS: DerivedCancelRate = " cancelRate)
                     TestPassed++
                 } else {
-                    Log("FAIL: DerivedCancelRate = " cancelRate " (expected " expectedCancelRate ")")
+                    Log("FAIL: DerivedCancelRate = " cancelRate " (expected 22.2)")
                     TestErrors++
                 }
 
-                ; Verify formula: AvgTabsPerSwitch — expected from known inputs (15 / 7)
-                expectedAvgTabs := Round(15 / 7, 1)
                 avgTabsVal := snapshot.DerivedAvgTabsPerSwitch
-                if (avgTabsVal = expectedAvgTabs) {
-                    Log("PASS: DerivedAvgTabsPerSwitch = " avgTabsVal " (matches formula)")
+                if (avgTabsVal = 2.1) {
+                    Log("PASS: DerivedAvgTabsPerSwitch = " avgTabsVal)
                     TestPassed++
                 } else {
-                    Log("FAIL: DerivedAvgTabsPerSwitch = " avgTabsVal " (expected " expectedAvgTabs ")")
+                    Log("FAIL: DerivedAvgTabsPerSwitch = " avgTabsVal " (expected 2.1)")
                     TestErrors++
                 }
             } else {

--- a/tests/test_live_watcher.ahk
+++ b/tests/test_live_watcher.ahk
@@ -330,23 +330,4 @@ _Watcher_FindGuiPid(launcherPid) {
     return 0
 }
 
-; Helper: send WM_COPYDATA command to launcher, return response
-_Watcher_SendCommand(launcherHwnd, commandId) {
-    cds := Buffer(3 * A_PtrSize, 0)
-    NumPut("uptr", commandId, cds, 0)
-    NumPut("uint", 0, cds, A_PtrSize)
-    NumPut("ptr", 0, cds, 2 * A_PtrSize)
 
-    response := 0
-    result := DllCall("user32\SendMessageTimeoutW"
-        , "ptr", launcherHwnd
-        , "uint", 0x4A
-        , "ptr", A_ScriptHwnd
-        , "ptr", cds.Ptr
-        , "uint", 0x0002
-        , "uint", 3000
-        , "ptr*", &response
-        , "ptr")
-
-    return (result ? response : 0)
-}


### PR DESCRIPTION
## Summary

- Replace 3 recomputed formula assertions in stats E2E test (`test_live_features.ahk:310-341`) with hardcoded golden values (`30.0`, `22.2`, `2.1`) — decouples test expectations from production implementation
- Delete unused `_Watcher_SendCommand` function from `test_live_watcher.ahk`

Closes #262

## Test plan

- [x] All 982 tests pass (`.\tests\test.ps1 --live`)
- [x] Features suite: 15/15 (golden values match production output)
- [x] Watcher suite: 5/5 (no impact from dead code removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)