### PR TITLE
Fix option interaction edge cases from combinatorial review (#338)

### DIFF
--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -57,7 +57,7 @@ Launcher_LogStartup() {
 ; Main launcher initialization
 ; Called from alt_tabby.ahk when g_AltTabbyMode = "launch"
 Launcher_Init() {
-    global g_GuiPID, g_MismatchDialogShown, g_TestingMode, cfg, gConfigIniPath
+    global g_GuiPID, g_MismatchDialogShown, g_TestingMode, g_SkipActiveMutex, cfg, gConfigIniPath
     global ALTTABBY_TASK_NAME, TIMING_MUTEX_RELEASE_WAIT, TIMING_SUBPROCESS_LAUNCH, TIMING_TASK_INIT_WAIT, g_SplashStartTick, APP_NAME
 
     ; Log startup (clears old log if DiagLauncherLog is enabled)
@@ -105,6 +105,31 @@ Launcher_Init() {
                 ExitApp()
             }
             ; Continue with normal startup below
+        } else {
+            ExitApp()
+        }
+    }
+
+    ; Early active mutex check: prevent two installations from showing overlapping
+    ; dialogs (mismatch, wizard, admin repair) before subprocess launch.
+    ; The same check runs again in Launcher_StartSubprocesses() (idempotent).
+    if (!g_TestingMode && !g_SkipActiveMutex && !_Launcher_AcquireActiveMutex()) {
+        result := ThemeMsgBox(
+            "Another Alt-Tabby installation is already running.`n`n"
+            "Only one installation can be active at a time.`n"
+            "Close the other installation and try again?",
+            APP_NAME,
+            "YesNo Iconx"
+        )
+        if (result = "Yes") {
+            _Launcher_KillAllAltTabbyProcesses()
+            Sleep(TIMING_MUTEX_RELEASE_WAIT)
+            if (!_Launcher_AcquireActiveMutex()) {
+                ThemeMsgBox("Another Alt-Tabby instance is already running.`n`n"
+                    "Close all Alt-Tabby windows and try again.`n"
+                    "If the problem persists, end 'AltTabby.exe' in Task Manager.", APP_NAME, "Iconx")
+                ExitApp()
+            }
         } else {
             ExitApp()
         }
@@ -700,12 +725,14 @@ Launcher_AcquireMutex() {
 }
 
 ; Try to acquire the system-wide active mutex
-; Returns true if acquired, false if another installation is running
+; Returns true if acquired (or already held), false if another installation is running.
+; Idempotent: safe to call multiple times (early check in Launcher_Init + Launcher_StartSubprocesses).
 ; This is separate from the launcher mutex (which uses InstallationId) to prevent
 ; multiple installations from running simultaneously regardless of their ID.
 _Launcher_AcquireActiveMutex() {
     global g_ActiveMutex
-
+    if (g_ActiveMutex)
+        return true  ; Already acquired by us
     return _Launcher_TryAcquireMutex(&g_ActiveMutex, "AltTabby_Active", "ACTIVE_MUTEX")
 }
 

--- a/src/shared/process_utils.ahk
+++ b/src/shared/process_utils.ahk
@@ -198,9 +198,11 @@ _ProcessUtils_KillAllAltTabbyExceptSelf(targetExeName := "") {
 ; Single entry point for all Alt-Tabby process killing.
 ;
 ; Behavior:
-;   1. Hard-kill editors (if provided)
-;   2. Graceful shutdown known PIDs in order: GUI→Pump (if pids provided)
-;   3. Force sweep by process name (if force=true)
+;   1. Hard-kill editors (if provided by PID)
+;   2. Graceful editor close by title discovery (if force=true — catches editors
+;      whose PIDs are unknown, e.g., elevated update modes)
+;   3. Graceful shutdown known PIDs in order: GUI→Pump (if pids provided)
+;   4. Force sweep by process name (if force=true)
 ;
 ; Graceful always happens when PIDs are available — no caller with PIDs
 ; should ever skip it. Force is the orthogonal axis: update/conflict flows
@@ -229,6 +231,13 @@ ProcessUtils_KillAltTabby(opts := "") {
         if (ed.HasOwnProp("blacklist") && ed.blacklist && ProcessExist(ed.blacklist))
             try ProcessClose(ed.blacklist)
     }
+
+    ; Editor save-prompt phase: discover editor windows by title and send WM_CLOSE.
+    ; This works in elevated update modes where editor PIDs are unknown (the non-elevated
+    ; launcher that knew the PIDs has already exited). Without this, the force sweep
+    ; below silently kills editors via taskkill /F — discarding unsaved changes.
+    if (force)
+        _PU_GracefulCloseEditorsByTitle()
 
     ; Graceful phase: ordered WM_CLOSE to known PIDs
     if (opts.HasOwnProp("pids"))
@@ -270,6 +279,60 @@ _PU_GracefulShutdownByPid(pids) {
             HiSleep(10)
         if (ProcessExist(pids.pump))
             ProcessClose(pids.pump)
+    }
+
+    DetectHiddenWindows(prevDHW)
+}
+
+; Internal: Discover Alt-Tabby editor windows by title and send WM_CLOSE.
+; Gives editors a chance to show "save changes?" prompts before the force-kill sweep.
+; Used by ProcessUtils_KillAltTabby when force=true — catches editors whose PIDs are
+; unknown (e.g., elevated --apply-update / --update-installed / --install-to-pf modes).
+_PU_GracefulCloseEditorsByTitle() {
+    static editorTitlePrefixes := ["Alt-Tabby Configuration", "Alt-Tabby Blacklist"]
+
+    prevDHW := A_DetectHiddenWindows
+    DetectHiddenWindows(true)
+
+    ; Collect all editor window HWNDs
+    editorHwnds := []
+    myPID := ProcessExist()
+    for prefix in editorTitlePrefixes {
+        try {
+            hwnds := WinGetList(prefix)
+            for hwnd in hwnds {
+                ; Skip windows belonging to our own process (e.g., config editor
+                ; launched in-process would be handled by its own cleanup)
+                try {
+                    if (WinGetPID("ahk_id " hwnd) != myPID)
+                        editorHwnds.Push(hwnd)
+                }
+            }
+        }
+    }
+
+    if (editorHwnds.Length = 0) {
+        DetectHiddenWindows(prevDHW)
+        return
+    }
+
+    ; Send WM_CLOSE to all discovered editors
+    for hwnd in editorHwnds
+        try PostMessage(0x0010, 0, 0, , "ahk_id " hwnd)  ; WM_CLOSE
+
+    ; Wait up to 3s for editors to close (user may be responding to save prompt)
+    deadline := A_TickCount + 3000
+    while (A_TickCount < deadline) {
+        allGone := true
+        for hwnd in editorHwnds {
+            if (DllCall("user32\IsWindow", "ptr", hwnd)) {
+                allGone := false
+                break
+            }
+        }
+        if (allGone)
+            break
+        Sleep(200)
     }
 
     DetectHiddenWindows(prevDHW)

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -1174,14 +1174,10 @@ Update_ApplyCore(opts) {
 ; Apply update: rename current exe, move new exe, relaunch
 ; Wrapper for auto-update flow - uses Update_ApplyCore with appropriate options
 _Update_ApplyAndRelaunch(newExePath, targetExePath) {
-    global g_PumpPID, g_GuiPID, g_ConfigEditorPID, g_BlacklistEditorPID
+    global g_PumpPID, g_GuiPID
 
-    ; Gracefully close any open editors before the force-kill sweep.
-    ; Editors have unsaved-changes prompts on WM_CLOSE — sending it first
-    ; gives the user a chance to save. Without this, the force sweep in
-    ; Update_ApplyCore silently kills editors via taskkill /F.
-    _Update_CloseEditors()
-
+    ; Editor graceful close is handled inside ProcessUtils_KillAltTabby (force=true)
+    ; via title-based discovery — works in both elevated and non-elevated paths.
     Update_ApplyCore({
         sourcePath: newExePath,
         targetPath: targetExePath,
@@ -1192,40 +1188,6 @@ _Update_ApplyAndRelaunch(newExePath, targetExePath) {
         cleanupSourceOnFailure: true,
         killPids: {gui: g_GuiPID, pump: g_PumpPID}
     })
-}
-
-; Send WM_CLOSE to editor windows and wait briefly for them to close.
-; This allows unsaved-changes prompts to appear before the update's force-kill sweep.
-_Update_CloseEditors() {
-    global g_ConfigEditorPID, g_BlacklistEditorPID
-
-    editorsClosed := true
-    for pid in [g_ConfigEditorPID, g_BlacklistEditorPID] {
-        if (!pid || !ProcessExist(pid))
-            continue
-        editorsClosed := false
-        try {
-            hwnd := WinExist("ahk_pid " pid)
-            if (hwnd)
-                PostMessage(0x0010, 0, 0, , "ahk_id " hwnd)  ; WM_CLOSE
-        }
-    }
-
-    if (editorsClosed)
-        return
-
-    ; Wait up to 3s for editors to close (user may be saving)
-    deadline := A_TickCount + 3000
-    while (A_TickCount < deadline) {
-        allGone := true
-        if (g_ConfigEditorPID && ProcessExist(g_ConfigEditorPID))
-            allGone := false
-        if (g_BlacklistEditorPID && ProcessExist(g_BlacklistEditorPID))
-            allGone := false
-        if (allGone)
-            return
-        Sleep(200)
-    }
 }
 
 ; Called on startup to clean up old exe from previous update
@@ -1371,6 +1333,33 @@ _Update_MergeStats(srcPath, targetPath) {
         }
     }
 
+    ; Detect reverse merge: target previously merged TO source (e.g., A→B then B→A).
+    ; Without this, the first B→A merge re-adds A's values that B already includes.
+    reverseMerge := false
+    if (!previouslyMerged) {
+        srcInstallId := ""
+        srcDir := ""
+        SplitPath(srcPath, , &srcDir)
+        srcConfigPath := srcDir "\config.ini"
+        if (FileExist(srcConfigPath))
+            try srcInstallId := IniRead(srcConfigPath, "Setup", "InstallationId", "")
+
+        if (srcInstallId != "") {
+            try {
+                targetLastMergedToId := IniRead(targetPath, "Merged", "LastMergedToId", "")
+                if (targetLastMergedToId = srcInstallId)
+                    reverseMerge := true
+            }
+        }
+        if (!reverseMerge) {
+            try {
+                targetLastMergedTo := IniRead(targetPath, "Merged", "LastMergedTo", "")
+                if (PathsEqual(targetLastMergedTo, srcPath))
+                    reverseMerge := true
+            }
+        }
+    }
+
     if (previouslyMerged) {
         ; Delta merge: only add stats accumulated since last merge
         hasNewStats := false
@@ -1413,6 +1402,38 @@ _Update_MergeStats(srcPath, targetPath) {
                         IniWrite(targetVal + delta, targetPath, "Lifetime", key)
                     }
                 }
+            }
+        }
+    } else if (reverseMerge) {
+        ; Reverse merge: target previously merged TO source (A→B, now B→A).
+        ; Source's values include target's contribution from the forward merge.
+        ; Use target's Snap values to determine what target contributed, then
+        ; only add source's accumulation beyond that contribution.
+        ; Example: A=100, B=0. A→B: B=100, A.Snap=100. B earns 50: B=150.
+        ;   B→A: delta = B.current(150) - A.Snap(100) = 50. A = 100+50 = 150. Correct.
+        for key in STATS_LIFETIME_KEYS {
+            try {
+                srcVal := Integer(IniRead(srcPath, "Lifetime", key, "0"))
+                targetVal := Integer(IniRead(targetPath, "Lifetime", key, "0"))
+                if (maxKeys.Has(key)) {
+                    if (srcVal > targetVal)
+                        IniWrite(srcVal, targetPath, "Lifetime", key)
+                } else {
+                    ; Target's Snap = what target contributed to source during forward merge
+                    targetSnap := Integer(IniRead(targetPath, "Merged", "Snap_" key, "0"))
+                    delta := srcVal - targetSnap
+                    if (delta > 0)
+                        IniWrite(targetVal + delta, targetPath, "Lifetime", key)
+                }
+            }
+        }
+
+        ; Update target's Snap to post-merge values so the next forward merge
+        ; (target→source again) uses correct baselines
+        for key in STATS_LIFETIME_KEYS {
+            try {
+                newTargetVal := Integer(IniRead(targetPath, "Lifetime", key, "0"))
+                IniWrite(newTargetVal, targetPath, "Merged", "Snap_" key)
             }
         }
     } else {


### PR DESCRIPTION
## Summary

Systematic review of all installation/update/admin/wizard option interactions found 3 edge cases:

- **Editor save prompt in elevated updates**: `_PU_GracefulCloseEditorsByTitle()` discovers editors by window title and sends WM_CLOSE before force-kill sweep — fixes data loss when editors had unsaved changes during elevated update paths
- **Stats reverse merge**: Detects when target previously merged TO source (A→B then B→A) and uses delta formula instead of full additive, preventing double-counting
- **Active mutex earlier**: Moved system-wide check before mismatch/wizard dialogs to prevent overlapping dialog cascades from two installations

Also verified: all 8 UAC refusal paths are clean, no DRY consolidation needed, 10+ other interaction paths already well-defended.

Closes #338

## Test plan

- [x] Static analysis: all 85 checks pass
- [x] Full test suite: 1006/1006 tests pass (unit, GUI, live, flight recorder)
- [ ] Manual: open config editor with unsaved changes → trigger update from PF install → verify save prompt appears
- [ ] Manual: verify two installations launched simultaneously get blocked at active mutex before dialog cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)