### PR TITLE
Fix silent test failures masked as SKIPs (#308)

### DIFF
--- a/tests/test_unit_cleanup.ahk
+++ b/tests/test_unit_cleanup.ahk
@@ -128,7 +128,8 @@ RunUnitTests_Cleanup() {
         sizeBefore := FileGetSize(testLogPath)
 
         if (sizeBefore <= 102400) {
-            Log("SKIP: LogTrim tail test: content only " sizeBefore " bytes (need > 102400)")
+            Log("FAIL: LogTrim tail test: content only " sizeBefore " bytes (need > 102400) - test wrote 128KB but file is too small")
+            TestErrors++
         } else {
             LogTrim(testLogPath)
 

--- a/tests/test_unit_core_config.ahk
+++ b/tests/test_unit_core_config.ahk
@@ -577,7 +577,8 @@ RunUnitTests_CoreConfig() {
     errFiles := []
     for idx, ep in entryPoints {
         if (!FileExist(ep.path)) {
-            Log("SKIP: " ep.name " not found")
+            Log("FAIL: " ep.name " not found at " ep.path)
+            TestErrors++
             pids.Push(0)
             errFiles.Push("")
             continue

--- a/tests/test_unit_setup.ahk
+++ b/tests/test_unit_setup.ahk
@@ -397,7 +397,8 @@ RunUnitTests_Setup() {
             TestErrors++
         }
     } catch as e {
-        Log("SKIP: Could not create test file: " e.Message)
+        Log("FAIL: Could not create test file: " e.Message)
+        TestErrors++
     }
     try FileDelete(smallFile)
 
@@ -418,7 +419,8 @@ RunUnitTests_Setup() {
             TestErrors++
         }
     } catch as e {
-        Log("SKIP: Could not create test file: " e.Message)
+        Log("FAIL: Could not create test file: " e.Message)
+        TestErrors++
     }
     try FileDelete(invalidMZ)
 


### PR DESCRIPTION
## Summary

- Audited all 30 `Log("SKIP:` statements across 9 test files
- Reclassified 4 as silent failures (test sets up the condition itself, so failure = bug, not skip)
- Changed SKIP→FAIL + `TestErrors++` in `test_unit_cleanup.ahk`, `test_unit_core_config.ahk`, `test_unit_setup.ahk`
- Remaining 26 SKIPs are legitimate (external deps, elevation, env state)

Closes #308

## Test plan

- [x] Full test suite passes: 1011/1011 (`.\tests\test.ps1 --live`)
- [ ] Verify no regressions in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)