### PR TITLE
Release raw IApplicationViewCollection COM pointer on exit (#324)

### DIFF
--- a/src/gui/gui_activation.ahk
+++ b/src/gui/gui_activation.ahk
@@ -741,7 +741,9 @@ GUI_ReleaseComObjects() {
     global gGUI_Pending, gGUI_ImmersiveShell, gGUI_AppViewCollection
     gGUI_Pending.shell := ""
     gGUI_ImmersiveShell := ""
-    gGUI_AppViewCollection := ""
+    if (gGUI_AppViewCollection)
+        ObjRelease(gGUI_AppViewCollection)
+    gGUI_AppViewCollection := 0
 }
 
 ; Check if a window is cloaked via DWM


### PR DESCRIPTION
## Summary

- `gGUI_AppViewCollection` is a raw COM pointer obtained via `DllCall(QueryService, ...)` — stored as an integer, not a `ComObject` wrapper
- `GUI_ReleaseComObjects()` was clearing it with `= ""`, which does **not** call `Release()` on the underlying COM interface
- Added `ObjRelease(gGUI_AppViewCollection)` before clearing to properly release the reference

Closes #324

## Test plan

- [x] All 1006 tests pass (unit, GUI, live, flight recorder)
- [ ] Manual: start Alt-Tabby, trigger cross-workspace activation (initializes IApplicationViewCollection), exit cleanly — verify no COM ref leak via Process Explorer handle count

🤖 Generated with [Claude Code](https://claude.com/claude-code)