### PR TITLE
Fix stale identifiers and rules drift in review skills (#321)

### DIFF
--- a/.claude/skills/review-blocking/SKILL.md
+++ b/.claude/skills/review-blocking/SKILL.md
@@ -82,7 +82,7 @@ Use `query_state.ps1` to determine if a blocking function is only reachable from
 **Critical section duration:**
 - Work inside `Critical "On"` ... `Critical "Off"` that doesn't need the interrupt lock
 - Computations that could be moved before Critical or after Critical
-- Note: Do NOT suggest removing Critical sections or restructuring them — that's `review-race-conditions` territory. Only suggest moving non-critical work outside the existing boundaries.
+- Note: Do NOT suggest removing Critical sections or restructuring them — that's `review-criticals` territory. Only suggest moving non-critical work outside the existing boundaries.
 
 **Cache opportunities:**
 - Pure computations (same input → same output) that are called repeatedly with the same arguments
@@ -92,7 +92,7 @@ Use `query_state.ps1` to determine if a blocking function is only reachable from
 
 - **Algorithmic changes that alter the function's contract** — changing sort order, filtering differently, returning different data
 - **Moving work to a different function or restructuring call patterns** — that's `review-latency` territory
-- **Removing Critical sections or changing their scope** — that's `review-race-conditions` territory
+- **Removing Critical sections or changing their scope** — that's `review-criticals` territory
 - **Buffer loops suitable for MCode** — that's `review-mcode` territory (but do note if you spot one, as a cross-reference)
 
 ### Micro-audit output (per function)

--- a/.claude/skills/review-criticals/SKILL.md
+++ b/.claude/skills/review-criticals/SKILL.md
@@ -66,9 +66,10 @@ This is not "is this a good idea" — it's "name the exact interleaving." What i
 
 These Critical sections have been deliberately designed, tested, and documented. Do not propose removing, narrowing, or questioning them:
 
-- **`Critical "On"` through the entire `GUI_OnInterceptorEvent` handler including GDI+ rendering** (~16ms). This was previously narrowed and reverted — releasing before render causes partial glass background, window mapping corruption, and stale projection data. See `keyboard-hooks.md` "Do NOT Release Critical Before Rendering." This is the most important Critical section in the codebase.
+- **`Critical "On"` through the entire `GUI_OnInterceptorEvent` handler including GDI+ rendering** (~16ms). This was previously narrowed and reverted — releasing before render causes partial glass background, window mapping corruption, and stale projection data. See `keyboard-hooks.md` "CRITICAL: Critical Sections During Rendering (Context-Dependent)." No internal abort points — unsafe to interrupt. This is the most important Critical section in the codebase.
 - **`Critical "On"` in `_INT_Alt_Down`, `_INT_Alt_Up`, `_INT_Tab_Down`, `_INT_Tab_Up`, `_INT_Tab_Decide`, `_INT_Ctrl_Down`, `_INT_Escape_Down`** — all hotkey callbacks require Critical to prevent callback-interrupting-callback corruption.
 - **`Critical "On"` in `_Anim_FrameLoop`** — covers `_Anim_UpdateTweens()` → `GUI_Repaint()` → DComp sync. Phase 1 (#177) deliberately moved the long blocking wait (compositor clock / waitable swap chain) OUTSIDE Critical so the AHK message pump runs during the wait. The Critical section is only held during the render + present + commit sequence. This is the intended design.
+- **`Critical "Off"` before `_GUI_ShowOverlayWithFrozen()` in `_GUI_GraceTimerFired`** — must release before the 1-2s first paint or Windows' `LowLevelHooksTimeout` (~300ms) silently removes hooks (#303). This is safe because the show path has 3 RACE FIX abort points that detect `gGUI_State != "ACTIVE"`. This is the deliberate opposite of `GUI_OnInterceptorEvent` — context-dependent rule, see `keyboard-hooks.md`.
 - **Async activation event buffer** (`gGUI_EventBuffer`) — Critical around buffer push/pop is necessary by design.
 - **Flight recorder `FR_Record()`** — if it uses Critical, it's protecting the ring buffer write pointer. Pre-allocated, intentional.
 

--- a/.claude/skills/review-debug/SKILL.md
+++ b/.claude/skills/review-debug/SKILL.md
@@ -16,13 +16,13 @@ Enter planning mode. Systematically audit all debug logging, tooltips, and diagn
 
 **Ungated outputs (problem):**
 - `FileAppend` / `FileOpen` for log files without a config guard
-- `Tooltip` calls outside of `cfg.AltTabTooltips` guard
+- `Tooltip` calls outside of `cfg.DiagAltTabTooltips` guard
 - `OutputDebug` calls left in production paths (acceptable in dev-only or rarely-hit error paths)
 - String concatenation for log messages evaluated before the config guard (see `ahk-patterns.md` caller-side log guards rule)
 
 **Correctly gated (not a problem):**
 - `if (cfg.DiagChurnLog)` → `FileAppend ...`
-- `if (cfg.AltTabTooltips)` → `Tooltip ...`
+- `if (cfg.DiagAltTabTooltips)` → `Tooltip ...`
 - `_GUI_LogError()` — always-on by design, only for actual errors
 - Flight recorder `FR_Record()` — near-zero cost by design (pre-allocated ring buffer)
 

--- a/.claude/skills/review-latency/SKILL.md
+++ b/.claude/skills/review-latency/SKILL.md
@@ -118,7 +118,7 @@ This is separate from the two paths above — even if Path 1 and Path 2 are indi
 Split by hot path (run in parallel):
 
 - **Path 1 agent**: All producers in `src/core/`, eligibility in `blacklist.ahk`, store internals in `window_list.ahk`. Focus on per-event callback cost.
-- **Path 2 agent**: `gui_interceptor.ahk`, `gui_state.ahk`, `gui_input.ahk`, `gui_data.ahk`, `gui_overlay.ahk`, `gui_antiflash.ahk`, `gui_workspace.ahk`. Focus on keypress-to-paint-call and paint-done-to-visible sequences. Do NOT audit the rendering pipeline itself.
+- **Path 2 agent**: `gui_interceptor.ahk`, `gui_state.ahk`, `gui_input.ahk`, `gui_data.ahk`, `gui_overlay.ahk`, `src/shared/gui_antiflash.ahk`, `gui_workspace.ahk`. Focus on keypress-to-paint-call and paint-done-to-visible sequences. Do NOT audit the rendering pipeline itself.
 - **Cross-cutting agent**: `query_timers.ps1` output, Critical section durations, any synchronous I/O on the main thread. Scan all `src/gui/` and `src/core/` files for blocking operations.
 
 ### Tools

--- a/.claude/skills/review-race-conditions/SKILL.md
+++ b/.claude/skills/review-race-conditions/SKILL.md
@@ -45,7 +45,7 @@ These have been deliberately designed and tested — flagging them wastes time:
 
 - `Critical "On"` held through the entire `GUI_OnInterceptorEvent` handler including rendering (~16ms). This is intentional — releasing early causes corruption.
 - `SendMode("Event")` instead of `SendInput` — prevents hook uninstall during sends.
-- Async activation with `gGUI_EventBuffer` — events buffered while `gGUI_PendingPhase != ""`.
+- Async activation with `gGUI_EventBuffer` — events buffered while `gGUI_Pending.phase != ""`.
 - Lost Tab synthesis (`ALT_DN` + `ALT_UP` without `TAB`).
 - Flight recorder `FR_Record()` — pre-allocated ring buffer, writes are inherently safe.
 - `_GUI_LogError()` — always-on by design.

--- a/.claude/skills/review-static-history/SKILL.md
+++ b/.claude/skills/review-static-history/SKILL.md
@@ -32,7 +32,7 @@ Group fix commits by root cause class. Use occurrence count as a signal, not a h
 Cross-reference each pattern against the current pre-gate inventory:
 
 **Already caught** (validate these are working):
-- Missing `global` declaration → `check_batch_simple.ps1` (switch_global sub-check) + `query_global_ownership.ps1 -Check`
+- Missing `global` declaration → `check_batch_simple_b.ps1` (switch_global sub-check) + `query_global_ownership.ps1 -Check`
 - Cross-file private function calls → `query_function_visibility.ps1 -Check`
 - Ownership violations → `query_global_ownership.ps1 -Check`
 

--- a/.claude/skills/review-test-skips/SKILL.md
+++ b/.claude/skills/review-test-skips/SKILL.md
@@ -38,3 +38,5 @@ If the test **set up the condition itself** (launched the exe, connected the pum
 
 5. If any silent failures are found, fix them: change `SKIP` to `FAIL` and add `TestErrors++`
 6. Run `.\tests\test.ps1 --live` to confirm all tests still pass after changes
+
+Ignore any existing plans — create a fresh one.


### PR DESCRIPTION
## Summary

- Fix 3 broken identifiers: `gGUI_PendingPhase` → `gGUI_Pending.phase`, `cfg.AltTabTooltips` → `cfg.DiagAltTabTooltips`, `check_batch_simple.ps1` → `check_batch_simple_b.ps1`
- Fix rules drift in review-criticals: correct non-existent section reference, add `_GUI_GraceTimerFired` Critical release as Known Safe pattern (#303)
- Fix cross-skill scope misdirection in review-blocking: Critical scope changes belong to `review-criticals`, not `review-race-conditions`
- Fix ambiguous `gui_antiflash.ahk` path in review-latency explore strategy
- Add missing closing line in review-test-skips

Closes #321

## Test plan

- [ ] Verify `gGUI_Pending.phase` matches actual code in `gui_activation.ahk` and `gui_state.ahk`
- [ ] Verify `cfg.DiagAltTabTooltips` matches actual config property in `gui_state.ahk:323`
- [ ] Verify `check_batch_simple_b.ps1` contains the `switch_global` sub-check
- [ ] Verify `keyboard-hooks.md` section heading matches updated reference in review-criticals
- [ ] Verify review-criticals Known Safe now covers `_GUI_GraceTimerFired`

🤖 Generated with [Claude Code](https://claude.com/claude-code)