### PR TITLE
Remove dead WL_IsOnCurrentWorkspace function (#332)

### DIFF
--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -761,10 +761,6 @@ WL_GetByHwnd(hwnd) {
     return gWS_Store.Get(hwnd, "")
 }
 
-WL_IsOnCurrentWorkspace(workspaceName, currentWSName) {
-    return (workspaceName = currentWSName) || (workspaceName = "")
-}
-
 WL_SetCurrentWorkspace(id, name := "") {
     Profiler.Enter("WL_SetCurrentWorkspace") ; @profile
     global gWS_Meta, gWS_Rev, gWS_Store, gWS_SortOrderDirty, gWS_MRUBumpOnly

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -331,10 +331,6 @@ Win_GetScaleForWindow(hwnd) {
 global gMock_StoreItems := []
 global gMock_StoreItemsMap := Map()
 
-WL_IsOnCurrentWorkspace(workspaceName, currentWSName) {
-    return (workspaceName = currentWSName) || (workspaceName = "")
-}
-
 WL_GetDisplayList(opts := "") {
     global gMock_StoreItems, gMock_StoreItemsMap
     ; Filter by currentWorkspaceOnly if requested

--- a/tests/test_unit_core_store.ahk
+++ b/tests/test_unit_core_store.ahk
@@ -947,19 +947,4 @@ RunUnitTests_CoreStore() {
     ; Cleanup
     WL_RemoveWindow([9201, 9202, 9203], true)
 
-    ; ============================================================
-    ; WL_IsOnCurrentWorkspace Edge Cases
-    ; ============================================================
-    Log("`n--- WL_IsOnCurrentWorkspace Edge Cases ---")
-
-    ; Both empty: non-komorebi windows (empty wsName) are always "on current"
-    AssertEq(WL_IsOnCurrentWorkspace("", ""), true, "IsOnCurrentWS: both empty = on current")
-    ; Empty workspace name always on current (non-komorebi window)
-    AssertEq(WL_IsOnCurrentWorkspace("", "Main"), true, "IsOnCurrentWS: empty wsName = on current")
-    ; Exact match
-    AssertEq(WL_IsOnCurrentWorkspace("Main", "Main"), true, "IsOnCurrentWS: exact match")
-    ; Different workspace
-    AssertEq(WL_IsOnCurrentWorkspace("Other", "Main"), false, "IsOnCurrentWS: different workspace")
-    ; Case sensitivity (AHK string comparison is case-insensitive by default)
-    AssertEq(WL_IsOnCurrentWorkspace("main", "Main"), true, "IsOnCurrentWS: case-insensitive match")
 }


### PR DESCRIPTION
## Summary

- Remove `WL_IsOnCurrentWorkspace()` from `window_list.ahk` — zero production callers
- Remove associated unit tests and GUI test mock
- Function was superseded by `GUI_GetItemIsOnCurrent()` which checks a pre-computed `item.isOnCurrentWorkspace` property

Closes #332

## Test plan

- [x] `query_function_visibility.ps1 WL_IsOnCurrentWorkspace` confirms 0 callers
- [x] Pre-gate static analysis passes (85 checks)
- [x] All 1001 tests pass (`.\tests\test.ps1 --live`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)