### PR TITLE
Promote pump + komorebi-lite constants to config registry (#328)

### DIFF
--- a/src/core/komorebi_lite.ahk
+++ b/src/core/komorebi_lite.ahk
@@ -17,10 +17,11 @@ global _KLite_PendingStart := 0    ; A_TickCount when query started
 global _KLite_PendingTimeout := 2000  ; Max wait time (ms)
 
 KomorebiLite_Init() {
+    global cfg
     ; Check if komorebi is available before starting timer
     if (!_KomorebiLite_IsAvailable())
         return false
-    SetTimer(_KomorebiLite_Tick, 1000)
+    SetTimer(_KomorebiLite_Tick, cfg.KomorebiLitePollMs)
     return true
 }
 

--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -29,6 +29,7 @@ global _WEH_TimerOn := false
 global _WEH_ShellWindow := 0
 global _WEH_IdleTicks := 0                ; Counter for consecutive empty ticks
 global _WEH_IdleThreshold := 10           ; Default, overridden from config in WinEventHook_Start()
+global FOCUS_PROBE_EXPIRY_MS := 10000     ; Max age for MRU timestamp before focus probe is considered stale
 
 ; MRU tracking (replaces MRU_Lite when hook is active)
 global gWEH_LastFocusHwnd := 0
@@ -752,7 +753,8 @@ _WEH_RetryFocusProbe(hwnd, originalTick, attempt) {
     global gFR_Enabled, FR_EV_FOCUS_RETRY
 
     ; Expire: don't stamp stale MRU ticks from long-delayed timers
-    if (A_TickCount - originalTick > 10000)
+    global FOCUS_PROBE_EXPIRY_MS
+    if (A_TickCount - originalTick > FOCUS_PROBE_EXPIRY_MS)
         return
 
     ; Fast path: window already in store (WinEnum scan discovered it) — stamp MRU

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -29,9 +29,10 @@ global gAnim_SelNewIndex := 0         ; New selection index (for slide Y calc)
 global gFX_AmbientTime := 0.0         ; Cumulative ms for ambient loops (Full mode)
 
 ; FPS debug counter state
+global FPS_SAMPLE_INTERVAL_MS := 500  ; How often to update the debug FPS readout
 global gAnim_FPSFrameCount := 0
 global gAnim_FPSLastSample := 0.0
-global gAnim_FPSDisplay := 0          ; Displayed FPS (updated every 500ms)
+global gAnim_FPSDisplay := 0          ; Displayed FPS (updated every FPS_SAMPLE_INTERVAL_MS)
 
 ; Compositor Clock state (Win11+ display-adaptive pacing)
 global gAnim_pWaitForClock := 0    ; Function ptr: DCompositionWaitForCompositorClock (0 = unavailable)
@@ -507,10 +508,10 @@ Anim_EaseOutQuad(t) {
 ; ========================= FPS DEBUG OVERLAY =========================
 
 _Anim_UpdateFPSCounter(now) {
-    global gAnim_FPSFrameCount, gAnim_FPSLastSample, gAnim_FPSDisplay
+    global gAnim_FPSFrameCount, gAnim_FPSLastSample, gAnim_FPSDisplay, FPS_SAMPLE_INTERVAL_MS
     gAnim_FPSFrameCount += 1
     elapsed := now - gAnim_FPSLastSample
-    if (elapsed >= 500.0) {  ; Update every 500ms
+    if (elapsed >= FPS_SAMPLE_INTERVAL_MS) {
         gAnim_FPSDisplay := Round(gAnim_FPSFrameCount / (elapsed / 1000.0))
         gAnim_FPSFrameCount := 0
         gAnim_FPSLastSample := now

--- a/src/gui/gui_data.ahk
+++ b/src/gui/gui_data.ahk
@@ -6,6 +6,7 @@
 ; hwnd -> item reference Map for O(1) lookups (populated alongside gGUI_LiveItems)
 global gGUI_LiveItemsMap := Map()
 global _gGUI_LastCosmeticRepaintTick := 0  ; Debounce for cosmetic repaints during ACTIVE
+global PRECACHE_TICK_MS := 50              ; Background icon pre-cache batch interval
 
 ; ========================= LIVE ITEMS REFRESH =========================
 
@@ -206,11 +207,11 @@ GUI_ReconcileDestroys() {
 ; Reads directly from gWS_Store (always current) — no dependency on display list freshness.
 ; Safe to call repeatedly: one-shot timer replacement deduplicates naturally.
 GUI_KickPreCache() {
-    global gGUI_State
+    global gGUI_State, PRECACHE_TICK_MS
     ; During ACTIVE, the visible-row path (A1 above) handles it
     if (gGUI_State = "ACTIVE")
         return
-    SetTimer(_GUI_PreCacheTick, -50)
+    SetTimer(_GUI_PreCacheTick, -PRECACHE_TICK_MS)
 }
 
 ; Stop the background pre-cache timer (called from gui_main shutdown).
@@ -248,6 +249,8 @@ _GUI_PreCacheTick() {
         Gdip_PreCacheIcon(job.hwnd, job.hicon)
 
     ; Re-arm if we hit the batch cap (more may remain)
-    if (hasMore)
-        SetTimer(_GUI_PreCacheTick, -50)
+    if (hasMore) {
+        global PRECACHE_TICK_MS
+        SetTimer(_GUI_PreCacheTick, -PRECACHE_TICK_MS)
+    }
 }

--- a/src/gui/gui_main.ahk
+++ b/src/gui/gui_main.ahk
@@ -102,6 +102,7 @@ global HOUSEKEEPING_INTERVAL_MS  ; Set from cfg.HousekeepingIntervalMs at init
 global STAGGER_ZPUMP_MS := 17
 global STAGGER_VALIDATE_MS := 37
 global STAGGER_HOUSEKEEPING_MS := 53
+global WORKING_SET_LOCK_DELAY_MS := 5000  ; Warm-up delay before locking working set (lets caches populate)
 ; _gGUI_LastCosmeticRepaintTick declared in gui_data.ahk (sole writer)
 
 ; gGUI_LauncherHwnd declared+defaulted before arg parsing (line 14), assigned there if --launcher-hwnd= present
@@ -252,9 +253,11 @@ _GUI_Main_Init() {
     ; Start housekeeping timer for cache pruning, log rotation, stats flush (staggered)
     SetTimer(_GUI_StartHousekeeping, -STAGGER_HOUSEKEEPING_MS)
 
-    ; Lock working set after warm-up (5s delay lets caches populate)
-    if (cfg.PerfKeepInMemory)
-        SetTimer(_GUI_LockWorkingSet, -5000)
+    ; Lock working set after warm-up (delay lets caches populate)
+    if (cfg.PerfKeepInMemory) {
+        global WORKING_SET_LOCK_DELAY_MS
+        SetTimer(_GUI_LockWorkingSet, -WORKING_SET_LOCK_DELAY_MS)
+    }
 
 }
 

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -13,6 +13,7 @@ global gPaint_LastPaintTick := 0      ; When we last painted (for idle duration 
 global gPaint_SessionPaintCount := 0  ; How many paints this session
 global gPaint_RepaintInProgress := false  ; Reentrancy guard (see #90)
 global _gPaint_SubCache := Map()      ; Paint-owned subtitle cache (hwnd → "Class: ..." string)
+global PAINT_IDLE_LOG_THRESHOLD_MS := 60000  ; Log verbose context for paints after this idle duration
 
 ; ========================= EFFECT STYLE SYSTEM =========================
 ; Toggled at runtime via B key (gui_interceptor.ahk).
@@ -87,8 +88,9 @@ GUI_Repaint() {
     gPaint_SessionPaintCount += 1
     paintNum := gPaint_SessionPaintCount
 
-    ; Log context for first paint or paint after long idle (>60s)
-    if (diagTiming && (paintNum = 1 || idleDuration > 60000)) {
+    ; Log context for first paint or paint after long idle
+    global PAINT_IDLE_LOG_THRESHOLD_MS
+    if (diagTiming && (paintNum = 1 || idleDuration > PAINT_IDLE_LOG_THRESHOLD_MS)) {
         iconCacheSize := gGdip_IconCache.Count  ; O(1) via Map.Count property
         resCount := gD2D_Res.Count
         Paint_Log("===== PAINT #" paintNum " (idle=" (idleDuration > 0 ? Round(idleDuration/1000, 1) "s" : "first") ") =====")

--- a/src/gui/gui_pump.ahk
+++ b/src/gui/gui_pump.ahk
@@ -23,7 +23,7 @@
 global _gPump_Client := ""           ; IPC pipe client object
 global _gPump_Connected := false     ; Pump connection state
 global _gPump_CollectTimerFn := 0    ; Bound timer callback ref
-global _gPump_CollectIntervalMs := 50  ; Batch collection interval (ms)
+global _gPump_CollectIntervalMs := 50  ; Batch collection interval (ms) — overridden from cfg.PumpCollectIntervalMs at init
 global _gPump_LastRequestTick := 0   ; Tick when last enrich request was sent
 global _gPump_LastResponseTick := 0  ; Tick when last response was received
 global _gPump_FailureNotified := false ; Prevent duplicate PUMP_FAILED notifications
@@ -31,7 +31,7 @@ global _gPump_FailureNotified := false ; Prevent duplicate PUMP_FAILED notificat
 ; Event-driven collection timer state
 global _gPump_TimerOn := false       ; Whether collection timer is running
 global _gPump_IdleTicks := 0         ; Consecutive empty ticks
-global _gPump_IdleThreshold := 5     ; Empty ticks before switching to heartbeat
+global _gPump_IdleThreshold := 5     ; Empty ticks before switching to heartbeat — overridden from cfg.PumpIdleThreshold at init
 global _GPUMP_HEARTBEAT_MS := 2000   ; Slow-poll interval for pump health check when idle
 
 ; IPC client timer management
@@ -55,10 +55,14 @@ global _gPump_EnrichCount := 0       ; Monotonic enrichment response counter
 
 GUIPump_Init(connectTimeoutMs := 2000) {
     global cfg, _gPump_Client, _gPump_Connected, _gPump_CollectTimerFn, _gPump_CollectIntervalMs
-    global _gPump_TimerOn, _gPump_IdleTicks, _gPump_ClientTimerOn
+    global _gPump_TimerOn, _gPump_IdleTicks, _gPump_IdleThreshold, _gPump_ClientTimerOn
     global _gPump_PumpHwnd, _gPump_HelloSent
     global _gPump_RetryTimerFn, _gPump_RetryCount, _GPUMP_MAX_RETRIES
     global _gPump_ConnectCount, g_TestingMode
+
+    ; Apply config-driven pump tuning
+    _gPump_CollectIntervalMs := cfg.PumpCollectIntervalMs
+    _gPump_IdleThreshold := cfg.PumpIdleThreshold
 
     ; Cancel any pending retry timer (handles re-entrant calls from Reconnect or retry)
     if (_gPump_RetryTimerFn) {

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -21,6 +21,7 @@ global gGUI_DisplayItems := []   ; Items being rendered (may be filtered by work
 global GUI_EVENT_BUFFER_MAX := 50           ; Max events to buffer during async
 
 ; Event buffering during async activation (queue events, don't cancel)
+global ACTIVE_WATCHDOG_MS := 500           ; Must be < Windows LowLevelHooksTimeout (~600ms). Safety net for #303.
 global gGUI_EventBuffer := []            ; Queued events during async activation
 
 ; Guard flag: true while _GUI_GraceTimerFired is executing.
@@ -440,7 +441,8 @@ _GUI_GraceTimerFired() {
 ; Catches ANY cause of stuck ACTIVE state, not just the grace timer path.
 
 _GUI_StartActiveWatchdog() {
-    SetTimer(_GUI_ActiveWatchdog, 500)
+    global ACTIVE_WATCHDOG_MS
+    SetTimer(_GUI_ActiveWatchdog, ACTIVE_WATCHDOG_MS)
 }
 
 _GUI_StopActiveWatchdog() {

--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -1040,6 +1040,10 @@ global gConfigRegistry := [
      min: 500, max: 10000,
      d: "Delay (ms) before first komorebi state poll at startup. Allows komorebi pipe to initialize. Increase on slow systems where komorebi takes longer to start."},
 
+    {s: "Komorebi", k: "LitePollMs", g: "KomorebiLitePollMs", t: "int", default: 1000,
+     min: 200, max: 5000,
+     d: "Polling interval (ms) for komorebi state when using Polling mode. Lower = more responsive workspace tracking, higher = less CPU. Only active when KomorebiIntegration=Polling."},
+
     ; ============================================================
     ; Setup & Installation
     ; ============================================================
@@ -1117,6 +1121,14 @@ global gConfigRegistry := [
     {s: "Store", k: "PumpHangTimeoutMs", g: "PumpHangTimeoutMs", t: "int", default: 15000,
      min: 5000, max: 60000,
      d: "Time (ms) without a pump response before declaring it hung and restarting"},
+
+    {s: "Store", k: "PumpCollectIntervalMs", g: "PumpCollectIntervalMs", t: "int", default: 50,
+     min: 10, max: 500,
+     d: "How often the pump batches pending hwnds into enrich requests (ms). Lower = faster icon/process resolution, higher = fewer IPC roundtrips."},
+
+    {s: "Store", k: "PumpIdleThreshold", g: "PumpIdleThreshold", t: "int", default: 5,
+     min: 1, max: 30,
+     d: "Empty queue ticks before pausing collection timer. Lower = faster idle detection, higher = more responsive to bursts."},
 
     {type: "subsection", section: "Store", name: "Window Filtering",
      desc: "Filter windows like native Alt-Tab (skip tool windows, etc.) and apply blacklist"},


### PR DESCRIPTION
## Summary

- Add 3 config registry entries that fill consistency gaps with existing configurable siblings:
  - `PumpCollectIntervalMs` (default 50ms) in `[Store]` — enrichment pump batch interval
  - `PumpIdleThreshold` (default 5) in `[Store]` — enrichment pump idle detection
  - `KomorebiLitePollMs` (default 1000ms) in `[Komorebi]` — polling mode interval
- Wire `GUIPump_Init()` and `KomorebiLite_Init()` to read from config
- Name 6 inline magic numbers as file-scope constants (readability only, not config)

Closes #328

## Test plan

- [x] Static analysis pre-gate passes (85 checks)
- [x] All unit tests pass (559 tests across 10 suites)
- [x] GUI tests pass (351 tests)
- [x] Live tests pass (39 tests across 6 suites)
- [x] Flight recorder tests pass (32 tests)
- [x] New config entries visible via `query_config.ps1`
- [x] Defaults match previous hardcoded values (zero behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)