### PR TITLE
Skip Z-pump full scan during active Alt-Tab overlay

### DIFF
--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -362,6 +362,11 @@ _GUI_StartZPump() {
 }
 
 _GUI_ZPumpTick() {
+    global gGUI_State
+    ; PERF: Skip during overlay session - FullScan costs 5-20ms of main thread.
+    ; Display list is frozen during ACTIVE anyway; Z updates can wait.
+    if (gGUI_State = "ACTIVE" || gGUI_State = "ALT_PENDING")
+        return
     static _errCount := 0  ; Error boundary: consecutive error tracking
     static _backoffUntil := 0  ; Tick-based cooldown for exponential backoff
     if (A_TickCount < _backoffUntil)


### PR DESCRIPTION
## Summary

- Add state guard to `_GUI_ZPumpTick()` to skip `_GUI_FullScan()` during `ACTIVE`/`ALT_PENDING` states, saving 5-20ms of main thread blocking during active Alt-Tab
- Matches existing guard pattern in `_GUI_ValidateExistenceTick` and `_GUI_Housekeeping` — this was the only timer missing it

Closes #291

## Test plan

- [x] Static analysis pre-gate passes (global declaration checked)
- [x] Full test suite passes (982/982 — unit, GUI, live, flight recorder)
- [ ] Flight recorder: rapid Alt-Tab during window activity shows no `_GUI_FullScan` while state=ACTIVE
- [ ] Z-order updates still process normally when overlay is not showing

🤖 Generated with [Claude Code](https://claude.com/claude-code)