### PR TITLE
Polish user-facing strings: replace jargon with plain language (#330)

### DIFF
--- a/src/editors/blacklist_editor.ahk
+++ b/src/editors/blacklist_editor.ahk
@@ -96,13 +96,13 @@ _BE_CreateGui() {
 
     ; Class tab
     tabs.UseTab("Class Patterns")
-    gBE_Gui.AddText("x20 y90 w550", "Class patterns — match window class names (e.g., 'Notepad', 'Chrome_*'):")
+    gBE_Gui.AddText("x20 y90 w550", "Class patterns — match the internal type name Windows assigns each window (e.g., 'Notepad', 'Chrome_*'):")
     gBE_ClassEdit := gBE_Gui.AddEdit("vClassEdit x20 y115 w550 h250 +Multi +WantReturn +VScroll")
     Theme_ApplyToControl(gBE_ClassEdit, "Edit", themeEntry)
 
     ; Pair tab
     tabs.UseTab("Pair Patterns")
-    gBE_Gui.AddText("x20 y90 w550", "Pair patterns — match class and title together (e.g., 'Chrome_WidgetWin_1|*YouTube*'):")
+    gBE_Gui.AddText("x20 y90 w550", "Pair patterns — match class AND title together, separated by | (e.g., 'Chrome_WidgetWin_1|*YouTube*'):")
     gBE_PairEdit := gBE_Gui.AddEdit("vPairEdit x20 y115 w550 h250 +Multi +WantReturn +VScroll")
     Theme_ApplyToControl(gBE_PairEdit, "Edit", themeEntry)
 

--- a/src/launcher/launcher_install.ahk
+++ b/src/launcher/launcher_install.ahk
@@ -304,7 +304,7 @@ _Launcher_OfferOneTimeElevation() {
     ; Offer one-time elevation for THIS session
     result := ThemeMsgBox(
         "The installed version runs as Administrator.`n`n"
-        "Run this version elevated too?`n"
+        "Run this version as Administrator too?`n"
         "(This is one-time and won't affect the installed version)",
         APP_NAME " - Run Elevated?",
         "YesNo Icon?"

--- a/src/shared/config_registry.ahk
+++ b/src/shared/config_registry.ahk
@@ -34,11 +34,11 @@ global gConfigRegistry := [
 
     {s: "AltTab", k: "GraceMs", g: "AltTabGraceMs", t: "int", default: 150,
      min: 0, max: 2000,
-     d: "Grace period before showing GUI (ms). During this time, if Alt is released, we do a quick switch without showing GUI."},
+     d: "Grace period before showing the overlay (ms). During this time, if Alt is released, we do a quick switch without showing the overlay."},
 
     {s: "AltTab", k: "QuickSwitchMs", g: "AltTabQuickSwitchMs", t: "int", default: 100,
      min: 0, max: 1000,
-     d: "Maximum time for quick switch without showing GUI (ms). If Alt+Tab and release happen within this time, instant switch."},
+     d: "Maximum time for quick switch without showing the overlay (ms). If Alt+Tab and release happen within this time, instant switch."},
 
     {s: "AltTab", k: "SwitchOnClick", g: "AltTabSwitchOnClick", t: "bool", default: true,
      d: "Activate window immediately when clicking a row (like Windows native). When false, clicking selects the row and activation happens when Alt is released."},
@@ -401,7 +401,7 @@ global gConfigRegistry := [
 
     {s: "GUI", k: "CornerStyle", g: "GUI_CornerStyle", t: "enum", default: "Round",
      options: ["Round", "RoundSmall", "Square"],
-     d: "Window corner shape. Round = 8px DWM rounding. RoundSmall = 4px. Square = sharp corners."},
+     d: "Window corner shape. Round = 8px rounding. RoundSmall = 4px. Square = sharp corners."},
 
     {s: "GUI", k: "OverlayMonitor", g: "GUI_OverlayMonitor", t: "enum", default: "FocusedWindow",
      options: ["FocusedWindow", "Primary"],
@@ -416,7 +416,7 @@ global gConfigRegistry := [
 
     {s: "GUI", k: "ScreenWidthPct", g: "GUI_ScreenWidthPct", t: "float", default: 0.6,
      min: 0.1, max: 1.0,
-     d: "GUI width as fraction of screen"},
+     d: "Overlay width as a fraction of screen width (0.6 = 60%)"},
 
     {s: "GUI", k: "RowsVisibleMin", g: "GUI_RowsVisibleMin", t: "int", default: 1,
      min: 1, max: 20,

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -761,7 +761,7 @@ CheckForUpdates(showIfCurrent := false, showModal := true) {
                             if (downloadUrl)
                                 Update_DownloadAndApply(downloadUrl, latestVersion)
                             else
-                                ThemeMsgBox("Could not find download URL for AltTabby.exe in the release.", "Update Error", "Iconx")
+                                ThemeMsgBox("The update file was not found on the server. Please try again later.", "Update Error", "Iconx")
                         }
                     }
                 } else {
@@ -778,7 +778,7 @@ CheckForUpdates(showIfCurrent := false, showModal := true) {
                 g_LastUpdateCheckTick := A_TickCount
                 g_LastUpdateCheckTime := FormatTime(, "MMM d, h:mm tt")
                 if (showIfCurrent && showModal) {
-                    TrayTip("Update Check Failed", "HTTP Status: " whr.Status, "Icon!")
+                    TrayTip("Update Check Failed", "The server returned an error. Please try again later.", "Icon!")
                 }
                 whr := ""  ; Release COM on error path
             }
@@ -791,7 +791,7 @@ CheckForUpdates(showIfCurrent := false, showModal := true) {
             g_LastUpdateCheckTick := A_TickCount
             g_LastUpdateCheckTime := FormatTime(, "MMM d, h:mm tt")
             if (showIfCurrent && showModal)
-                TrayTip("Update Check Failed", "Could not check for updates:`n" e.Message, "Icon!")
+                TrayTip("Update Check Failed", "Could not check for updates. Please check your internet connection and try again.", "Icon!")
         }
         whr := ""  ; Final safety - ensure release on all exit paths
     } finally {
@@ -849,7 +849,7 @@ Update_DownloadAndApply(downloadUrl, newVersion) {
         if (whr.Status != 200) {
             if (cfg.DiagUpdateLog)
                 _Update_Log("DownloadAndApply: HTTP error status=" whr.Status)
-            ThemeMsgBox("Download failed (HTTP " whr.Status ").`n`nPlease check your internet connection or visit the GitHub releases page to download manually.", "Update Error", "Iconx")
+            ThemeMsgBox("Download failed (HTTP " whr.Status ").`n`nPlease check your internet connection or visit github.com/cwilliams5/Alt-Tabby/releases to download manually.", "Update Error", "Iconx")
             whr := ""  ; Release COM before return
             return
         }


### PR DESCRIPTION
## Summary

- **Update error messages**: Replace raw HTTP status codes and COM error text with user-friendly messages; give users the actual releases URL instead of assuming they know "the GitHub releases page"
- **Config descriptions**: Replace ambiguous "GUI" with "overlay" (matching section headers), remove "DWM" jargon from corner style, add fraction→percentage example to ScreenWidthPct
- **Blacklist editor**: Clarify "window class names" as "the internal type name Windows assigns each window"; explain pipe separator in pair patterns
- **Elevation dialog**: Replace developer jargon "elevated" with standard Windows phrasing "as Administrator"

Closes #330

## Test plan

- [x] Full test suite passes (1006/1006 tests across all suites)
- [ ] Open config editor → verify GraceMs, QuickSwitchMs, CornerStyle, ScreenWidthPct descriptions render correctly
- [ ] Open blacklist editor → verify Class Patterns and Pair Patterns tab descriptions
- [ ] Trigger update check error path (disconnect network) → verify friendly error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)