### PR TITLE
Fix UWP focus events lost during ApplicationFrameHost probe (#302)

### DIFF
--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -330,7 +330,7 @@ _WEH_ProcessBatch() {
     global gWEH_LastFocusHwnd, _WEH_PendingFocusHwnd
     global _WEH_IdleTicks, _WEH_IdleThreshold, _WEH_TimerOn, WinEventHook_BatchMs
     global cfg, gWS_Meta, gKSub_MruSuppressUntilTick, gWS_Store, gWS_OnStoreChanged
-    global FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS, FR_EV_PRODUCER_RECOVER, gFR_Enabled
+    global FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS, FR_EV_FOCUS_PROBE_FAIL, FR_EV_PRODUCER_RECOVER, gFR_Enabled
     global LOG_PATH_STORE
     static _errCount := 0  ; Error boundary: consecutive error tracking
     static _backoffUntil := 0  ; Tick-based cooldown for exponential backoff
@@ -482,8 +482,21 @@ _WEH_ProcessBatch() {
                     _WEH_DiagLog("  PROBE SUPERSEDED: newer focus " _WEH_PendingFocusHwnd " arrived during probe")
             }
         } else {
+            ; Probe failed — likely UWP app with empty title during initialization.
+            ; Fix #302 cascade: update LastFocusHwnd so the NEXT focus event isn't
+            ; skipped as "same hwnd" (line ~440). Without this, both the failed
+            ; window AND the window the user returns to miss their MRU ticks.
+            Critical "On"
+            gWEH_LastFocusHwnd := pendingProbeHwnd
+            Critical "Off"
+            if (gFR_Enabled)
+                FR_Record(FR_EV_FOCUS_PROBE_FAIL, pendingProbeHwnd)
+            ; Schedule escalating retries: UWP apps (ApplicationFrameHost) can take
+            ; 2-3 seconds to populate their title. Retries check if WinEnum's scan
+            ; already discovered the window (fast path) before re-probing.
+            SetTimer(_WEH_RetryFocusProbe.Bind(pendingProbeHwnd, A_TickCount, 1), -300)
             if (logEnabled)
-                _WEH_DiagLog("  NOT ELIGIBLE or probe failed (system UI or blacklisted)")
+                _WEH_DiagLog("  NOT ELIGIBLE or probe failed: LastFocusHwnd=" pendingProbeHwnd ", retry scheduled")
         }
     }
 
@@ -722,6 +735,67 @@ _WEH_ProbeWindow(hwnd) {
     result := WinUtils_ProbeWindow(hwnd, 0, true, true)  ; checkExists=true, checkEligible=true
     Profiler.Leave() ; @profile
     return result
+}
+
+; Deferred retry for focus probes that failed during UWP app initialization.
+; UWP apps (ApplicationFrameHost.exe) can take 2-3 seconds to populate their title,
+; causing WinUtils_ProbeWindow to return "" — the window gets no MRU tick and sorts
+; to the bottom of the Alt-Tab list. Escalating retries at 300ms/1000ms/2500ms
+; cover the observed initialization range. See #302.
+;
+; No superseded check: the MRU tick records a historical fact ("this window had focus
+; at time T"). Even if focus has since moved, the tick is still correct. Only a 10s
+; expiry prevents stale stamps. System UI windows (Search, Start) are filtered by
+; the eligibility probe — they never pass, and retries stop after 3 attempts.
+_WEH_RetryFocusProbe(hwnd, originalTick, attempt) {
+    global gWS_Store, gWS_OnStoreChanged, cfg
+    global gFR_Enabled, FR_EV_FOCUS_RETRY
+
+    ; Expire: don't stamp stale MRU ticks from long-delayed timers
+    if (A_TickCount - originalTick > 10000)
+        return
+
+    ; Fast path: window already in store (WinEnum scan discovered it) — stamp MRU
+    if (gWS_Store.Has(hwnd + 0)) {
+        WL_BatchUpdateFields(Map(hwnd, {lastActivatedTick: originalTick}), "weh_focus_retry")
+        if (gFR_Enabled)
+            FR_Record(FR_EV_FOCUS_RETRY, hwnd, 1)
+        if (gWS_OnStoreChanged)
+            gWS_OnStoreChanged(false)
+        if (cfg.DiagWinEventLog)
+            _WEH_DiagLog("  RETRY OK (in store): hwnd=" hwnd " MRU=" originalTick " attempt=" attempt)
+        return
+    }
+
+    ; Not in store — try full probe
+    probe := WinUtils_ProbeWindow(hwnd, 0, true, true)
+    if (probe && probe.Has("title") && probe["title"] != "") {
+        probe["lastActivatedTick"] := originalTick
+        probe["present"] := true
+        probe["presentNow"] := true
+        WL_UpsertWindow([probe], "winevent_focus_retry")
+        if (gFR_Enabled)
+            FR_Record(FR_EV_FOCUS_RETRY, hwnd, 1)
+        if (gWS_OnStoreChanged)
+            gWS_OnStoreChanged(false)
+        if (cfg.DiagWinEventLog)
+            _WEH_DiagLog("  RETRY OK (probed): hwnd=" hwnd " '" SubStr(probe["title"], 1, 30) "' attempt=" attempt)
+        return
+    }
+
+    ; Probe still fails — schedule next attempt with escalating delay
+    if (attempt < 3) {
+        nextDelay := (attempt = 1) ? 700 : 1500
+        SetTimer(_WEH_RetryFocusProbe.Bind(hwnd, originalTick, attempt + 1), -nextDelay)
+        if (cfg.DiagWinEventLog)
+            _WEH_DiagLog("  RETRY " attempt "/3 FAILED: hwnd=" hwnd ", next in " nextDelay "ms")
+    } else {
+        ; All attempts exhausted
+        if (gFR_Enabled)
+            FR_Record(FR_EV_FOCUS_RETRY, hwnd, 0)
+        if (cfg.DiagWinEventLog)
+            _WEH_DiagLog("  RETRY EXHAUSTED: hwnd=" hwnd " after 3 attempts")
+    }
 }
 
 ; Lightweight update for windows already in the store.

--- a/src/gui/gui_flight_recorder.ahk
+++ b/src/gui/gui_flight_recorder.ahk
@@ -54,6 +54,8 @@ global FR_EV_FOCUS             := 50  ; d1=hwnd — focus changed to window in s
 global FR_EV_FOCUS_SUPPRESS    := 51  ; d1=hwnd d2=remainingMs — focus blocked by MRU suppression
 global FR_EV_KSUB_MRU_STALE   := 52  ; d1=ksubHwnd d2=actualFgHwnd — komorebi stale focus skipped
 global FR_EV_FG_GUARD         := 53  ; d1=hwnd — foreground guard caught missing window at REFRESH time
+global FR_EV_FOCUS_PROBE_FAIL := 54  ; d1=hwnd — focus probe failed (UWP/empty title), retry scheduled
+global FR_EV_FOCUS_RETRY      := 55  ; d1=hwnd d2=success(0/1) — deferred retry of failed focus probe
 
 ; Producer health events (60-69)
 global FR_EV_PRODUCER_BACKOFF  := 60  ; d1=errCount d2=backoffMs — producer entering backoff
@@ -368,6 +370,7 @@ _FR_BuildHwndMap(entries, itemsCopy, fgHwnd) {
     global FR_EV_ACTIVATE_START, FR_EV_ACTIVATE_RESULT, FR_EV_MRU_UPDATE
     global FR_EV_WINDOW_ADD, FR_EV_WINDOW_REMOVE
     global FR_EV_ACTIVATE_GONE, FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS
+    global FR_EV_FOCUS_PROBE_FAIL, FR_EV_FOCUS_RETRY
     global FR_EV_KSUB_MRU_STALE, FR_EV_FG_GUARD
     global FR_EV_DISPLAY_EVICT
     ; Collect all unique hwnds from entries + items + foreground
@@ -379,6 +382,7 @@ _FR_BuildHwndMap(entries, itemsCopy, fgHwnd) {
             || ev = FR_EV_MRU_UPDATE
             || ev = FR_EV_WINDOW_ADD || ev = FR_EV_WINDOW_REMOVE
             || ev = FR_EV_ACTIVATE_GONE || ev = FR_EV_FOCUS || ev = FR_EV_FOCUS_SUPPRESS
+            || ev = FR_EV_FOCUS_PROBE_FAIL || ev = FR_EV_FOCUS_RETRY
             || ev = FR_EV_KSUB_MRU_STALE || ev = FR_EV_FG_GUARD
             || ev = FR_EV_DISPLAY_EVICT) {
             h := entry[3]
@@ -450,7 +454,7 @@ _FR_GetEventName(ev) {
     global FR_EV_SESSION_START, FR_EV_PRODUCER_INIT, FR_EV_ACTIVATE_GONE
     global FR_EV_ACTIVATE_RETRY
     global FR_EV_WS_SWITCH, FR_EV_WS_TOGGLE, FR_EV_MON_TOGGLE
-    global FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS
+    global FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS, FR_EV_FOCUS_PROBE_FAIL, FR_EV_FOCUS_RETRY
     global FR_EV_KSUB_MRU_STALE, FR_EV_FG_GUARD
     global FR_EV_PRODUCER_BACKOFF, FR_EV_PRODUCER_RECOVER
     global FR_EV_PAINT_RESIZE, FR_EV_PAINT_BLOCKED
@@ -492,6 +496,8 @@ _FR_GetEventName(ev) {
         case FR_EV_MON_TOGGLE:        return "MON_TOGGLE"
         case FR_EV_FOCUS:             return "FOCUS"
         case FR_EV_FOCUS_SUPPRESS:    return "FOCUS_SUPPRESS"
+        case FR_EV_FOCUS_PROBE_FAIL: return "FOCUS_PROBE_FAIL"
+        case FR_EV_FOCUS_RETRY:      return "FOCUS_RETRY"
         case FR_EV_KSUB_MRU_STALE:   return "KSUB_MRU_STALE"
         case FR_EV_FG_GUARD:         return "FG_GUARD"
         case FR_EV_PRODUCER_BACKOFF:  return "PRODUCER_BACKOFF"
@@ -528,7 +534,7 @@ _FR_FormatDetails(ev, d1, d2, d3, d4, hwndMap) {
     global FR_EV_SESSION_START, FR_EV_PRODUCER_INIT, FR_EV_ACTIVATE_GONE
     global FR_EV_ACTIVATE_RETRY
     global FR_EV_WS_SWITCH, FR_EV_WS_TOGGLE, FR_EV_MON_TOGGLE
-    global FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS
+    global FR_EV_FOCUS, FR_EV_FOCUS_SUPPRESS, FR_EV_FOCUS_PROBE_FAIL, FR_EV_FOCUS_RETRY
     global FR_EV_KSUB_MRU_STALE, FR_EV_FG_GUARD
     global FR_EV_PRODUCER_BACKOFF, FR_EV_PRODUCER_RECOVER
     global FR_EV_PAINT_RESIZE, FR_EV_PAINT_BLOCKED
@@ -609,6 +615,10 @@ _FR_FormatDetails(ev, d1, d2, d3, d4, hwndMap) {
             return _FR_HwndStr(d1, hwndMap)
         case FR_EV_FOCUS_SUPPRESS:
             return _FR_HwndStr(d1, hwndMap) "  remainMs=" d2
+        case FR_EV_FOCUS_PROBE_FAIL:
+            return _FR_HwndStr(d1, hwndMap)
+        case FR_EV_FOCUS_RETRY:
+            return _FR_HwndStr(d1, hwndMap) "  success=" d2
         case FR_EV_KSUB_MRU_STALE:
             return "ksub=" _FR_HwndStr(d1, hwndMap) "  fg=" _FR_HwndStr(d2, hwndMap)
         case FR_EV_FG_GUARD:


### PR DESCRIPTION
## Summary
- UWP apps (Calculator, Settings, etc.) lost their MRU tick on first launch — sorted to bottom of Alt-Tab list instead of #2
- Root cause: `WinUtils_ProbeWindow` returns empty during UWP initialization (~2-3s), and the probe failure path silently dropped the focus event
- Two-part fix: update `gWEH_LastFocusHwnd` on probe failure (prevents cascade) + escalating retry (300ms/1000ms/2500ms) that checks the store first before re-probing

## Key findings from investigation
- UWP launch fires FOREGROUND events for Search → Start → Calculator in sequence — all fail probing
- 300ms retry is insufficient: Calculator takes ~2.4s to populate its title
- The superseded check (`gWEH_LastFocusHwnd != hwnd`) killed late retries because the user clicks away before the window initializes — replaced with 10s time expiry since the MRU tick is a historical fact
- The store-first check on retry is critical: by attempt 3, WinEnum scan has usually discovered the window already

## Flight recorder observability
Added `FOCUS_PROBE_FAIL` (54) and `FOCUS_RETRY` (55) events — the previously invisible 4.6s gap in dumps is now fully traceable.

## Test plan
- [x] All 1008 tests pass (unit, GUI, live, flight recorder)
- [x] Smoke tested: launch Calculator, switch away immediately, Alt-Tab → Calculator at MRU #2
- [x] Verified via flight recorder: `FOCUS_PROBE_FAIL` → `FOCUS_RETRY success=1` (in store) path works
- [x] Regression: rapid Alt-Tab between normal windows unaffected

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)