### PR TITLE
Fix STA reentrancy in hide-path D2D calls

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -32,6 +32,7 @@ gGUI_HoverBtn: gui_input, gui_paint
 gGUI_HoverRow: gui_input, gui_paint
 gGUI_Sel: gui_input, gui_state
 gGUI_FocusBeforeShow: gui_state, gui_paint
+gPaint_RepaintInProgress: gui_animation, gui_overlay, gui_paint
 gAnim_DeferredTimerStart: gui_animation, gui_paint
 gAnim_OverlayOpacity: gui_animation, gui_state
 gAnim_HidePending: gui_animation, gui_overlay

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -417,7 +417,7 @@ _Anim_DoActualHide() {
     Profiler.Enter("_Anim_DoActualHide") ; @profile
     global gGUI_OverlayVisible, gGUI_Base, gGUI_BaseH, gGUI_Revealed, gD2D_RT
     global cfg, GUI_LOG_TRIM_EVERY_N_HIDES
-    global gGUI_DisplayItems
+    global gGUI_DisplayItems, gPaint_RepaintInProgress
     static hideCount := 0
 
     if (!gGUI_OverlayVisible) {
@@ -431,8 +431,14 @@ _Anim_DoActualHide() {
 
     GUI_ClearHoverState()
 
-    ; Clear D2D surface — ensures clean swap chain buffer for next Show
+    ; Clear D2D surface — ensures clean swap chain buffer for next Show.
+    ; STA reentrancy guard: BeginDraw/EndDraw/Present pump the message loop,
+    ; which can dispatch callbacks that reach GUI_Repaint (e.g., via
+    ; Anim_ForceCompleteHide during a new show sequence while state is ACTIVE).
+    ; Save/restore handles nesting when called from within an existing paint.
     if (gD2D_RT) {
+        wasInProgress := gPaint_RepaintInProgress
+        gPaint_RepaintInProgress := true
         try {
             if (D2D_AcquireBackBuffer()) {
                 gD2D_RT.BeginDraw()
@@ -443,6 +449,8 @@ _Anim_DoActualHide() {
             }
         } catch {
             D2D_ReleaseBackBuffer()
+        } finally {
+            gPaint_RepaintInProgress := wasInProgress
         }
     }
 

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -107,7 +107,7 @@ GUI_HideOverlay() {
     Profiler.Enter("GUI_HideOverlay") ; @profile
     global gGUI_OverlayVisible, gGUI_Base, gGUI_BaseH, gGUI_Revealed
     global cfg, GUI_LOG_TRIM_EVERY_N_HIDES, gD2D_RT
-    global gAnim_HidePending
+    global gAnim_HidePending, gPaint_RepaintInProgress
     static hideCount := 0
 
     if (!gGUI_OverlayVisible) {
@@ -146,7 +146,12 @@ GUI_HideOverlay() {
     ; Clear D2D surface BEFORE hiding — ensures a clean swap chain buffer
     ; for the next Show().  SwapChain.Present() works for hidden windows
     ; (unlike HwndRenderTarget), so the clear actually commits.
+    ; STA reentrancy guard: BeginDraw/EndDraw/Present pump the message loop,
+    ; which can dispatch callbacks that reach GUI_Repaint. Save/restore
+    ; handles nesting when called from within an existing paint.
     if (gD2D_RT) {
+        wasInProgress := gPaint_RepaintInProgress
+        gPaint_RepaintInProgress := true
         try {
             if (D2D_AcquireBackBuffer()) {
                 gD2D_RT.BeginDraw()
@@ -157,6 +162,8 @@ GUI_HideOverlay() {
             }
         } catch {
             D2D_ReleaseBackBuffer()
+        } finally {
+            gPaint_RepaintInProgress := wasInProgress
         }
     }
 


### PR DESCRIPTION
## Summary

- `_Anim_DoActualHide` and `GUI_HideOverlay` (immediate path) make D2D COM calls without `gPaint_RepaintInProgress`, allowing nested BeginDraw via STA pump (D2DERR_WRONG_STATE)
- Wrap both D2D blocks with save/restore `gPaint_RepaintInProgress` guard using try/finally
- Save/restore pattern (not simple set/clear) handles nesting correctly when called from within an existing paint's STA pump
- Add ownership.manifest entry for cross-file mutation

Closes #285

## Test plan

- [x] Pre-gate static analysis passes (84 checks including global ownership validation)
- [x] All 898 tests pass (unit, GUI, live, flight recorder, pump, network, watcher)
- [ ] Manual: rapid Alt+Tab cycling (hold Alt, tap Tab repeatedly, release, immediately re-Alt+Tab) — exercises `Anim_ForceCompleteHide` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)