### PR TITLE
Main thread micro-optimizations + reduce Critical blocking

### DIFF
--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -1235,7 +1235,7 @@ _KSub_ScheduleCloakPush() {
     }
 
     _KSub_CloakPushPending := true
-    _KSub_CloakBatchTimerFn := _KSub_FlushCloakBatch.Bind()
+    _KSub_CloakBatchTimerFn := _KSub_FlushCloakBatch
     SetTimer(_KSub_CloakBatchTimerFn, -cfg.KomorebiSubBatchCloakEventsMs)
 }
 
@@ -1376,9 +1376,7 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
     ; Build map of ALL windows to their workspaces from komorebi state
     ; Only stores wsName/isCurrent/winObj — title/class/exe extracted lazily
     ; in the "add to store" branch (uncommon path) to avoid wasted work
-    wsMapNames := Map()    ; hwnd -> wsName (string)
-    wsMapCurrent := Map()  ; hwnd -> isCurrent (bool)
-    wsMapWinObj := Map()   ; hwnd -> winObj (Map from cJson)
+    wsMap := Map()         ; hwnd -> {wsName, isCurrent, winObj}
     now := A_TickCount
 
     for mi, monObj in monitorsArr {
@@ -1417,11 +1415,8 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
                         ; Prefer current workspace for duplicates: during move events,
                         ; mid-operation snapshot may have window on BOTH source and target.
                         ; If source is iterated after target, source would overwrite target.
-                        if (!wsMapNames.Has(hwnd) || isCurrentWs) {
-                            wsMapNames[hwnd] := wsName
-                            wsMapCurrent[hwnd] := isCurrentWs
-                            wsMapWinObj[hwnd] := win
-                        }
+                        if (!wsMap.Has(hwnd) || isCurrentWs)
+                            wsMap[hwnd] := {wsName: wsName, isCurrent: isCurrentWs, winObj: win}
                     }
                 }
 
@@ -1431,11 +1426,8 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
                     if (winObj is Map && winObj.Has("hwnd")) {
                         _v := winObj["hwnd"]
                         hwnd := (_v is Integer) ? _v : 0
-                        if (!wsMapNames.Has(hwnd) || isCurrentWs) {
-                            wsMapNames[hwnd] := wsName
-                            wsMapCurrent[hwnd] := isCurrentWs
-                            wsMapWinObj[hwnd] := winObj
-                        }
+                        if (!wsMap.Has(hwnd) || isCurrentWs)
+                            wsMap[hwnd] := {wsName: wsName, isCurrent: isCurrentWs, winObj: winObj}
                     }
                 }
             }
@@ -1451,11 +1443,8 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
                                 continue
                             _v := win["hwnd"]
                             hwnd := (_v is Integer) ? _v : 0
-                            if (hwnd && (!wsMapNames.Has(hwnd) || isCurrentWs)) {
-                                wsMapNames[hwnd] := wsName
-                                wsMapCurrent[hwnd] := isCurrentWs
-                                wsMapWinObj[hwnd] := win
-                            }
+                            if (hwnd && (!wsMap.Has(hwnd) || isCurrentWs))
+                                wsMap[hwnd] := {wsName: wsName, isCurrent: isCurrentWs, winObj: win}
                         }
                     }
                     ; Monocle may have single "window"
@@ -1464,11 +1453,8 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
                         if (winObj is Map && winObj.Has("hwnd")) {
                             _v := winObj["hwnd"]
                             hwnd := (_v is Integer) ? _v : 0
-                            if (hwnd && (!wsMapNames.Has(hwnd) || isCurrentWs)) {
-                                wsMapNames[hwnd] := wsName
-                                wsMapCurrent[hwnd] := isCurrentWs
-                                wsMapWinObj[hwnd] := winObj
-                            }
+                            if (hwnd && (!wsMap.Has(hwnd) || isCurrentWs))
+                                wsMap[hwnd] := {wsName: wsName, isCurrent: isCurrentWs, winObj: winObj}
                         }
                     }
                 }
@@ -1479,7 +1465,8 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
     ; Batch update workspace cache for all windows in wsMap (single Critical section
     ; instead of per-window Critical enter/exit)
     Critical "On"
-    for hwnd, _wsn in wsMapNames {
+    for hwnd, _data in wsMap {
+        _wsn := _data.wsName
         if (_KSub_WorkspaceCache.Has(hwnd) && _KSub_WorkspaceCache[hwnd].wsName = _wsn)
             _KSub_WorkspaceCache[hwnd].tick := now
         else
@@ -1496,7 +1483,7 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
     }
 
     if (cfg.DiagKomorebiLog)
-        KSub_DiagLog("ProcessFullState: wsMap has " wsMapNames.Count " windows, gWS_Store has " gWS_Store.Count " windows")
+        KSub_DiagLog("ProcessFullState: wsMap has " wsMap.Count " windows, gWS_Store has " gWS_Store.Count " windows")
 
     ; Capture MRU tick early to preserve timing (before batch collection)
     mruTick := A_TickCount
@@ -1507,14 +1494,15 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
     addedCount := 0
     updatedCount := 0
     skippedIneligible := 0
-    for hwnd, _wsn in wsMapNames {
-        _isCur := wsMapCurrent[hwnd]
+    for hwnd, _data in wsMap {
+        _wsn := _data.wsName
+        _isCur := _data.isCurrent
         ; Check if window exists in store
         if (!gWS_Store.Has(hwnd)) {
             ; Window not in store - add it!
             ; This happens for windows on other workspaces that winenum didn't see
             ; Extract title/class/exe lazily — only needed for new windows
-            _winObj := wsMapWinObj[hwnd]
+            _winObj := _data.winObj
             kTitle := _winObj.Has("title") ? String(_winObj["title"]) : ""
             kClass := _winObj.Has("class") ? String(_winObj["class"]) : ""
             title := (kTitle != "") ? kTitle : _KSub_GetWindowTitle(hwnd)
@@ -1613,7 +1601,7 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
             ; Guard: window may have been removed between snapshot and processing
             if (!gWS_Store.Has(hwnd))
                 continue
-            if (!wsMapNames.Has(hwnd) && _KSub_WorkspaceCache.Has(hwnd)) {
+            if (!wsMap.Has(hwnd) && _KSub_WorkspaceCache.Has(hwnd)) {
                 cached := _KSub_WorkspaceCache.Get(hwnd, 0)
                 if (!cached)
                     continue

--- a/src/core/mru_lite.ahk
+++ b/src/core/mru_lite.ahk
@@ -38,19 +38,14 @@ MRU_Lite_Tick() {
         if (!hwnd || hwnd = _MRU_LastHwnd) {
             return
         }
-        ; Atomic focus update - prevent race conditions with other timers/hotkeys
-        Critical "On"
-        ; Clear focus on previous window
-        if (_MRU_LastHwnd) {
-            try {
-                WL_UpdateFields(_MRU_LastHwnd, { isFocused: false })
-            }
-        }
+        ; Batch both focus updates into single rev bump
+        ; WL_BatchUpdateFields handles its own Critical for store atomicity
+        patches := Map()
+        if (_MRU_LastHwnd)
+            patches[_MRU_LastHwnd] := {isFocused: false}
+        patches[hwnd] := {lastActivatedTick: A_TickCount, isFocused: true}
         _MRU_LastHwnd := hwnd
-        try {
-            WL_UpdateFields(hwnd, { lastActivatedTick: A_TickCount, isFocused: true })
-        }
-        Critical "Off"
+        try WL_BatchUpdateFields(patches, "mru_lite")
         _errCount := 0
         _backoffUntil := 0
     } catch as e {

--- a/src/core/proc_pump.ahk
+++ b/src/core/proc_pump.ahk
@@ -208,17 +208,32 @@ ProcPump_PruneFailedPidCache() {
     if (!IsObject(_PP_FailedPidCache) || _PP_FailedPidCache.Count = 0)
         return 0
 
+    ; Snapshot keys+ticks under Critical (prevents iteration-during-modification),
+    ; then check TTL+ProcessExist outside Critical (cross-process query ~100-500us each)
     Critical "On"
     now := A_TickCount
+    entries := []
+    for pid, tick in _PP_FailedPidCache
+        entries.Push({pid: pid, tick: tick})
+    Critical "Off"
+
     toDelete := []
-    for pid, tick in _PP_FailedPidCache {
+    for _, entry in entries {
         ; Only prune if TTL expired AND process no longer exists
         ; (if process restarted with same PID, we want to retry)
-        if ((now - tick) >= _PP_FailedPidCacheTTL && !ProcessExist(pid))
-            toDelete.Push(pid)
+        if ((now - entry.tick) >= _PP_FailedPidCacheTTL && !ProcessExist(entry.pid))
+            toDelete.Push(entry.pid)
     }
-    for _, pid in toDelete
-        _PP_FailedPidCache.Delete(pid)
+
+    if (toDelete.Length = 0)
+        return 0
+
+    ; Only hold Critical for the fast delete loop
+    Critical "On"
+    for _, pid in toDelete {
+        if (_PP_FailedPidCache.Has(pid))
+            _PP_FailedPidCache.Delete(pid)
+    }
     Critical "Off"
     return toDelete.Length
 }

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -291,8 +291,11 @@ _Anim_FrameLoop() {
             continue  ; CancelAll sets gAnim_TimerRunning=false → loop exits
         }
 
+        ; Cache shader state for this frame (unchanged during paint)
+        hasShaders := FX_HasActiveShaders()
+
         ; Update ambient animations (Full mode, or any mode with active shaders)
-        if (gGUI_OverlayVisible && (cfg.PerfAnimationType = "Full" || FX_HasActiveShaders()))
+        if (gGUI_OverlayVisible && (cfg.PerfAnimationType = "Full" || hasShaders))
             FX_UpdateAmbient(gAnim_FrameDt)
 
         ; Paint frame (gAnim_FrameTimeDisplay set inside GUI_Repaint,
@@ -304,7 +307,7 @@ _Anim_FrameLoop() {
         _Anim_UpdateFPSCounter(now)
 
         ; Auto-stop (Minimal mode: exit when no active tweens AND no active shaders)
-        if (cfg.PerfAnimationType != "Full" && activeCount = 0 && !gAnim_HidePending && !FX_HasActiveShaders())
+        if (cfg.PerfAnimationType != "Full" && activeCount = 0 && !gAnim_HidePending && !hasShaders)
             break
 
         Critical "Off"

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -370,13 +370,15 @@ FX_PreRenderShaderLayers(w, h) {
         return
     }
 
+    ; Hoist loop-invariant computation (gFX_AmbientTime unchanged during paint)
+    ambientSec := gFX_AmbientTime / 1000.0
+
     for _, layer in gFX_ShaderLayers {
         if (layer.key = "")
             continue
 
         ; Compute effective time: (ambient / 1000) * speed + offset + carry
         ; Single Map.Get avoids Has+[] double lookup
-        ambientSec := gFX_AmbientTime / 1000.0
         baseTime := ambientSec
         t := gFX_ShaderTime.Get(layer.layerIndex, 0)
         if (t)
@@ -735,6 +737,17 @@ _FX_ResolveConfiguredShaders() {
 
     gFX_ShaderLayers := []
 
+    ; Build O(1) lookup sets from key arrays (replaces 6 linear scans below)
+    shaderKeySet := Map()
+    for _, k in SHADER_KEYS
+        shaderKeySet[k] := true
+    mouseKeySet := Map()
+    for _, k in MOUSE_SHADER_KEYS
+        mouseKeySet[k] := true
+    selKeySet := Map()
+    for _, k in SELECTION_SHADER_KEYS
+        selKeySet[k] := true
+
     ; Global shader toggle — skip all layer resolution when disabled
     if (!cfg.ShaderUseShaderLayers)
         return
@@ -746,14 +759,7 @@ _FX_ResolveConfiguredShaders() {
             continue
 
         ; Validate key exists in SHADER_KEYS
-        found := false
-        for _, k in SHADER_KEYS {
-            if (k = layerKey) {
-                found := true
-                break
-            }
-        }
-        if (!found)
+        if (!shaderKeySet.Has(layerKey))
             continue
 
         ; renderKey: per-layer alias so each layer gets its own render target
@@ -778,14 +784,7 @@ _FX_ResolveConfiguredShaders() {
     ; Resolve mouse effect
     mouseKey := cfg.MouseEffect_UseMouseEffect ? cfg.MouseEffect_Name : ""
     if (mouseKey != "") {
-        found := false
-        for _, k in MOUSE_SHADER_KEYS {
-            if (k = mouseKey) {
-                found := true
-                break
-            }
-        }
-        if (found) {
+        if (mouseKeySet.Has(mouseKey)) {
             gFX_MouseEffect := {key: mouseKey, name: mouseKey,
                 opacity: cfg.MouseEffect_Opacity,
                 darkness: cfg.MouseEffect_Darkness,
@@ -803,19 +802,12 @@ _FX_ResolveConfiguredShaders() {
     }
 
     ; Resolve selection effect — BG-as-selection overrides dedicated selection shaders
-    _emptySelEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
+    static _emptySelEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
     if (!cfg.GUI_UseSelectionEffect) {
         gFX_SelectionEffect := _emptySelEffect
     } else if (cfg.GUI_UseBGShaderAsSelection) {
         bgKey := cfg.GUI_BGShaderAsSelection
-        found := false
-        for _, k in SHADER_KEYS {
-            if (k = bgKey) {
-                found := true
-                break
-            }
-        }
-        if (found) {
+        if (shaderKeySet.Has(bgKey)) {
             gFX_SelectionEffect := {key: bgKey, name: bgKey,
                 opacity: cfg.GUI_SelectionOpacity,
                 darkness: cfg.GUI_SelectionDarkness,
@@ -828,14 +820,7 @@ _FX_ResolveConfiguredShaders() {
     } else {
         selKey := cfg.GUI_SelectionEffect
         if (selKey != "" && selKey != "None") {
-            found := false
-            for _, k in SELECTION_SHADER_KEYS {
-                if (k = selKey) {
-                    found := true
-                    break
-                }
-            }
-            if (found) {
+            if (selKeySet.Has(selKey)) {
                 gFX_SelectionEffect := {key: selKey, name: selKey,
                     opacity: cfg.GUI_SelectionOpacity,
                     darkness: cfg.GUI_SelectionDarkness,
@@ -855,19 +840,12 @@ _FX_ResolveConfiguredShaders() {
     }
 
     ; Resolve hover effect — mirrors selection resolve with hover-specific config
-    _emptyHovEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
+    static _emptyHovEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
     if (!cfg.GUI_UseHoverSelectionEffect) {
         gFX_HoverEffect := _emptyHovEffect
     } else if (cfg.GUI_UseBGShaderAsHoverSelection) {
         bgKey := cfg.GUI_HoverBGShaderAsSelection
-        found := false
-        for _, k in SHADER_KEYS {
-            if (k = bgKey) {
-                found := true
-                break
-            }
-        }
-        if (found) {
+        if (shaderKeySet.Has(bgKey)) {
             gFX_HoverEffect := {key: bgKey, name: bgKey,
                 opacity: cfg.GUI_HoverSelectionOpacity,
                 darkness: cfg.GUI_HoverSelectionDarkness,
@@ -880,14 +858,7 @@ _FX_ResolveConfiguredShaders() {
     } else {
         hovSelKey := cfg.GUI_HoverSelectionEffect
         if (hovSelKey != "" && hovSelKey != "None") {
-            found := false
-            for _, k in SELECTION_SHADER_KEYS {
-                if (k = hovSelKey) {
-                    found := true
-                    break
-                }
-            }
-            if (found) {
+            if (selKeySet.Has(hovSelKey)) {
                 gFX_HoverEffect := {key: hovSelKey, name: hovSelKey,
                     opacity: cfg.GUI_HoverSelectionOpacity,
                     darkness: cfg.GUI_HoverSelectionDarkness,

--- a/src/gui/gui_input.ahk
+++ b/src/gui/gui_input.ahk
@@ -573,7 +573,7 @@ GUI_ClearHoverState() {
 }
 
 _GUI_HoverPollTick() {
-    global gGUI_OverlayVisible, gGUI_HoverRow, gGUI_HoverBtn, gGUI_OverlayH
+    global gGUI_OverlayVisible, gGUI_HoverRow, gGUI_HoverBtn, gGUI_OverlayH, gAnim_TimerRunning
 
     ; Stop polling if overlay not visible
     if (!gGUI_OverlayVisible) {
@@ -612,7 +612,9 @@ _GUI_HoverPollTick() {
         gGUI_HoverRow := 0
         gGUI_HoverBtn := ""
         Critical "Off"
-        GUI_Repaint()
+        ; Skip redundant repaint when frame loop is already running (next frame paints it)
+        if (!gAnim_TimerRunning)
+            GUI_Repaint()
     }
 }
 
@@ -653,13 +655,8 @@ _GUI_ScrollBy(step) {
         return
     }
 
-    visEff := vis
-    if (visEff > count) {
-        visEff := count
-    }
-    if (count <= visEff) {
+    if (count <= vis)
         return
-    }
 
     Critical "On"
     gGUI_ScrollTop := Win_Wrap0(gGUI_ScrollTop + step, count)

--- a/src/gui/gui_interceptor.ahk
+++ b/src/gui/gui_interceptor.ahk
@@ -405,32 +405,33 @@ INT_SetBypassMode(shouldBypass) {
     global gINT_BypassMode, cfg
 
     global FR_EV_BYPASS, gFR_Enabled
+    diagLog := cfg.DiagEventLog
     if (shouldBypass && !gINT_BypassMode) {
         ; Entering bypass mode - disable Tab hooks
         if (gFR_Enabled)
             FR_Record(FR_EV_BYPASS, 1)
-        if (cfg.DiagEventLog)
+        if (diagLog)
             GUI_LogEvent("INT: Entering BYPASS MODE, disabling Tab hotkey")
         gINT_BypassMode := true
         try {
             Hotkey("$*Tab", "Off")
             Hotkey("$*Tab Up", "Off")
         } catch as e {
-            if (cfg.DiagEventLog)
+            if (diagLog)
                 GUI_LogEvent("INT: BYPASS Hotkey Off FAILED: " e.Message)
         }
     } else if (!shouldBypass && gINT_BypassMode) {
         ; Leaving bypass mode - re-enable Tab hooks
         if (gFR_Enabled)
             FR_Record(FR_EV_BYPASS, 0)
-        if (cfg.DiagEventLog)
+        if (diagLog)
             GUI_LogEvent("INT: Leaving BYPASS MODE, re-enabling Tab hotkey")
         gINT_BypassMode := false
         try {
             Hotkey("$*Tab", "On")
             Hotkey("$*Tab Up", "On")
         } catch as e {
-            if (cfg.DiagEventLog)
+            if (diagLog)
                 GUI_LogEvent("INT: BYPASS Hotkey On FAILED: " e.Message)
         }
     }
@@ -457,13 +458,13 @@ INT_ReassertTabHotkey() {
 
 _INT_BuildBypassList() {
     global cfg
-    list := []
+    list := Map()
     if (cfg.AltTabBypassProcesses = "")
         return list
     for _, nm in StrSplit(cfg.AltTabBypassProcesses, ",") {
         nm := Trim(nm)
         if (nm != "")
-            list.Push(StrLower(nm))
+            list[StrLower(nm)] := true
     }
     return list
 }
@@ -478,26 +479,26 @@ INT_ShouldBypassWindow(hwnd := 0) {
     if (!hwnd)
         return false
 
+    diagLog := cfg.DiagEventLog
+
     ; Check process blacklist (list pre-computed once per process lifetime)
     static bypassList := _INT_BuildBypassList()
-    if (bypassList.Length > 0) {
+    if (bypassList.Count > 0) {
         exename := ""
         try exename := WinGetProcessName(hwnd)
         if (exename) {
             lex := StrLower(exename)
-            for _, nm in bypassList {
-                if (nm = lex) {
-                    if (cfg.DiagEventLog)
-                        GUI_LogEvent("BYPASS REASON: process='" exename "' hwnd=" hwnd)
-                    return true
-                }
+            if (bypassList.Has(lex)) {
+                if (diagLog)
+                    GUI_LogEvent("BYPASS REASON: process='" exename "' hwnd=" hwnd)
+                return true
             }
         }
     }
 
     ; Check fullscreen detection
     if (cfg.AltTabBypassFullscreen && _INT_IsFullscreenHwnd(hwnd)) {
-        if (cfg.DiagEventLog)
+        if (diagLog)
             GUI_LogEvent("BYPASS REASON: fullscreen hwnd=" hwnd)
         return true
     }

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -370,13 +370,6 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
     if (diagTiming)
         tPO_Resources := QPC() - t1
 
-    ; ===== TIMING: Clear =====
-    if (diagTiming)
-        t1 := QPC()
-    ; Clear already done in GUI_Repaint (BeginDraw + Clear)
-    if (diagTiming)
-        tPO_GraphicsClear := QPC() - t1
-
     scrollTop := gGUI_ScrollTop
 
     cachedLayout := GUI_GetCachedLayout(scale)
@@ -613,7 +606,8 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
                     FX_GPU_DrawHover(hoverX, hoverY, hoverW, RowH, Rad)
                 } else if ((cfg.GUI_HoverARGB >> 24) > 0 || cfg.GUI_HovBorderWidthPx > 0) {
                     ; Path 4: CPU fallback fill + border
-                    if ((cfg.GUI_HoverARGB >> 24) > 0)
+                    hoverAlpha := cfg.GUI_HoverARGB >> 24
+                    if (hoverAlpha > 0)
                         D2D_FillRoundRect(hoverX, hoverY, hoverW, RowH, Rad, D2D_GetCachedBrush(cfg.GUI_HoverARGB))
                     bw := cfg.GUI_HovBorderWidthPx
                     if (bw > 0) {
@@ -732,7 +726,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
         tPO_Total := QPC() - tPO_Start
         idleDuration := (gPaint_LastPaintTick > 0) ? (A_TickCount - gPaint_LastPaintTick) : -1
         if (gPaint_SessionPaintCount <= 1 || idleDuration > 60000 || tPO_Total > 50) {
-            Paint_Log("  PaintOverlay: total=" Round(tPO_Total, 2) "ms | resources=" Round(tPO_Resources, 2) " clear=" Round(tPO_GraphicsClear, 2) " rows=" (IsSet(tPO_RowsTotal) ? Round(tPO_RowsTotal, 2) : 0) " scrollbar=" Round(tPO_Scrollbar, 2) " footer=" Round(tPO_Footer, 2))
+            Paint_Log("  PaintOverlay: total=" Round(tPO_Total, 2) "ms | resources=" Round(tPO_Resources, 2) " rows=" (IsSet(tPO_RowsTotal) ? Round(tPO_RowsTotal, 2) : 0) " scrollbar=" Round(tPO_Scrollbar, 2) " footer=" Round(tPO_Footer, 2))
             if (IsSet(tPO_IconsTotal)) {
                 Paint_Log("    Icons: totalTime=" Round(tPO_IconsTotal, 2) "ms | hits=" iconCacheHits " misses=" iconCacheMisses " rowsDrawn=" rowsToDraw)
             }

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -1213,12 +1213,22 @@ WL_PruneProcNameCache() {
     ; Snapshot keys to prevent iteration-during-modification
     pids := WS_SnapshotMapKeys(gWS_ProcNameCache)
 
-    ; RACE FIX: Wrap delete loop in Critical to prevent interleaving with
-    ; UpdateProcessName which inserts under Critical
+    ; Two-phase: check ProcessExist OUTSIDE Critical (cross-process query ~100-500us each),
+    ; then delete dead PIDs inside Critical (quick Map.Delete only)
+    deadPids := []
+    for _, pid in pids {
+        if (!ProcessExist(pid))
+            deadPids.Push(pid)
+    }
+
+    if (deadPids.Length = 0)
+        return 0
+
+    ; RACE FIX: Only hold Critical for the fast delete loop
     Critical "On"
     pruned := 0
-    for _, pid in pids {
-        if (!ProcessExist(pid)) {
+    for _, pid in deadPids {
+        if (gWS_ProcNameCache.Has(pid)) {
             gWS_ProcNameCache.Delete(pid)  ; lint-ignore: map-delete (pid from SnapshotMapKeys of same map)
             pruned++
         }

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -81,6 +81,7 @@ global _gGUI_LastCosmeticRepaintTick := 0
 ; Animation globals (from gui_animation.ahk - not included in GUI test chain)
 global gAnim_OverlayOpacity := 1.0
 global gAnim_HidePending := false
+global gAnim_TimerRunning := false
 global gFX_AmbientTime := 0.0
 
 ; GPU effects globals (from gui_effects.ahk / gui_paint.ahk - not included in GUI test chain)


### PR DESCRIPTION
## Summary

- **High-impact**: Guard redundant `GUI_Repaint()` in hover poll when frame loop active (~16ms); move `ProcessExist()` outside Critical in both `WL_PruneProcNameCache` and `ProcPump_PruneFailedPidCache` (~1-5ms each)
- **Medium**: Consolidate triple wsMap into single Map in `_KSub_ProcessFullState` (~60μs/event); batch MRU_Lite focus updates; cache `FX_HasActiveShaders()` per frame; bypass list Array→Map for O(1) lookup
- **Trivial/init**: Hoist loop-invariant `ambientSec`; replace 6 linear key scans with Map lookups; static empty effect objects; remove dead timing block; simplify visEff bounds check

Closes #297

## Test plan

- [x] Static analysis pre-gate passes (84 checks)
- [x] Unit tests pass (588 tests across 10 suites)
- [x] GUI state machine tests pass (298 tests)
- [x] Flight recorder tests pass (32 tests)
- [x] Live integration tests pass (64 tests across 6 suites)
- [ ] Manual: Alt+Tab overlay responsiveness during rapid switching
- [ ] Manual: Hover clear visual feedback when frame loop active vs stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)