### PR TITLE
Fix stale underscore prefix in AntiFlash comment

### DIFF
--- a/src/editors/config_editor_webview.ahk
+++ b/src/editors/config_editor_webview.ahk
@@ -60,7 +60,7 @@
 ;    hides it during this gap. Alpha=0 USUALLY hides the frame but can
 ;    intermittently leak (DWM race). Off-screen ensures any leak is invisible.
 ;
-;    See _GUI_AntiFlashPrepare/Reveal() in gui_antiflash.ahk.
+;    See GUI_AntiFlashPrepare/Reveal() in gui_antiflash.ahk.
 ;
 ; 6. OFF-SCREEN CENTERING REQUIRES RAW WIN32
 ;    AHK v2's Gui.Move() applies DPI scaling on coordinates. When a window


### PR DESCRIPTION
## Summary

- Fix comment in `config_editor_webview.ahk:63` referencing `_GUI_AntiFlashPrepare/Reveal()` — functions are public (no underscore prefix)
- Aligns with the correct reference on line 70 of the same comment block

Closes #276

## Test plan

- [x] Full test suite passes (982/982 tests)
- [x] Static analysis pre-gate passes (no stale function references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)