### PR TITLE
Remove dead code: unused functions, globals, and DWM scaffolding

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -233,7 +233,7 @@ if (g_AltTabbyMode = "config") {
 if (g_AltTabbyMode = "blacklist") {
     launcherHwnd := _ParseLauncherHwnd()
     ; Config + theme init is handled inside BlacklistEditor_Run (matches ConfigEditor_Run pattern)
-    BlacklistEditor_Run(launcherHwnd)
+    BlacklistEditor_Run()
     _NotifyEditorClosed(launcherHwnd)
     ExitApp()
 }

--- a/src/editors/blacklist_editor.ahk
+++ b/src/editors/blacklist_editor.ahk
@@ -28,7 +28,6 @@ global gBE_OriginalTitle := ""
 global gBE_OriginalClass := ""
 global gBE_OriginalPair := ""
 global gBE_SavedChanges := false
-global gBE_LauncherHwnd := 0  ; lint-ignore: dead-global  ; Set by init, consumed by alt_tabby.ahk exit handler
 
 ; ============================================================
 ; PUBLIC API
@@ -36,10 +35,9 @@ global gBE_LauncherHwnd := 0  ; lint-ignore: dead-global  ; Set by init, consume
 
 ; Run the blacklist editor
 ; Returns: true if changes were saved, false otherwise
-BlacklistEditor_Run(launcherHwnd := 0) {
-    global gBE_Gui, gBE_SavedChanges, gBE_LauncherHwnd, gBlacklist_FilePath, gBlacklist_Loaded
+BlacklistEditor_Run() {
+    global gBE_Gui, gBE_SavedChanges, gBlacklist_FilePath, gBlacklist_Loaded
     global gConfigLoaded
-    gBE_LauncherHwnd := launcherHwnd
 
     ; Hide tray icon - only launcher should have one
     A_IconHidden := true

--- a/src/editors/config_editor.ahk
+++ b/src/editors/config_editor.ahk
@@ -41,7 +41,7 @@ ConfigEditor_Run(launcherHwnd := 0, forceNative := false) {
     ; Try WebView2 first if not forcing native
     if (!forceNative && IsWebView2Available()) {
         try {
-            return CE_RunWebView2(launcherHwnd)
+            return CE_RunWebView2()
         } catch as e {
             ; WebView2 detection succeeded but init failed - fall back to native
             ; This can happen if WebView2 is registered but DLL is missing/corrupt

--- a/src/editors/config_editor_webview.ahk
+++ b/src/editors/config_editor_webview.ahk
@@ -77,7 +77,6 @@ global gCEW_Controller := 0
 global gCEW_WebView := 0
 global gCEW_SavedChanges := false
 global gCEW_HasChanges := false
-global gCEW_LauncherHwnd := 0  ; lint-ignore: dead-global  ; Set by init, consumed by alt_tabby.ahk exit handler
 global gCEW_MessageHandler := 0  ; Must store HANDLER OBJECT to prevent garbage collection
 
 ; ============================================================
@@ -87,12 +86,10 @@ global gCEW_MessageHandler := 0  ; Must store HANDLER OBJECT to prevent garbage 
 ; Run the WebView2 config editor
 ; launcherHwnd: HWND of launcher process for WM_COPYDATA restart signal (0 = standalone)
 ; Returns: true if changes were saved, false otherwise
-CE_RunWebView2(launcherHwnd := 0) {
-    global gCEW_Gui, gCEW_Controller, gCEW_WebView, gCEW_SavedChanges, gCEW_HasChanges, gCEW_LauncherHwnd
+CE_RunWebView2() {
+    global gCEW_Gui, gCEW_Controller, gCEW_WebView, gCEW_SavedChanges, gCEW_HasChanges
     global gCEW_MessageHandler
     global gConfigLoaded, RES_ID_WEBVIEW2_DLL, RES_ID_EDITOR_HTML
-
-    gCEW_LauncherHwnd := launcherHwnd
     gCEW_SavedChanges := false
     gCEW_HasChanges := false
 
@@ -215,7 +212,7 @@ _CEW_OnWebMessageRaw(this, sender, argsPtr) { ; lint-ignore: dead-param
 }
 
 _CEW_OnWebMessage(sender, args) { ; lint-ignore: dead-param
-    global gCEW_Gui, gCEW_SavedChanges, gCEW_HasChanges, gCEW_LauncherHwnd
+    global gCEW_Gui, gCEW_SavedChanges, gCEW_HasChanges
     global cfg, LOG_PATH_WEBVIEW, LOG_PATH_STORE
 
     ; Parse JSON message from JavaScript

--- a/src/gui/d2d_shader.ahk
+++ b/src/gui/d2d_shader.ahk
@@ -1042,14 +1042,6 @@ _Shader_CreateRT(entry, w, h) {
     return true
 }
 
-; GUID helper
-; lint-ignore: dead-function
-_Shader_MakeGUID(str) {
-    buf := Buffer(16, 0)
-    DllCall("ole32\CLSIDFromString", "str", str, "ptr", buf, "hresult")
-    return buf
-}
-
 ; ========================= PRE-RENDER =========================
 
 ; Run the D3D11 shader pipeline. Call BEFORE D2D BeginDraw.
@@ -1284,15 +1276,6 @@ Shader_GetBitmap(name) {
     global gShader_Registry
     try return gShader_Registry[name].bitmap
     return 0
-}
-
-; Return the metadata for a registered shader, or 0 if not found.
-; lint-ignore: dead-function
-_Shader_GetMeta(name) {
-    global gShader_Registry
-    if (!gShader_Registry.Has(name))
-        return 0
-    return gShader_Registry[name].meta
 }
 
 ; ========================= CLEANUP =========================

--- a/src/gui/d2d_types.ahk
+++ b/src/gui/d2d_types.ahk
@@ -104,35 +104,6 @@ D2D_Matrix3x2_Identity() { ; lint-ignore: dead-function
     return buf
 }
 
-; ========================= DWM_THUMBNAIL_PROPERTIES (48 bytes) =========================
-; Used with DwmUpdateThumbnailProperties
-
-; Flag constants ; lint-ignore: dead-global (consumed by dwm_thumbnail.ahk in Phase 2)
-global DWM_TNP_RECTDESTINATION := 0x01
-global DWM_TNP_RECTSOURCE      := 0x02 ; lint-ignore: dead-global
-global DWM_TNP_OPACITY         := 0x04
-global DWM_TNP_VISIBLE         := 0x08
-global DWM_TNP_SOURCECLIENTAREAONLY := 0x10
-
-_DWM_ThumbnailProps(destL, destT, destR, destB, visible := true, opacity := 255, clientOnly := true) { ; lint-ignore: dead-function
-    global DWM_TNP_RECTDESTINATION, DWM_TNP_VISIBLE, DWM_TNP_OPACITY, DWM_TNP_SOURCECLIENTAREAONLY
-    ; Layout: { DWORD flags (4), RECT dest (16), RECT source (16),
-    ;           BYTE opacity (1+3 pad), BOOL visible (4), BOOL srcClientOnly (4) }
-    buf := Buffer(48, 0)
-    flags := DWM_TNP_RECTDESTINATION | DWM_TNP_VISIBLE | DWM_TNP_OPACITY | DWM_TNP_SOURCECLIENTAREAONLY
-    NumPut("uint", flags, buf, 0)
-    ; rcDestination (RECT: left, top, right, bottom as int32)
-    NumPut("int", destL, "int", destT, "int", destR, "int", destB, buf, 4)
-    ; rcSource left at zero (use whole source)
-    ; opacity
-    NumPut("uchar", opacity, buf, 36)
-    ; fVisible
-    NumPut("int", visible ? 1 : 0, buf, 40)
-    ; fSourceClientAreaOnly
-    NumPut("int", clientOnly ? 1 : 0, buf, 44)
-    return buf
-}
-
 ; ========================= D2D1_ARC_SEGMENT (28 bytes) =========================
 ; Used with path geometry for per-corner rounded rects
 

--- a/src/gui/gui_capture.ahk
+++ b/src/gui/gui_capture.ahk
@@ -8,7 +8,6 @@
 ; ============================================================
 
 global gCapture_Recording := false
-global gCapture_FfmpegPID := 0 ; lint-ignore: dead-global
 global gCapture_StdinPipe := 0
 
 ; ========================= INIT =========================
@@ -164,7 +163,7 @@ _Capture_Screenshot() {
 ;
 
 _Capture_RecordStart() {
-    global gGUI_OverlayVisible, gGUI_BaseH, gCapture_Recording, gCapture_FfmpegPID, gCapture_StdinPipe
+    global gGUI_OverlayVisible, gGUI_BaseH, gCapture_Recording, gCapture_StdinPipe
 
     if (!gGUI_OverlayVisible || gCapture_Recording)
         return
@@ -240,7 +239,6 @@ _Capture_RecordStart() {
         return
     }
 
-    gCapture_FfmpegPID := NumGet(pi, 16, "UInt")
     DllCall("CloseHandle", "Ptr", NumGet(pi, 0, "Ptr"))   ; hProcess
     DllCall("CloseHandle", "Ptr", NumGet(pi, 8, "Ptr"))   ; hThread
 
@@ -252,7 +250,7 @@ _Capture_RecordStart() {
 }
 
 _Capture_RecordStop() {
-    global gCapture_Recording, gCapture_FfmpegPID, gCapture_StdinPipe
+    global gCapture_Recording, gCapture_StdinPipe
 
     if (!gCapture_Recording)
         return
@@ -266,7 +264,6 @@ _Capture_RecordStop() {
     DllCall("CloseHandle", "Ptr", gCapture_StdinPipe)
 
     gCapture_Recording := false
-    gCapture_FfmpegPID := 0
     gCapture_StdinPipe := 0
 
     ToolTip("Recording stopped")

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -29,10 +29,6 @@ global gDComp_Target := 0      ; IDCompositionTarget
 global gDComp_Visual := 0      ; IDCompositionVisual (content: swap chain)
 global gDComp_ClipVisual := 0  ; IDCompositionVisual (parent: clip rect)
 
-; Fixed-size swap chain dimensions (Phase 2: max monitor resolution)
-global gD2D_SwapChainMaxW := 0 ; Physical width of the oversized swap chain ; lint-ignore: dead-global
-global gD2D_SwapChainMaxH := 0 ; Physical height of the oversized swap chain ; lint-ignore: dead-global
-
 ; Waitable swap chain state (latency optimization — Present(0,0) pattern)
 global gD2D_SwapChain2 := 0     ; IDXGISwapChain2 (0 = fallback/non-waitable mode)
 global gD2D_WaitableHandle := 0  ; HANDLE from GetFrameLatencyWaitableObject
@@ -488,7 +484,6 @@ _D2D_CreateRenderTarget(hwnd, wPhys, hPhys) {
     global gD2D_SwapChain, gD2D_BackBuffer
     global gD2D_SwapChain2, gD2D_WaitableHandle
     global gDComp_Device, gDComp_Target, gDComp_Visual, gDComp_ClipVisual
-    global gD2D_SwapChainMaxW, gD2D_SwapChainMaxH
     global D2D1_ANTIALIAS_MODE_PER_PRIMITIVE, D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE
     global DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SWAP_EFFECT_FLIP_DISCARD
     global DXGI_ALPHA_MODE_PREMULTIPLIED
@@ -514,8 +509,6 @@ _D2D_CreateRenderTarget(hwnd, wPhys, hPhys) {
     scW := 0
     scH := 0
     _D2D_GetMaxMonitorSize(&scW, &scH)
-    gD2D_SwapChainMaxW := scW
-    gD2D_SwapChainMaxH := scH
 
     ; Try waitable swap chain first (lower input-to-photon latency)
     waitableOk := false
@@ -651,7 +644,6 @@ D2D_HandleDeviceLoss() {
 D2D_ShutdownAll() {
     global gD2D_RT, gD2D_SwapChain, gD2D_BackBuffer
     global gDComp_Device, gDComp_Target, gDComp_Visual, gDComp_ClipVisual
-    global gD2D_SwapChainMaxW, gD2D_SwapChainMaxH
     global gD2D_D2DDevice, gD2D_D3DDevice
     global gD2D_Factory, gDW_Factory
 
@@ -670,10 +662,6 @@ D2D_ShutdownAll() {
     gDComp_ClipVisual := 0
     gDComp_Target := 0
     gDComp_Device := 0
-
-    ; Clear swap chain max size tracking
-    gD2D_SwapChainMaxW := 0
-    gD2D_SwapChainMaxH := 0
 
     ; Release waitable state before swap chain
     _D2D_CleanupWaitableState()


### PR DESCRIPTION
## Summary
- Remove 2 dead private functions (`_Shader_MakeGUID`, `_Shader_GetMeta`) from `d2d_shader.ahk`
- Remove DWM thumbnail block (5 constants + `_DWM_ThumbnailProps`) from `d2d_types.ahk` — referenced nonexistent `dwm_thumbnail.ahk`
- Remove 4 dead globals written but never read: `gD2D_SwapChainMaxW/H`, `gCapture_FfmpegPID`, `gBE_LauncherHwnd`, `gCEW_LauncherHwnd`
- Remove now-dead `launcherHwnd` param from `BlacklistEditor_Run()` and `CE_RunWebView2()` + update callers

Closes #266

## Test plan
- [x] Static analysis pre-gate passes (all 84 checks)
- [x] All 982 tests pass (unit, GUI, live, flight recorder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)