### PR TITLE
Add query_shader, query_events tools and improve skill coverage (#316)

### DIFF
--- a/.claude/skills/flight-recorder/SKILL.md
+++ b/.claude/skills/flight-recorder/SKILL.md
@@ -78,7 +78,7 @@ When analyzing multiple dumps for the same bug:
 
 ## Event Reference
 
-See `docs/USING_RECORDER.md` for the full event reference table with field descriptions and analysis patterns. Do NOT maintain a separate event list here — read the doc at analysis time.
+Use `query_events.ps1 <name_or_code>` for structured event lookups — shows field meanings (d1-d4) and emitter functions. Use `query_events.ps1` with no args for the full index. See `docs/USING_RECORDER.md` for analysis patterns and worked examples.
 
 ## Reporting
 

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -84,7 +84,7 @@ Match timestamps across sources to build the full picture.
 
 If the cause is clear:
 - Explain the root cause with evidence from the data
-- Point to the relevant code (use query tools — `query_state.ps1` for state machine issues, `query_messages.ps1` for message handlers)
+- Point to the relevant code (use query tools — `query_state.ps1` for state machine issues, `query_messages.ps1` for message handlers, `query_events.ps1 <code>` to look up event field meanings and emitter functions)
 - Suggest whether this is a bug to fix or a known limitation
 
 If the cause is unclear:

--- a/.claude/skills/review-ahk2/SKILL.md
+++ b/.claude/skills/review-ahk2/SKILL.md
@@ -70,6 +70,8 @@ Exclude `src/lib/` (third-party code).
 
 Each explore agent should scan for ALL checklist patterns within its zone, not just one pattern at a time.
 
+Use `query_function_visibility.ps1 <funcName>` to validate whether flagged function call patterns are v1 or v2 — it shows all callers and the definition site, confirming whether indirect references (timers, callbacks) use v1 string syntax or v2 direct refs.
+
 ## Validation
 
 Many v1-looking patterns may actually be correct v2 code. AHK v2 kept some syntax from v1. **Validate every finding yourself** before including it in the plan.

--- a/.claude/skills/review-code-quality/SKILL.md
+++ b/.claude/skills/review-code-quality/SKILL.md
@@ -79,7 +79,7 @@ Split by area for parallel scanning:
 
 Exclude `src/lib/` (third-party code).
 
-Use `query_interface.ps1` to compare module public surfaces — similar API shapes across files can reveal DRY violations or misplaced responsibilities.
+Use `query_interface.ps1` to compare module public surfaces — similar API shapes across files can reveal DRY violations or misplaced responsibilities. Use `query_function.ps1 <funcName>` to read function bodies when evaluating DRY violations without loading full files. Use `query_callchain.ps1 <funcName> -Reverse` to trace callers when checking whether misplaced logic is called from the expected module or from elsewhere.
 
 ## Validation
 

--- a/.claude/skills/review-criticals/SKILL.md
+++ b/.claude/skills/review-criticals/SKILL.md
@@ -83,7 +83,7 @@ Split by file group (run in parallel):
 - **GUI support** — `src/gui/gui_overlay.ahk`, `gui_pump.ahk`, `gui_workspace.ahk`, `gui_win.ahk`, `gui_monitor.ahk`
 - **Shared infrastructure** — `src/shared/window_list.ahk`, `blacklist.ahk`, `ipc_pipe.ahk`, `stats.ahk`
 
-Use `query_timers.ps1` to cross-reference — timer callbacks are the primary interrupt source for non-hotkey Critical sections.
+Use `query_timers.ps1` to cross-reference — timer callbacks are the primary interrupt source for non-hotkey Critical sections. Use `query_mutations.ps1 <globalName>` to see which functions mutate a given global — reveals whether all writers are inside Critical sections without reading full files.
 
 ## Validation
 

--- a/.claude/skills/review-dead-code/SKILL.md
+++ b/.claude/skills/review-dead-code/SKILL.md
@@ -33,6 +33,7 @@ Use the query tools to validate findings — do NOT rely on grep alone:
 - `query_global_ownership.ps1 <globalName>` — who declares, writes, and reads a global
 - `query_interface.ps1 <filename>` — public surface of a file (spot unused exports)
 - `query_visibility.ps1` — lists public functions with 0 or 1 external callers (direct dead code signal)
+- `query_includes.ps1` — include tree for finding orphaned `#Include` files whose exports are entirely unused
 
 For each candidate:
 

--- a/.claude/skills/review-debug/SKILL.md
+++ b/.claude/skills/review-debug/SKILL.md
@@ -38,7 +38,7 @@ See `.claude/rules/debugging.md` for the full list of diagnostic config flags an
 
 ## Explore Strategy
 
-Use `query_timers.ps1` to identify timer callbacks — these often contain diagnostic writes for heartbeat, stats, or producer health checks.
+Use `query_timers.ps1` to identify timer callbacks — these often contain diagnostic writes for heartbeat, stats, or producer health checks. Use `query_callchain.ps1 <logFunc> -Reverse` to trace all callers of logging functions and verify gate coverage. Use `query_function_visibility.ps1 <logFunc>` to find all call sites of diagnostic output functions.
 
 Split into independent zones and explore in parallel:
 

--- a/.claude/skills/review-function-visibility/SKILL.md
+++ b/.claude/skills/review-function-visibility/SKILL.md
@@ -22,6 +22,7 @@ Enter planning mode. Audit function visibility boundaries for cleanup opportunit
 | `query_function_visibility.ps1 <funcName>` | Where defined, public/private, all callers |
 | `query_interface.ps1 <file>` | Public/private function ratios for a file |
 | `query_impact.ps1 <funcName>` | Blast radius of making a function public (downstream callers/readers) |
+| `query_includes.ps1` | Include tree — verify cross-file boundaries when assessing visibility |
 
 ## What to Look For
 

--- a/.claude/skills/review-mcode/SKILL.md
+++ b/.claude/skills/review-mcode/SKILL.md
@@ -12,7 +12,7 @@ MCode replaces AHK-interpreted tight loops with native C machine code embedded a
 
 All four must be true:
 
-1. **Hot path** — called frequently OR scales with data (per-window, per-pixel, per-byte). Use `query_function_visibility.ps1` to check call frequency — a loop called 1x/session vs 100x/sec changes the MCode ROI.
+1. **Hot path** — called frequently OR scales with data (per-window, per-pixel, per-byte). Use `query_function_visibility.ps1` to check call frequency — a loop called 1x/session vs 100x/sec changes the MCode ROI. Use `query_callchain.ps1 <funcName> -Reverse` to trace all invocation contexts. Use `query_timers.ps1` to check if the candidate is inside a timer callback (hot path signal).
 2. **Pure buffer computation** — operates on `Buffer` / `NumGet` / `NumPut`, not AHK objects
 3. **Interpreter-bound** — the bottleneck is AHK loop overhead, not an underlying Win32/native call
 4. **Measurable** — worst-case cost exceeds ~100μs (below that, DllCall overhead eats the savings)

--- a/.claude/skills/review-option-interaction/SKILL.md
+++ b/.claude/skills/review-option-interaction/SKILL.md
@@ -41,7 +41,7 @@ Before testing combinations, build a current inventory by reading the code. Thes
 
 ## Step 2 — Test Combinatorial Paths
 
-For each pair/group of options, trace the user journey through the code. Use `query_callchain.ps1` to follow how config option reads flow through functions across files. Use `query_ipc.ps1` to check cross-process message flows that can trigger option interactions:
+For each pair/group of options, trace the user journey through the code. Use `query_callchain.ps1` to follow how config option reads flow through functions across files. Use `query_ipc.ps1` to check cross-process message flows that can trigger option interactions. Use `query_function_visibility.ps1 <funcName>` to find all callers of elevation/UAC functions. Use `query_global_ownership.ps1 <globalName>` to trace install state ownership across files:
 
 - How does feature X behave when run as admin vs not admin?
 - What happens if UAC is refused at each elevation prompt?

--- a/.claude/skills/review-ownership-manifest/SKILL.md
+++ b/.claude/skills/review-ownership-manifest/SKILL.md
@@ -25,6 +25,7 @@ The manifest lists all files that write to each global (alphabetical, no file is
 | `query_interface.ps1 <file>` | What a file exports (public functions + globals) |
 | `query_function_visibility.ps1 <funcName>` | Where defined, public/private, all callers |
 | `query_function.ps1 <funcName>` | Extract full function body without loading entire file |
+| `query_mutations.ps1 <globalName>` | Detailed per-function mutation sites with assignment operators and values |
 
 ## What to Look For
 

--- a/.claude/skills/review-race-conditions/SKILL.md
+++ b/.claude/skills/review-race-conditions/SKILL.md
@@ -62,6 +62,7 @@ Split by concurrency boundary, not just file location:
 - **IPC handlers** — `ipc_pipe.ahk`, pump files: pipe read/write paths
 - **State machine** — use `query_state.ps1` to extract specific branches from `GUI_OnInterceptorEvent` without loading the full function
 - **Call graph** — use `query_function_visibility.ps1` to map which interrupt sources can reach vulnerable code (e.g., "is this function called from both timer callbacks and hotkey handlers?")
+- **Mutation detail** — use `query_mutations.ps1 <globalName>` to see per-function mutation sites with assignment operators and assigned values — reveals unguarded writes without reading full files
 
 ## Validation
 

--- a/.claude/skills/review-reentrancy/SKILL.md
+++ b/.claude/skills/review-reentrancy/SKILL.md
@@ -173,6 +173,7 @@ Split by path (run in parallel):
 - `query_callchain.ps1 <func> -Reverse` — find callers (verify a COM call is only reached from protected contexts)
 - `query_global_ownership.ps1 gPaint_RepaintInProgress` — verify the reentrancy guard is set/cleared correctly
 - `query_timers.ps1` — identify all timer callbacks that could fire during STA pump
+- `query_state.ps1` — extract state machine branches to identify which state transitions could trigger COM calls or be interrupted by STA pump reentrancy
 
 ## Assessment Format
 

--- a/.claude/skills/review-resource-leaks/SKILL.md
+++ b/.claude/skills/review-resource-leaks/SKILL.md
@@ -72,7 +72,7 @@ Data structures that grow over time without pruning:
 Split by resource type for independent parallel exploration:
 
 - **D2D / GDI+** — `src/gui/gui_paint.ahk`, `src/gui/gui_overlay.ahk`, `src/gui/gui_gdip.ahk`, any file using `D2D_*` functions. Some `Gdip_*` may remain in `src/lib/` but the paint pipeline is D2D now
-- **Win32 handles** — `src/core/` producers, `src/shared/ipc_pipe.ahk`, DllCall-heavy files. Use `query_function_visibility.ps1` to trace cleanup call chains and `query_callchain.ps1 -Reverse` to find all callers that should reach cleanup — verify every Create/Open has a corresponding Close/Delete reachable from all callers.
+- **Win32 handles** — `src/core/` producers, `src/shared/ipc_pipe.ahk`, DllCall-heavy files. Use `query_function_visibility.ps1` to trace cleanup call chains and `query_callchain.ps1 -Reverse` to find all callers that should reach cleanup — verify every Create/Open has a corresponding Close/Delete reachable from all callers. Use `query_global_ownership.ps1 <resource>` to determine who declares and writes resource handles (responsible for cleanup). Use `query_impact.ps1 <cleanup_func>` to assess the blast radius if a cleanup function is missing or broken.
 - **Timers** — use `query_timers.ps1` to inventory all timers, then check each for proper cleanup
 - **Pipe IPC** — `src/shared/ipc_pipe.ahk`, `src/pump/` files
 - **Data growth** — `src/shared/window_list.ahk` (window store), icon/process caches

--- a/.claude/skills/review-shaders/SKILL.md
+++ b/.claude/skills/review-shaders/SKILL.md
@@ -150,6 +150,7 @@ Split by optimization category (run in parallel):
 - Grep for pattern scanning across all HLSL files
 - Read for examining specific shaders in detail
 - The `.glsl` file next to each `.hlsl` is the original Shadertoy source for reference
+- `query_interface.ps1 <file>` — understand the public surface of D3D11 infrastructure files (`d2d_shader.ahk`, `gui_effects.ahk`) when tracing how shaders are loaded and composed
 
 ## Assessment Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,10 @@ Query tools live in `tools/`. Prefer these over reading full files or grepping:
 - `query_function_visibility.ps1 <funcName>` — where defined, public/private, all callers
 - `query_function.ps1 <funcName>` — extract full function body without loading the entire file
 - `query_interface.ps1 <filename>` — public functions + globals for a file (like help(module))
-- `query_config.ps1` — no args: shows section/group index. With keyword: fuzzy search. `-Section <name>`: list section. `-Usage <key>`: which files consume a config value
+- `query_config.ps1` — no args: shows section/group index. With keyword: fuzzy search. `-Section <name>`: list section. `-Usage <key>`: which files consume a config value. `-Format hex` / `-Type int` / `-HasBounds`: metadata filters
 - `query_callchain.ps1 <funcName>` — call graph from a function: what it calls (or `-Reverse` for callers), to `-Depth N` levels. Primary tool for tracing code paths
 
-Additional domain-specific query tools (ipc, timers, impact, mutations, includes, messages, state) exist in `tools/` — run `ls tools/query_*.ps1` to discover when needed.
+Additional domain-specific query tools (ipc, timers, impact, mutations, includes, messages, state, shader, events) exist in `tools/` — run `ls tools/query_*.ps1` to discover when needed.
 
 For deep multi-module flow tracing, use `/trace <question>` — spawns an agent in separate context that uses all query tools and returns only the semantic answer.
 

--- a/tools/query_config.ps1
+++ b/tools/query_config.ps1
@@ -8,12 +8,18 @@
 #   powershell -File tools/query_config.ps1 theme                 (fuzzy search for "theme")
 #   powershell -File tools/query_config.ps1 -Section GUI          (list all settings in a section)
 #   powershell -File tools/query_config.ps1 -Usage GUI_RowHeight  (find all consumers of cfg.X)
+#   powershell -File tools/query_config.ps1 -Format hex           (filter: all color/hex settings)
+#   powershell -File tools/query_config.ps1 -Type int             (filter: all settings of type int/bool/string)
+#   powershell -File tools/query_config.ps1 -HasBounds            (filter: all settings with min/max constraints)
 
 param(
     [Parameter(Position=0)]
     [string]$Search,
     [string]$Section,
-    [string]$Usage
+    [string]$Usage,
+    [string]$Format,
+    [string]$Type,
+    [switch]$HasBounds
 )
 
 $ErrorActionPreference = 'Stop'
@@ -83,10 +89,13 @@ foreach ($rawLine in $rawLines) {
                 $eOptions = ($Matches[1] -split ',' | ForEach-Object { $_.Trim().Trim($q) }) -join ', '
             }
             $eFmt = if ($e -match 'fmt:\s*"([^"]*)"') { $Matches[1] } else { $null }
+            $eMin = if ($e -match '\bmin:\s*(0x[0-9A-Fa-f]+|-?\d+(?:\.\d+)?)') { $Matches[1] } else { $null }
+            $eMax = if ($e -match '\bmax:\s*(0x[0-9A-Fa-f]+|-?\d+(?:\.\d+)?)') { $Matches[1] } else { $null }
 
             [void]$settings.Add(@{
                 S = $eS; K = $eK; G = $eG; T = $eT; D = $eD
                 Default = $eDefault; Options = $eOptions; Fmt = $eFmt
+                Min = $eMin; Max = $eMax
                 SL = $eS.ToLower(); KL = $eK.ToLower(); GL = $eG.ToLower()
                 DL = $eD.ToLower()
             })
@@ -94,6 +103,43 @@ foreach ($rawLine in $rawLines) {
 
         $entryText = ""
     }
+}
+
+# === Metadata filter modes ===
+if ($Format -or $Type -or $HasBounds.IsPresent) {
+    $filtered = [System.Collections.ArrayList]::new()
+    foreach ($st in $settings) {
+        if ($Format -and $st.Fmt -ne $Format) { continue }
+        if ($Type -and $st.T -ne $Type) { continue }
+        if ($HasBounds.IsPresent -and (-not $st.Min -and -not $st.Max)) { continue }
+        [void]$filtered.Add($st)
+    }
+
+    $label = "Filtered settings"
+    if ($Format) { $label = "Settings with fmt=$Format" }
+    elseif ($Type) { $label = "Settings with type=$Type" }
+    elseif ($HasBounds.IsPresent) { $label = "Settings with min/max bounds" }
+
+    Write-Host ""
+    Write-Host "  $label ($($filtered.Count)):" -ForegroundColor White
+    Write-Host ""
+
+    foreach ($st in $filtered) {
+        $typeInfo = "type: $($st.T)"
+        if ($st.Options) { $typeInfo += "  options: $($st.Options)" }
+        $defaultInfo = "default: $($st.Default)"
+        if ($st.Fmt) { $defaultInfo += " [fmt=$($st.Fmt)]" }
+        if ($st.Min -or $st.Max) { $defaultInfo += " [min=$($st.Min) max=$($st.Max)]" }
+
+        Write-Host "  [$($st.S)] $($st.K)  $($st.G)" -ForegroundColor Green
+        Write-Host "    $typeInfo  $defaultInfo" -ForegroundColor DarkGray
+        if ($st.D) {
+            Write-Host "    $($st.D)" -ForegroundColor DarkGray
+        }
+    }
+
+    Write-Host ""
+    exit 0
 }
 
 # === No arguments: show section/group index ===
@@ -116,9 +162,10 @@ if (-not $Search -and -not $Section -and -not $Usage) {
     }
 
     Write-Host ""
-    Write-Host "  Search: query_config.ps1 <keyword>" -ForegroundColor DarkGray
-    Write-Host "  List:   query_config.ps1 -Section <name>" -ForegroundColor DarkGray
-    Write-Host "  Usage:  query_config.ps1 -Usage <propertyName>" -ForegroundColor DarkGray
+    Write-Host "  Search:  query_config.ps1 <keyword>" -ForegroundColor DarkGray
+    Write-Host "  List:    query_config.ps1 -Section <name>" -ForegroundColor DarkGray
+    Write-Host "  Usage:   query_config.ps1 -Usage <propertyName>" -ForegroundColor DarkGray
+    Write-Host "  Filter:  query_config.ps1 -Format hex | -Type int | -HasBounds" -ForegroundColor DarkGray
     Write-Host ""
     exit 0
 }
@@ -214,7 +261,8 @@ if ($Section) {
         $typeInfo = "type: $($st.T)"
         if ($st.Options) { $typeInfo += "  options: $($st.Options)" }
         $defaultInfo = "default: $($st.Default)"
-        if ($st.Fmt -eq 'hex') { $defaultInfo += " [hex]" }
+        if ($st.Fmt) { $defaultInfo += " [fmt=$($st.Fmt)]" }
+        if ($st.Min -or $st.Max) { $defaultInfo += " [min=$($st.Min) max=$($st.Max)]" }
 
         Write-Host "  [$sectionName] $($st.K)  $($st.G)" -ForegroundColor Green
         Write-Host "    $typeInfo  $defaultInfo" -ForegroundColor DarkGray
@@ -274,7 +322,8 @@ foreach ($r in $sorted) {
     $typeInfo = "type: $($st.T)"
     if ($st.Options) { $typeInfo += "  options: $($st.Options)" }
     $defaultInfo = "default: $($st.Default)"
-    if ($st.Fmt -eq 'hex') { $defaultInfo += " [hex]" }
+    if ($st.Fmt) { $defaultInfo += " [fmt=$($st.Fmt)]" }
+    if ($st.Min -or $st.Max) { $defaultInfo += " [min=$($st.Min) max=$($st.Max)]" }
 
     Write-Host "  [$($st.S)] $($st.K)  $($st.G)" -ForegroundColor Green
     Write-Host "    $typeInfo  $defaultInfo" -ForegroundColor DarkGray

--- a/tools/query_events.ps1
+++ b/tools/query_events.ps1
@@ -1,0 +1,227 @@
+# query_events.ps1 - Flight recorder event type query
+#
+# Extracts event code definitions from gui_flight_recorder.ahk without
+# loading the full 700+ line file into context.
+#
+# Usage:
+#   powershell -File tools/query_events.ps1                  (list all event types)
+#   powershell -File tools/query_events.ps1 focus             (fuzzy search by name)
+#   powershell -File tools/query_events.ps1 50                (lookup by numeric code)
+#   powershell -File tools/query_events.ps1 -Emitters         (show which functions emit each event)
+
+param(
+    [Parameter(Position=0)]
+    [string]$Query,
+    [switch]$Emitters
+)
+
+$ErrorActionPreference = 'Stop'
+. "$PSScriptRoot\_query_helpers.ps1"
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+$projectRoot = Split-Path $PSScriptRoot -Parent
+$srcDir = Join-Path $projectRoot "src"
+$frFile = Join-Path $srcDir "gui\gui_flight_recorder.ahk"
+
+if (-not (Test-Path $frFile)) {
+    Write-Host "  ERROR: Cannot find $frFile" -ForegroundColor Red
+    exit 1
+}
+
+# === Parse event code definitions ===
+$events = [System.Collections.ArrayList]::new()
+$stateConstants = [System.Collections.ArrayList]::new()
+$lines = [System.IO.File]::ReadAllLines($frFile)
+$sectionComment = ""
+
+$evRx = [regex]::new('^\s*global\s+(FR_EV_\w+)\s*:=\s*(\d+)\s*;\s*(.*)')
+$stRx = [regex]::new('^\s*global\s+(FR_ST_\w+)\s*:=\s*(\d+)')
+$secRx = [regex]::new(';\s*(\w[\w /]+)\((\d+)-(\d+)\)')
+
+for ($i = 0; $i -lt $lines.Count; $i++) {
+    $line = $lines[$i]
+
+    # Track section comments
+    if ($line -match ';\s*=+\s*(.+?)\s*=+') {
+        if ($Matches[1] -ne "EVENT CODES" -and $Matches[1] -ne "RING BUFFER" -and $Matches[1] -ne "INIT") {
+            $sectionComment = $Matches[1]
+        }
+        continue
+    }
+    $secMatch = $secRx.Match($line)
+    if ($secMatch.Success) {
+        $sectionComment = $secMatch.Groups[1].Value.Trim()
+        continue
+    }
+
+    # Parse event definitions
+    $m = $evRx.Match($line)
+    if ($m.Success) {
+        $name = $m.Groups[1].Value
+        $code = [int]$m.Groups[2].Value
+        $comment = $m.Groups[3].Value.Trim()
+
+        # Parse d1-d4 field descriptions from comment
+        $fields = [System.Collections.ArrayList]::new()
+        foreach ($fm in [regex]::Matches($comment, '(d[1-4])=(\S+(?:\s*\([^)]+\))?)')) {
+            [void]$fields.Add(@{ Field = $fm.Groups[1].Value; Desc = $fm.Groups[2].Value })
+        }
+        # Also capture trailing text after last d= as context
+        $context = $comment -replace 'd[1-4]=\S+(?:\s*\([^)]+\))?\s*', '' | ForEach-Object { $_.Trim() }
+        if ($context -eq '—' -or $context.Length -lt 3) { $context = "" }
+
+        [void]$events.Add(@{
+            Name = $name; Code = $code; Comment = $comment
+            Fields = $fields; Context = $context
+            Section = $sectionComment; Line = ($i + 1)
+        })
+    }
+
+    # Parse state constants (FR_ST_*)
+    $sm = $stRx.Match($line)
+    if ($sm.Success) {
+        [void]$stateConstants.Add(@{ Name = $sm.Groups[1].Value; Value = [int]$sm.Groups[2].Value })
+    }
+}
+
+if ($events.Count -eq 0) {
+    Write-Host "  ERROR: No FR_EV_ constants found in $frFile" -ForegroundColor Red
+    exit 1
+}
+
+# === Find emitters if requested ===
+$emitterMap = @{}
+if ($Emitters.IsPresent -or $Query) {
+    $allFiles = Get-AhkSourceFiles $srcDir
+    foreach ($file in $allFiles) {
+        $fileText = [System.IO.File]::ReadAllText($file.FullName)
+        if ($fileText.IndexOf('FR_Record(', [StringComparison]::Ordinal) -lt 0 -and
+            $fileText.IndexOf('FR_EV_', [StringComparison]::Ordinal) -lt 0) { continue }
+
+        $fileLines = Split-Lines $fileText
+        $relPath = $file.FullName.Replace("$projectRoot\", '')
+        $funcBounds = Build-FuncBoundaryMap $fileLines
+
+        for ($i = 0; $i -lt $fileLines.Count; $i++) {
+            $fl = $fileLines[$i]
+            if ($fl.IndexOf('FR_Record(') -lt 0) { continue }
+            if ($fl -match 'FR_Record\(\s*(FR_EV_\w+)') {
+                $evName = $Matches[1]
+                $funcName = Find-EnclosingFunction $funcBounds $i
+                $lineNum = $i + 1
+                if (-not $emitterMap.ContainsKey($evName)) {
+                    $emitterMap[$evName] = [System.Collections.ArrayList]::new()
+                }
+                [void]$emitterMap[$evName].Add(@{ File = $relPath; Line = $lineNum; Func = $funcName })
+            }
+        }
+    }
+}
+
+# === Apply query filter ===
+$filtered = $events
+if ($Query) {
+    $matches = [System.Collections.ArrayList]::new()
+    # Try numeric code lookup first
+    $numericCode = 0
+    $isNumeric = [int]::TryParse($Query, [ref]$numericCode)
+    if ($isNumeric) {
+        foreach ($ev in $events) {
+            if ($ev.Code -eq $numericCode) { [void]$matches.Add($ev) }
+        }
+    }
+    if ($matches.Count -eq 0) {
+        $qLower = $Query.ToLower()
+        foreach ($ev in $events) {
+            if ($ev.Name.ToLower().Contains($qLower) -or $ev.Comment.ToLower().Contains($qLower)) {
+                [void]$matches.Add($ev)
+            }
+        }
+    }
+    $filtered = $matches
+}
+
+if ($filtered.Count -eq 0 -and $Query) {
+    Write-Host "`n  No events matching '$Query'" -ForegroundColor Red
+    Write-Host "  Total: $($events.Count) event types"
+    Write-Host ""; exit 1
+}
+
+# === Output ===
+if ($Query -and $filtered.Count -le 5) {
+    # Detail mode
+    foreach ($ev in $filtered) {
+        Write-Host ""
+        Write-Host "  $($ev.Name)  (code $($ev.Code))" -ForegroundColor White
+        Write-Host "    section: $($ev.Section)" -ForegroundColor DarkGray
+        Write-Host "    defined: gui_flight_recorder.ahk:$($ev.Line)" -ForegroundColor DarkGray
+        if ($ev.Fields.Count -gt 0) {
+            Write-Host "    fields:" -ForegroundColor Cyan
+            foreach ($f in $ev.Fields) {
+                Write-Host "      $($f.Field) = $($f.Desc)" -ForegroundColor Green
+            }
+        } else {
+            Write-Host "    fields:  (none)" -ForegroundColor DarkGray
+        }
+        if ($ev.Context) {
+            Write-Host "    note:    $($ev.Context)" -ForegroundColor DarkGray
+        }
+        # Show emitters
+        $evEmits = $emitterMap[$ev.Name]
+        if ($evEmits -and $evEmits.Count -gt 0) {
+            Write-Host "    emitters:" -ForegroundColor Cyan
+            foreach ($e in ($evEmits | Sort-Object { $_.File }, { $_.Line })) {
+                Write-Host "      $($e.File):$($e.Line)  [$($e.Func)]" -ForegroundColor Green
+            }
+        } elseif ($Emitters) {
+            Write-Host "    emitters: (none found)" -ForegroundColor DarkGray
+        }
+    }
+} else {
+    # Table mode — group by section
+    Write-Host ""
+    $title = if ($Query) { "Events matching '$Query'" } else { "Flight Recorder Event Types" }
+    Write-Host "  $title ($($filtered.Count)):" -ForegroundColor White
+
+    $currentSection = ""
+    $maxNameLen = ($filtered | ForEach-Object { $_.Name.Length } | Measure-Object -Maximum).Maximum
+    $maxCodeLen = ($filtered | ForEach-Object { "$($_.Code)".Length } | Measure-Object -Maximum).Maximum
+
+    foreach ($ev in ($filtered | Sort-Object { $_.Code })) {
+        if ($ev.Section -ne $currentSection) {
+            $currentSection = $ev.Section
+            Write-Host ""
+            Write-Host "    ; $currentSection" -ForegroundColor DarkGray
+        }
+        $nameStr = $ev.Name.PadRight($maxNameLen + 2)
+        $codeStr = "$($ev.Code)".PadLeft($maxCodeLen)
+        $fieldStr = if ($ev.Fields.Count -gt 0) {
+            ($ev.Fields | ForEach-Object { "$($_.Field)=$($_.Desc)" }) -join ' '
+        } else { "" }
+
+        Write-Host "    $codeStr  $nameStr $fieldStr" -ForegroundColor Cyan
+
+        if ($Emitters) {
+            $evEmits = $emitterMap[$ev.Name]
+            if ($evEmits) {
+                foreach ($e in ($evEmits | Sort-Object { $_.File })) {
+                    Write-Host "          -> $($e.File):$($e.Line) [$($e.Func)]" -ForegroundColor DarkGray
+                }
+            }
+        }
+    }
+
+    # State constants
+    if (-not $Query -and $stateConstants.Count -gt 0) {
+        Write-Host ""
+        Write-Host "    ; State code constants (FR_EV_STATE d1)" -ForegroundColor DarkGray
+        foreach ($sc in $stateConstants) {
+            Write-Host "    $($sc.Value)  $($sc.Name)" -ForegroundColor Yellow
+        }
+    }
+}
+
+Write-Host ""
+$elapsed = $sw.ElapsedMilliseconds
+Write-Host "  Total: $($events.Count) event types across $(@($filtered | ForEach-Object { $_.Section } | Select-Object -Unique).Count) sections" -ForegroundColor DarkGray
+Write-Host "  Completed in ${elapsed}ms" -ForegroundColor DarkGray

--- a/tools/query_shader.ps1
+++ b/tools/query_shader.ps1
@@ -1,0 +1,185 @@
+# query_shader.ps1 - Shader metadata query
+#
+# Extracts shader metadata from the auto-generated shader_bundle.ahk without
+# loading the full 1100+ line file into context.
+#
+# Usage:
+#   powershell -File tools/query_shader.ps1                  (list all shaders with summary)
+#   powershell -File tools/query_shader.ps1 fire              (fuzzy search by name/key)
+#   powershell -File tools/query_shader.ps1 -Category mouse   (filter: background, mouse, selection)
+#   powershell -File tools/query_shader.ps1 -Compute           (list only compute-enabled shaders)
+#   powershell -File tools/query_shader.ps1 -Textures          (list only shaders with iChannel textures)
+
+param(
+    [Parameter(Position=0)]
+    [string]$Query,
+    [string]$Category,
+    [switch]$Compute,
+    [switch]$Textures
+)
+
+$ErrorActionPreference = 'Stop'
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+$projectRoot = Split-Path $PSScriptRoot -Parent
+$bundleFile = Join-Path $projectRoot "src\gui\shader_bundle.ahk"
+$resourceFile = Join-Path $projectRoot "src\gui\shader_resources.ahk"
+
+if (-not (Test-Path $bundleFile)) {
+    Write-Host "  ERROR: Cannot find $bundleFile" -ForegroundColor Red
+    exit 1
+}
+
+# === Parse name/key arrays ===
+$bundleText = [System.IO.File]::ReadAllText($bundleFile)
+
+function Parse-ArrayLine {
+    param([string]$Text, [string]$VarName)
+    if ($Text -match "global $VarName\s*:=\s*\[(.+)\]") {
+        $raw = $Matches[1]
+        $items = [System.Collections.ArrayList]::new()
+        foreach ($m in [regex]::Matches($raw, '"([^"]*)"')) {
+            [void]$items.Add($m.Groups[1].Value)
+        }
+        return ,$items
+    }
+    return ,@()
+}
+
+$bgNames = Parse-ArrayLine $bundleText "SHADER_NAMES"
+$bgKeys = Parse-ArrayLine $bundleText "SHADER_KEYS"
+$mouseNames = Parse-ArrayLine $bundleText "MOUSE_SHADER_NAMES"
+$mouseKeys = Parse-ArrayLine $bundleText "MOUSE_SHADER_KEYS"
+$selNames = Parse-ArrayLine $bundleText "SELECTION_SHADER_NAMES"
+$selKeys = Parse-ArrayLine $bundleText "SELECTION_SHADER_KEYS"
+
+# === Parse meta functions for iChannel and compute info ===
+# Match meta functions — use greedy brace matching for nested objects (iChannels)
+$metaRx = [regex]::new('_Shader_Meta_(\w+)\(\)\s*\{\s*return\s*(\{.+?\})\s*\}', 'Singleline')
+$metaMap = @{}
+foreach ($m in $metaRx.Matches($bundleText)) {
+    $funcName = $m.Groups[1].Value
+    $body = $m.Groups[2].Value
+    $hasCompute = $body.Contains('compute:')
+    $channelCount = ([regex]::Matches($body, 'index:\s*\d+')).Count
+    $metaMap[$funcName] = @{ Compute = $hasCompute; Channels = $channelCount; Raw = $body.Trim() }
+}
+
+# === Parse registration lines to map key → registration type ===
+$registerRx = [regex]::new('case\s+"(\w+)":\s+Shader_(RegisterComputeFromResource|RegisterFromResource|RegisterComputeFromFile|RegisterFromFile)\("([^"]+)",[^,]+,\s*_Shader_Meta_(\w+)\(\)')
+$regMap = @{}
+foreach ($m in $registerRx.Matches($bundleText)) {
+    $key = $m.Groups[1].Value
+    $regType = $m.Groups[2].Value
+    $metaFunc = $m.Groups[4].Value
+    $regMap[$key] = @{ MetaFunc = $metaFunc; RegType = $regType }
+}
+
+# === Parse texture resource IDs from shader_resources.ahk ===
+$textureCount = 0
+if (Test-Path $resourceFile) {
+    $resText = [System.IO.File]::ReadAllText($resourceFile)
+    $textureCount = ([regex]::Matches($resText, 'Ahk2Exe-AddResource .+shaders.+\.(png|jpg)')).Count
+}
+
+# === Build unified shader list ===
+$shaders = [System.Collections.ArrayList]::new()
+
+function Add-Shaders {
+    param($Names, $Keys, [string]$Cat)
+    for ($i = 0; $i -lt $Names.Count; $i++) {
+        $name = $Names[$i]
+        $key = $Keys[$i]
+        if (-not $key) { continue }  # Skip "None" entries
+        $reg = $regMap[$key]
+        $meta = if ($reg) { $metaMap[$reg.MetaFunc] } else { $null }
+        $hasCompute = if ($meta) { $meta.Compute } else { $false }
+        $channels = if ($meta) { $meta.Channels } else { 0 }
+        [void]$shaders.Add(@{
+            Name = $name; Key = $key; Category = $Cat
+            Compute = $hasCompute; Channels = $channels
+            MetaFunc = if ($reg) { $reg.MetaFunc } else { "" }
+        })
+    }
+}
+
+Add-Shaders $bgNames $bgKeys "background"
+Add-Shaders $mouseNames $mouseKeys "mouse"
+Add-Shaders $selNames $selKeys "selection"
+
+# === Apply filters ===
+$filtered = $shaders
+
+if ($Category) {
+    $catLower = $Category.ToLower()
+    $filtered = @($filtered | Where-Object { $_.Category -eq $catLower })
+}
+if ($Compute) {
+    $filtered = @($filtered | Where-Object { $_.Compute })
+}
+if ($Textures) {
+    $filtered = @($filtered | Where-Object { $_.Channels -gt 0 })
+}
+if ($Query) {
+    $qLower = $Query.ToLower()
+    $filtered = @($filtered | Where-Object {
+        $_.Name.ToLower().Contains($qLower) -or $_.Key.ToLower().Contains($qLower)
+    })
+}
+
+# === Output ===
+if ($filtered.Count -eq 0 -and $Query) {
+    Write-Host "`n  No shaders matching '$Query'" -ForegroundColor Red
+    Write-Host "  Total: $($shaders.Count) shaders ($($bgNames.Count - 1) background, $($mouseNames.Count - 1) mouse, $($selNames.Count - 1) selection)"
+    Write-Host ""; exit 1
+}
+
+if ($filtered.Count -eq 1 -or ($Query -and $filtered.Count -le 3)) {
+    # Detail mode
+    foreach ($s in $filtered) {
+        $meta = if ($s.MetaFunc) { $metaMap[$s.MetaFunc] } else { $null }
+        Write-Host ""
+        Write-Host "  $($s.Name)" -ForegroundColor White
+        Write-Host "    key:      $($s.Key)" -ForegroundColor Cyan
+        Write-Host "    category: $($s.Category)" -ForegroundColor Cyan
+        Write-Host "    compute:  $(if ($s.Compute) { 'yes (compute + pixel shader)' } else { 'no (pixel shader only)' })" -ForegroundColor $(if ($s.Compute) { "Green" } else { "DarkGray" })
+        Write-Host "    textures: $(if ($s.Channels -gt 0) { "$($s.Channels) iChannel(s)" } else { 'none' })" -ForegroundColor $(if ($s.Channels -gt 0) { "Green" } else { "DarkGray" })
+        if ($meta) {
+            Write-Host "    meta:     $($meta.Raw)" -ForegroundColor DarkGray
+        }
+    }
+} else {
+    # Table mode
+    $title = "Shaders"
+    if ($Category) { $title = "$Category shaders" }
+    elseif ($Compute) { $title = "Compute-enabled shaders" }
+    elseif ($Textures) { $title = "Shaders with textures" }
+    elseif ($Query) { $title = "Shaders matching '$Query'" }
+
+    Write-Host ""
+    Write-Host "  $title ($($filtered.Count)):" -ForegroundColor White
+    Write-Host ""
+
+    $maxNameLen = ($filtered | ForEach-Object { $_.Name.Length } | Measure-Object -Maximum).Maximum
+    $maxNameLen = [Math]::Min($maxNameLen, 45)
+
+    foreach ($s in ($filtered | Sort-Object { $_.Category }, { $_.Name })) {
+        $nameStr = $s.Name.PadRight($maxNameLen + 2)
+        $catStr = $s.Category.PadRight(12)
+        $flags = ""
+        if ($s.Compute) { $flags += "CS " }
+        if ($s.Channels -gt 0) { $flags += "T$($s.Channels) " }
+        $color = switch ($s.Category) { "background" { "Cyan" } "mouse" { "Green" } "selection" { "Yellow" } }
+        Write-Host "    $nameStr $catStr $flags" -ForegroundColor $color
+    }
+}
+
+Write-Host ""
+$totalBg = $bgNames.Count - 1
+$totalMouse = $mouseNames.Count - 1
+$totalSel = $selNames.Count - 1
+$totalCompute = @($shaders | Where-Object { $_.Compute }).Count
+$totalTextured = @($shaders | Where-Object { $_.Channels -gt 0 }).Count
+Write-Host "  Total: $($shaders.Count) shaders ($totalBg bg, $totalMouse mouse, $totalSel selection) | $totalCompute compute | $totalTextured textured | $textureCount texture resources" -ForegroundColor DarkGray
+$elapsed = $sw.ElapsedMilliseconds
+Write-Host "  Completed in ${elapsed}ms" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary

- **New tools**: `query_shader.ps1` (shader metadata from 1600-line auto-generated bundle) and `query_events.ps1` (flight recorder event codes with field meanings and emitter functions)
- **Extended `query_config.ps1`**: added `-Format hex`, `-Type int|bool|string`, `-HasBounds` metadata filters with proper hex min/max parsing
- **15 skill cross-references**: added missing query tool references so review agents use structured lookups — key adoptions: `query_mutations` (0→3 skills), `query_includes` (0→2 skills), `query_events` (0→2 skills)
- **Documentation**: updated CLAUDE.md query tools section, flight-recorder and investigate skills

Closes #316

## Test plan

- [x] Static analysis pre-gate passes (all 85 checks)
- [x] `query_shader.ps1`: no-args list, fuzzy search (`ember`), `-Compute`, `-Textures`, `-Category selection`
- [x] `query_events.ps1`: no-args list, fuzzy search (`focus`), code lookup (`50`), `-Emitters`
- [x] `query_config.ps1`: `-Format hex`, `-Type bool`, `-HasBounds` — all return correct filtered results
- [ ] Spot-check that updated skills load without error when invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)