### PR TITLE
Parallelize shader compilation and fix --timing measurement

### DIFF
--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -589,6 +589,7 @@ $guiScript = "$PSScriptRoot\gui_tests.ahk"
 $guiLogFile = "$env:TEMP\gui_tests_${worktreeId}.log"
 $guiHandle = [IntPtr]::Zero
 $guiTimingRecorded = $false
+$unitEarlyDone = @{}
 $frScript = "$PSScriptRoot\test_unit_flight_recorder.ahk"
 $frLogFile = "$env:TEMP\fr_tests_${worktreeId}.log"
 $frHandle = [IntPtr]::Zero
@@ -827,8 +828,33 @@ if ($live) {
     Write-Host "`n--- Compilation Phase (compile.ps1) ---" -ForegroundColor Yellow
 
     if ($compileHandle -ne [IntPtr]::Zero) {
-        # Compilation was started in background — wait for it
+        # Compilation was started in background — poll until done.
+        # While waiting, capture unit/GUI test exits for accurate --timing data.
         Write-Host "  Waiting for background compilation..."
+        $compileExitPoll = [SilentProcess]::TryGetExitCode($compileHandle)
+        while ($compileExitPoll -eq -259) {
+            if ($timing) {
+                # Capture unit suite exits as they happen
+                foreach ($us in $unitSuites) {
+                    if ($unitEarlyDone.ContainsKey($us.Label)) { continue }
+                    $code = [SilentProcess]::TryGetExitCode($us.Handle)
+                    if ($code -ne -259) {
+                        $unitEarlyDone[$us.Label] = $masterSw.ElapsedMilliseconds - $guiStartTickMs
+                    }
+                }
+                # Capture GUI Tests exit
+                if (-not $guiTimingRecorded -and $guiHandle -ne [IntPtr]::Zero) {
+                    $code = [SilentProcess]::TryGetExitCode($guiHandle)
+                    if ($code -ne -259) {
+                        $guiDurationMs = $masterSw.ElapsedMilliseconds - $guiStartTickMs
+                        $guiTimingRecorded = $true
+                    }
+                }
+            }
+            Start-Sleep -Milliseconds 25
+            $compileExitPoll = [SilentProcess]::TryGetExitCode($compileHandle)
+        }
+        # Process exited — get exit code and close handle
         $compileExit = [SilentProcess]::WaitAndGetExitCode($compileHandle)
         Record-PhaseEnd "Compilation"
         # Parse compile.ps1 step timings from captured output
@@ -962,7 +988,7 @@ if ($live) {
 # --- Check if GUI tests already finished (accurate timing) ---
 # GUI tests take ~1s but WaitAndGetExitCode below is called much later,
 # so snapshot the duration now if the process has already exited.
-if ($guiHandle -ne [IntPtr]::Zero) {
+if (-not $guiTimingRecorded -and $guiHandle -ne [IntPtr]::Zero) {
     $guiCode = [SilentProcess]::TryGetExitCode($guiHandle)
     if ($guiCode -ne -259) {
         $guiDurationMs = $masterSw.ElapsedMilliseconds - $guiStartTickMs
@@ -1052,7 +1078,10 @@ if ($live) {
         if ($guiInPoll) { $suiteHandles["GUI Tests"] = $guiHandle }
 
         $suiteDone = @{}
-        # If GUI Tests already finished, record it now
+        # Pre-seed with unit/GUI suites captured during compilation wait
+        foreach ($label in $unitEarlyDone.Keys) {
+            $suiteDone[$label] = $unitEarlyDone[$label]
+        }
         if ($guiTimingRecorded) { $suiteDone["GUI Tests"] = $guiDurationMs }
 
         $totalToWait = $suiteHandles.Count

--- a/tools/shader_compile.ps1
+++ b/tools/shader_compile.ps1
@@ -184,15 +184,7 @@ if ($staleShaders.Count -eq 0) {
 } else {
     Write-Host "  $cachedCount cached, $($staleShaders.Count) to compile"
 
-    # === Write manifest for worker ===
-    $manifestPath = Join-Path ([IO.Path]::GetTempPath()) "alttabby_shader_manifest_$([Guid]::NewGuid().ToString('N').Substring(0,8)).txt"
-    $manifestLines = @()
-    foreach ($s in $staleShaders) {
-        $manifestLines += "$($s.HlslPath)|$($s.BinPath)|$($s.Entry)|$($s.Target)"
-    }
-    [IO.File]::WriteAllLines($manifestPath, $manifestLines)
-
-    # === Invoke worker ===
+    # === Validate worker prerequisites ===
     if (!(Test-Path $ahk2base)) {
         Write-Host "ERROR: AutoHotkey v2 not found at: $ahk2base" -ForegroundColor Red
         exit 1
@@ -202,48 +194,95 @@ if ($staleShaders.Count -eq 0) {
         exit 1
     }
 
-    $proc = Start-Process -FilePath $ahk2base -ArgumentList "/ErrorStdOut `"$workerScript`" `"$manifestPath`"" `
-        -Wait -PassThru -WindowStyle Hidden -RedirectStandardOutput "$manifestPath.out" -RedirectStandardError "$manifestPath.err"
+    # === Partition shaders into N chunks for parallel compilation ===
+    $workerCount = [Math]::Min([Math]::Max([int]([Environment]::ProcessorCount / 2), 1), 8)
+    if ($staleShaders.Count -lt $workerCount) { $workerCount = $staleShaders.Count }
+    Write-Host "  Compiling with $workerCount parallel worker(s)..."
 
-    # Display worker output
-    if (Test-Path "$manifestPath.out") {
-        $workerOutput = Get-Content "$manifestPath.out" -Raw
-        if ($workerOutput) {
-            # Parse output for reporting
-            $lines = $workerOutput -split "`r?`n" | Where-Object { $_ -ne '' }
-            foreach ($line in $lines) {
-                if ($line -match '^OK ') {
-                    $shortName = [IO.Path]::GetFileNameWithoutExtension(($line -replace '^OK\s+', '' -replace '\s+\(.*$', ''))
-                    $sizeInfo = ''
-                    if ($line -match '\(([^)]+)\)') { $sizeInfo = " ($($Matches[1]))" }
-                    Write-Host "  NEW  $shortName$sizeInfo"
-                } elseif ($line -match '^FAIL') {
-                    Write-Host "  $line" -ForegroundColor Red
-                } elseif ($line -match '^SUMMARY') {
-                    # Skip — we'll report our own summary
-                } else {
-                    Write-Host "  $line"
+    # Round-robin partition into chunks
+    $chunks = @()
+    for ($i = 0; $i -lt $workerCount; $i++) { $chunks += ,@() }
+    for ($i = 0; $i -lt $staleShaders.Count; $i++) {
+        $chunks[$i % $workerCount] += $staleShaders[$i]
+    }
+
+    # === Write manifests and spawn workers ===
+    $workers = @()
+    $guid = [Guid]::NewGuid().ToString('N').Substring(0,8)
+    for ($i = 0; $i -lt $workerCount; $i++) {
+        $manifestPath = Join-Path ([IO.Path]::GetTempPath()) "alttabby_shader_manifest_${guid}_${i}.txt"
+        $manifestLines = @()
+        foreach ($s in $chunks[$i]) {
+            $manifestLines += "$($s.HlslPath)|$($s.BinPath)|$($s.Entry)|$($s.Target)"
+        }
+        [IO.File]::WriteAllLines($manifestPath, $manifestLines)
+
+        $proc = Start-Process -FilePath $ahk2base `
+            -ArgumentList "/ErrorStdOut `"$workerScript`" `"$manifestPath`"" `
+            -PassThru -WindowStyle Hidden `
+            -RedirectStandardOutput "$manifestPath.out" `
+            -RedirectStandardError "$manifestPath.err"
+
+        $workers += @{
+            Process      = $proc
+            ManifestPath = $manifestPath
+            ShaderCount  = $chunks[$i].Count
+        }
+    }
+
+    # === Wait for all workers and collect results ===
+    $totalFailures = 0
+    foreach ($w in $workers) {
+        $w.Process.WaitForExit()
+
+        # Display worker output
+        $outPath = "$($w.ManifestPath).out"
+        if (Test-Path $outPath) {
+            $workerOutput = Get-Content $outPath -Raw
+            if ($workerOutput) {
+                $lines = $workerOutput -split "`r?`n" | Where-Object { $_ -ne '' }
+                foreach ($line in $lines) {
+                    if ($line -match '^OK ') {
+                        $shortName = [IO.Path]::GetFileNameWithoutExtension(($line -replace '^OK\s+', '' -replace '\s+\(.*$', ''))
+                        $sizeInfo = ''
+                        if ($line -match '\(([^)]+)\)') { $sizeInfo = " ($($Matches[1]))" }
+                        Write-Host "  NEW  $shortName$sizeInfo"
+                    } elseif ($line -match '^FAIL') {
+                        Write-Host "  $line" -ForegroundColor Red
+                    } elseif ($line -match '^SUMMARY') {
+                        # Skip — we'll report our own summary
+                    } else {
+                        Write-Host "  $line"
+                    }
                 }
             }
+            Remove-Item $outPath -Force -ErrorAction SilentlyContinue
         }
-        Remove-Item "$manifestPath.out" -Force -ErrorAction SilentlyContinue
-    }
-    if (Test-Path "$manifestPath.err") {
-        $errContent = Get-Content "$manifestPath.err" -Raw
-        if ($errContent) { Write-Host $errContent -ForegroundColor Red }
-        Remove-Item "$manifestPath.err" -Force -ErrorAction SilentlyContinue
+        $errPath = "$($w.ManifestPath).err"
+        if (Test-Path $errPath) {
+            $errContent = Get-Content $errPath -Raw
+            if ($errContent) { Write-Host $errContent -ForegroundColor Red }
+            Remove-Item $errPath -Force -ErrorAction SilentlyContinue
+        }
+
+        # Accumulate failures (exit code = number of failed shaders)
+        if ($w.Process.ExitCode -ne 0) {
+            $totalFailures += $w.Process.ExitCode
+        }
+
+        # Cleanup manifest
+        Remove-Item $w.ManifestPath -Force -ErrorAction SilentlyContinue
     }
 
-    # Cleanup
-    Remove-Item $manifestPath -Force -ErrorAction SilentlyContinue
+    # Cleanup VS temp HLSL
     if ($vsTempHlsl -and (Test-Path $vsTempHlsl)) {
         Remove-Item $vsTempHlsl -Force -ErrorAction SilentlyContinue
     }
 
-    # Check worker exit code (= number of failures)
-    if ($proc.ExitCode -ne 0) {
+    # Check for failures
+    if ($totalFailures -ne 0) {
         Write-Host ""
-        Write-Host "ERROR: $($proc.ExitCode) shader(s) failed to compile." -ForegroundColor Red
+        Write-Host "ERROR: $totalFailures shader(s) failed to compile." -ForegroundColor Red
         exit 1
     }
 }


### PR DESCRIPTION
## Summary

- Shader compilation now spawns N parallel AHK workers (N = CPU_cores/2, max 8) via round-robin manifest partitioning — fresh-build shader compile drops from ~70s to ~24s
- `--timing` report now captures unit/GUI test exits during the compilation wait instead of after, fixing the bug where all suites showed ~69s during fresh builds
- Guard post-compilation GUI timing check to prevent overwriting early captures

Closes #287

## Test plan

- [x] All 982 tests pass (`--live`)
- [x] `--timing` report shows accurate per-suite durations during fresh builds (GUI Tests: 1.7s, not 69s)
- [x] Parallel shader compilation produces identical .bin outputs (196/196 OK, DXBC magic validated)
- [x] Cached builds unaffected (no stale shaders = no workers spawned)
- [ ] 5 consecutive `--live` runs pass (stability gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)