### PR TITLE
Audit lint-ignore suppressions: prune stale tags and fix violations (#315)

### DIFF
--- a/src/gui/gui_gdip.ahk
+++ b/src/gui/gui_gdip.ahk
@@ -174,39 +174,6 @@ D2D_FillEllipse(x, y, w, h, brush) {
     gD2D_RT.FillEllipse(eBuf, brush)
 }
 
-; Draw ellipse stroke. D2D ellipse uses center point + radii (not bounding box).
-_D2D_DrawEllipse(cx, cy, rx, ry, brush, strokeWidth := 1.0) { ; lint-ignore: dead-function (general D2D utility)
-    global gD2D_RT
-    if (!gD2D_RT)
-        return
-    static eBuf := Buffer(16)
-    NumPut("float", Float(cx), "float", Float(cy),
-           "float", Float(rx), "float", Float(ry), eBuf)
-    gD2D_RT.DrawEllipse(eBuf, brush, strokeWidth)
-}
-
-; Fill rectangle.
-_D2D_FillRect(x, y, w, h, brush) { ; lint-ignore: dead-function
-    global gD2D_RT
-    if (!gD2D_RT)
-        return
-    static rect := Buffer(16)
-    NumPut("float", Float(x), "float", Float(y),
-           "float", Float(x + w), "float", Float(y + h), rect)
-    gD2D_RT.FillRectangle(rect, brush)
-}
-
-; Stroke a rectangle outline.
-_D2D_StrokeRect(x, y, w, h, brush, strokeWidth := 1.0) { ; lint-ignore: dead-function
-    global gD2D_RT
-    if (w <= 0 || h <= 0 || !gD2D_RT)
-        return
-    static rect := Buffer(16)
-    NumPut("float", Float(x), "float", Float(y),
-           "float", Float(x + w), "float", Float(y + h), rect)
-    gD2D_RT.DrawRectangle(rect, brush, strokeWidth, 0)
-}
-
 ; ========================= BRUSH CACHE =========================
 
 ; Get or create a cached D2D solid color brush for the given ARGB color.

--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -250,7 +250,7 @@ Launcher_StartSubprocesses() {
         hwndPath := A_Temp "\" StrLower(exeBase) "_hwnd.txt"
         try FileDelete(hwndPath)
         ; Line 1: launcher HWND, Line 2: gui PID, Line 3: pump PID
-        try FileAppend(A_ScriptHwnd "`n" g_GuiPID "`n" g_PumpPID, hwndPath)  ; lint-ignore: fileappend-encoding
+        try FileAppend(A_ScriptHwnd "`n" g_GuiPID "`n" g_PumpPID, hwndPath, "UTF-8")
     }
 
     ; Hide splash after duration/loops complete

--- a/src/launcher/launcher_tray.ahk
+++ b/src/launcher/launcher_tray.ahk
@@ -497,7 +497,7 @@ ToggleAdminMode() {
             try {
                 ; Create lock file before elevation (will be deleted by elevated instance)
                 try FileDelete(TEMP_ADMIN_TOGGLE_LOCK)
-                FileAppend(A_TickCount, TEMP_ADMIN_TOGGLE_LOCK)  ; lint-ignore: fileappend-encoding
+                FileAppend(A_TickCount, TEMP_ADMIN_TOGGLE_LOCK, "UTF-8")
                 g_AdminToggleInProgress := true  ; lint-ignore: guard-try-finally — async: polling timer resets on completion
                 g_AdminToggleStartTick := A_TickCount  ; Track start time for timeout
 

--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -968,10 +968,6 @@ global gConfigRegistry := [
      min: 0, max: 50,
      d: "Gap between content and footer in pixels"},
 
-    {s: "GUI", k: "FooterPaddingX", g: "GUI_FooterPaddingX", t: "int", default: 12, ; lint-ignore: dead-config
-     min: 0, max: 100,
-     d: "Footer horizontal padding in pixels"},
-
     ; ============================================================
     ; Komorebi Integration
     ; ============================================================

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -279,7 +279,7 @@ AdminToggle_WriteResult(result) {
     try {
         tempPath := TEMP_ADMIN_TOGGLE_LOCK ".tmp"
         try FileDelete(tempPath)
-        FileAppend(result, tempPath)  ; lint-ignore: fileappend-encoding
+        FileAppend(result, tempPath, "UTF-8")
         FileMove(tempPath, TEMP_ADMIN_TOGGLE_LOCK, true)  ; Atomic overwrite
     }
 }
@@ -915,7 +915,7 @@ Update_NeedsElevation(targetDir) {
     ; Try to create a temp file in the target directory
     testFile := targetDir "\alttabby_write_test.tmp"
     try {
-        FileAppend("test", testFile)  ; lint-ignore: fileappend-encoding
+        FileAppend("test", testFile, "UTF-8")
         FileDelete(testFile)
         return false  ; Write succeeded, no elevation needed
     } catch {
@@ -971,7 +971,7 @@ Update_ApplyCore(opts) {
                 FileDelete(lockFile)
             }
         }
-        try FileAppend(A_Now, lockFile)  ; lint-ignore: fileappend-encoding
+        try FileAppend(A_Now, lockFile, "UTF-8")
     }
 
     targetDir := ""

--- a/tests/check_batch_simple_b.ps1
+++ b/tests/check_batch_simple_b.ps1
@@ -1011,21 +1011,14 @@ $liIssues = [System.Collections.ArrayList]::new()
 $validLintNames = [System.Collections.Generic.HashSet[string]]::new()
 @(
     'phantom-global',
-    'singleinstance', 'winexist-cloaked', 'mixed-returns',
+    'mixed-returns',
     'critical-leak',
-    'ipc-constant', 'dllcall-types', 'isset-with-default',
-    'cfg-property', 'duplicate-function',
-    'fileappend-encoding',
-    'send-pattern', 'map-dot-access',
-    'thememsgbox', 'callback-critical', 'onmessage-collision',
-    'postmessage-unsafe', 'callback-signature',
+    'cfg-property',
+    'callback-critical', 'onmessage-collision',
+    'postmessage-unsafe',
     'static-in-timer', 'timer-lifecycle',
-    'dead-function', 'dead-config', 'dead-global', 'dead-local', 'dead-param', 'test-assertions',
-    'arity', 'error-boundary',
-    'onevent-name', 'destroy-untrack',
-    'unreachable-code', 'ipc-symmetry',
-    'callback-null-guard', 'setcallbacks-wiring', 'cosmetic-patch-safety',
-    'registry-duplicate-key', 'registry-completeness', 'registry-section-casing',
+    'dead-function', 'dead-config', 'dead-global', 'dead-param',
+    'error-boundary',
     'map-delete',
     'guard-try-finally'
 ) | ForEach-Object { [void]$validLintNames.Add($_) }


### PR DESCRIPTION
## Summary

- Remove 3 stale dead D2D functions from `gui_gdip.ahk` (`_D2D_DrawEllipse`, `_D2D_FillRect`, `_D2D_StrokeRect` — zero callers)
- Fix 5 `FileAppend` calls to specify `"UTF-8"` encoding instead of suppressing the `fileappend-encoding` check
- Remove unused `GUI_FooterPaddingX` config registry entry (sibling footer configs are used; this one never was)
- Prune lint-ignore tag registry from 39 → 16 entries (remove 24 zero-use tags including `fileappend-encoding` which now has no suppressions)

Net: 104 → 96 suppressions, 39 → 16 registry tags, -44 lines

Closes #315

## Test plan

- [x] Static analysis: all 81 checks pass (including orphan tag checker with pruned registry)
- [x] Unit tests: 559/559 pass
- [x] GUI tests: 351/351 pass
- [x] Flight recorder tests: 32/32 pass
- [x] Core/Network/Features live tests pass
- [ ] Verify orphan checker catches typos: temporarily add `; lint-ignore: bogus-tag` → pre-gate should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)