### PR TITLE
Fix stale identifier references in skill files

### DIFF
--- a/.claude/skills/profile-coverage/SKILL.md
+++ b/.claude/skills/profile-coverage/SKILL.md
@@ -10,7 +10,7 @@ Enter planning mode. Review which functions are instrumented for profiling and i
 
 Alt-Tabby has a build-time strip profiler (`src/shared/profiler.ahk`). Functions are instrumented with `Profiler.Enter("FuncName") ; @profile` / `Profiler.Leave() ; @profile` pairs. In release builds, `compile.ps1` strips all `; @profile` lines — true zero cost. In `--profile` builds, the profiler records QPC-timestamped events to a ring buffer and exports speedscope flame graphs.
 
-The static analysis check `tests/check_profile_markers.ps1` validates balanced Enter/Leave per function (catches the early-return problem).
+The static analysis check validates balanced Enter/Leave per function (sub-check `profile_markers` in `tests/check_batch_directives.ps1`) — catches the early-return problem.
 
 ## Step 1 — Generate the instrumentation map
 
@@ -88,7 +88,7 @@ Produce a summary of all YES recommendations:
 
 | File | Function | Why (one line) |
 |------|----------|----------------|
-| `gui_paint.ahk` | `_GP_DrawItem` | Variable cost per-item, parent `GUI_Repaint` can't show which item is slow |
+| `gui_paint.ahk` | `_GUI_PaintOverlay` | Variable cost per-item, parent `GUI_Repaint` can't show which item is slow |
 
 And a count: "X new functions recommended, bringing total from Y to Z (N% coverage)."
 

--- a/.claude/skills/review-option-interaction/SKILL.md
+++ b/.claude/skills/review-option-interaction/SKILL.md
@@ -98,7 +98,7 @@ For each candidate:
 
 | Pattern | Files | Variations | Proposed Consolidation |
 |---------|-------|-----------|----------------------|
-| "Is installed to PF?" check | `launcher.ahk:30`, `update.ahk:55`, `wizard.ahk:80` | Slightly different path comparisons | Shared `IsInstalledToProgramFiles()` helper |
+| "Is installed to PF?" check | `launcher_main.ahk:30`, `update.ahk:55`, `wizard.ahk:80` | Slightly different path comparisons | Shared `IsInstalledToProgramFiles()` helper |
 
 Order by severity: data-loss risks first, cosmetic inconsistencies last.
 

--- a/.claude/skills/review-professionalism/SKILL.md
+++ b/.claude/skills/review-professionalism/SKILL.md
@@ -81,7 +81,7 @@ Group by user-facing area:
 | Area | File | Lines | Issue | User Impact | Fix |
 |------|------|-------|-------|------------|-----|
 | Wizard | `launcher_wizard.ahk` | 88 | "Click OK to continue" — no explanation of what happens next | Confusing first-run | Rewrite to "This will install Alt-Tabby to Program Files and create a startup task." |
-| Tray menu | `launcher.ahk` | 42 | Menu item "Debug Viewer" — technical jargon | Intimidating to non-technical users | Rename to "Window Inspector" or similar |
+| Tray menu | `launcher_tray.ahk` | 42 | Menu item "Debug Viewer" — technical jargon | Intimidating to non-technical users | Rename to "Window Inspector" or similar |
 | Config editor | `config_editor.ahk` | 200 | Setting description uses ms units without explanation | User doesn't know what 150ms means | Add "(lower = faster response)" hint |
 
 Order by user exposure: high-traffic surfaces first (overlay, tray, config editor), rarely-seen surfaces last (wizard, error dialogs).


### PR DESCRIPTION
## Summary

- Fix broken file path in `profile-coverage` skill: `tests/check_profile_markers.ps1` → sub-check in `tests/check_batch_directives.ps1` (file was merged into batch)
- Fix stale function name in `profile-coverage` example table: `_GP_DrawItem` → `_GUI_PaintOverlay`
- Fix non-existent `launcher.ahk` references in `review-professionalism` and `review-option-interaction` example tables → `launcher_tray.ahk` / `launcher_main.ahk`

Closes #275

## Test plan

- [x] Verified all updated paths exist via glob
- [x] `check_skill_frontmatter.ps1` passes (54/54 skills valid)
- [ ] Spot-check: read each modified skill to confirm edits are contextually correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)