### PR TITLE
Fix test reliability anti-patterns causing intermittent failures

### DIFF
--- a/tests/gui_tests_data.ahk
+++ b/tests/gui_tests_data.ahk
@@ -604,7 +604,7 @@ RunGUITests_Data() {
     gWS_Store[1000] := {present: true, iconHicon: 50001}
     GUI_KickPreCache()
     ; Timer should NOT have been set; verify by calling tick manually after brief wait
-    Sleep(150)  ; 3x the -50ms timer period for reliable negative assertion
+    Sleep(500)  ; 10x the timer period for reliability under load
     GUI_AssertEq(gMock_PreCachedIcons.Count, 0, "KickPreCache ACTIVE: timer not set, no icons cached")
 
     ; ============================================================

--- a/tests/test_live_core.ahk
+++ b/tests/test_live_core.ahk
@@ -201,7 +201,6 @@ RunLiveTests_Core() {
         try FileDelete(tmpState)
         cmdLine := 'cmd.exe /c ""' komorebicPath '" state > "' tmpState '"" 2>&1'
         _Test_RunWaitSilent(cmdLine)
-        Sleep(200)  ; Give file time to write
         stateTxt := ""
         try stateTxt := FileRead(tmpState, "UTF-8")
         try FileDelete(tmpState)

--- a/tests/test_live_execution.ahk
+++ b/tests/test_live_execution.ahk
@@ -126,14 +126,19 @@ RunLiveTests_Execution() {
         }
 
         ; Kill launcher and its children (targeted by PID tree)
+        killPids := []
         for _, child in _Test_FindChildProcesses(launcherPid, EXECTEST_EXE_NAME) {
             try ProcessClose(child.pid)
+            killPids.Push(child.pid)
         }
         try ProcessClose(launcherPid)
-        waitStart := A_TickCount
-        while (ProcessExist(launcherPid) && (A_TickCount - waitStart) < 2000)
-            Sleep(20)
-        Sleep(50)  ; Brief grace for handle release
+        killPids.Push(launcherPid)
+        deadline := A_TickCount + 2000
+        for _, pid in killPids {
+            while (ProcessExist(pid) && (A_TickCount < deadline))
+                Sleep(20)
+        }
+        Sleep(50)  ; handle release grace
     }
 
     ; --- Config/Blacklist Recreation Test (in isolated dir) ---

--- a/tests/test_live_watcher.ahk
+++ b/tests/test_live_watcher.ahk
@@ -119,7 +119,7 @@ RunLiveTests_Watcher() {
         if (FileExist(storeLogPath)) {
             try {
                 content := FileRead(storeLogPath)
-                if (StrLen(content) > 0) {
+                if (StrLen(content) > 50) {
                     settleReady := true
                     break
                 }
@@ -138,6 +138,11 @@ RunLiveTests_Watcher() {
 
     ; Modify blacklist.txt on disk — the GUI file watcher should detect this
     blPath := testDir "\blacklist.txt"
+
+    ; Record log baseline BEFORE triggering the change so we only search new content
+    logBaseline := 0
+    try logBaseline := StrLen(FileRead(storeLogPath))
+
     try FileAppend("; file watcher test " A_TickCount "`n", blPath, "UTF-8")
 
     ; Poll store log for watcher reload message
@@ -147,7 +152,7 @@ RunLiveTests_Watcher() {
         if (FileExist(storeLogPath)) {
             try {
                 logContent := FileRead(storeLogPath)
-                if (InStr(logContent, "WATCH: blacklist reloaded")) {
+                if (InStr(SubStr(logContent, logBaseline + 1), "WATCH: blacklist reloaded")) {
                     watchReloaded := true
                     break
                 }
@@ -225,9 +230,15 @@ RunLiveTests_Watcher() {
     ; ============================================================
     Log("`n--- Ordered Shutdown Test ---")
 
-    ; Re-find GUI PID after potential restart
-    Sleep(200)
-    guiPid := _Watcher_FindGuiPid(launcherPid)
+    ; Re-find GUI PID after potential restart (poll instead of blind sleep)
+    guiPid := 0
+    guiDiscStart := A_TickCount
+    while ((A_TickCount - guiDiscStart) < 3000) {
+        guiPid := _Watcher_FindGuiPid(launcherPid)
+        if (guiPid)
+            break
+        Sleep(50)
+    }
 
     if (!guiPid) {
         Log("FAIL: Could not find GUI pid for shutdown test")

--- a/tests/test_unit_core_config.ahk
+++ b/tests/test_unit_core_config.ahk
@@ -622,9 +622,6 @@ RunUnitTests_CoreConfig() {
             break
         Sleep(50)
     }
-    ; Additional grace for processes still running to finish init
-    Sleep(200)
-
     ; Collect results from all entry points
     for idx, ep in entryPoints {
         pid := pids[idx]
@@ -638,7 +635,10 @@ RunUnitTests_CoreConfig() {
         if (InStr(ep.name, "launcher") && stillRunning) {
             ; taskkill /T kills the entire process tree (cmd → launcher → store + gui)
             _Test_RunWaitSilent('taskkill /F /T /PID ' pid)
-            stillRunning := false  ; We just killed it
+            killDeadline := A_TickCount + 2000
+            while (ProcessExist(pid) && (A_TickCount < killDeadline))
+                Sleep(20)
+            stillRunning := ProcessExist(pid)
         } else if (stillRunning) {
             ProcessClose(pid)
             closeDeadline := A_TickCount + 2000

--- a/tests/test_unit_file_watcher.ahk
+++ b/tests/test_unit_file_watcher.ahk
@@ -59,7 +59,7 @@ RunUnitTests_FileWatcher() {
         ; Poll — callback should NOT fire. 2s confirms absence convincingly;
         ; exits early if callback does fire (catches false-negatives faster).
         noFireStart2 := A_TickCount
-        while ((A_TickCount - noFireStart2) < 500) {
+        while ((A_TickCount - noFireStart2) < 2000) {
             if (callbackFired2)
                 break
             Sleep(50)
@@ -101,7 +101,7 @@ RunUnitTests_FileWatcher() {
         }
         ; Poll for stable count (600ms confirms absence, exits early if spurious fires)
         graceStart := A_TickCount
-        while ((A_TickCount - graceStart) < 600) {
+        while ((A_TickCount - graceStart) < 2000) {
             if (callbackCount3 > 1)
                 break
             Sleep(50)
@@ -134,7 +134,7 @@ RunUnitTests_FileWatcher() {
 
         ; Poll — callback should NOT fire. 2s confirms absence convincingly.
         noFireStart4 := A_TickCount
-        while ((A_TickCount - noFireStart4) < 500) {
+        while ((A_TickCount - noFireStart4) < 2000) {
             if (callbackFired4)
                 break
             Sleep(50)
@@ -197,7 +197,12 @@ RunUnitTests_FileWatcher() {
         w6.Stop()
 
         ; Wait past the debounce window
-        Sleep(500)
+        noFireStart6 := A_TickCount
+        while ((A_TickCount - noFireStart6) < 2000) {
+            if (callbackFired6)
+                break
+            Sleep(50)
+        }
 
         if (!callbackFired6) {
             Log("PASS: FileWatch Stop() during active debounce prevented callback")


### PR DESCRIPTION
## Summary

- **P1 flake fixes**: Poll all child PIDs for death after ProcessClose (F1), track log baseline to search only new content (F2), poll for process death after taskkill (F3)
- **P2 timing fixes**: Remove 3 redundant blind sleeps after synchronous operations (F4, F6), strengthen log readiness signal (F5), replace blind sleep with poll for GUI discovery (F7)
- **P3 negative assertions**: Extend 4 negative assertion windows from 500-600ms to 2000ms (F8-F11), extend timer suppression wait from 150ms to 500ms (F12)

Closes #279

## Test plan

- [x] All 982 tests pass (`.\tests\test.ps1 --live`)
- [x] Unit/FileWatcher: 7/7 — extended poll windows work correctly
- [x] Live/Watcher: 5/5 — log baseline and GUI discovery poll work
- [x] Live/Execution: 4/4 — child PID death polling works
- [x] GUI tests: 298/298 — timer suppression wait increase works
- [ ] Test-only changes — no production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)