### PR TITLE
Add profiler instrumentation for 20 hot-path functions (#340)

### DIFF
--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -48,7 +48,19 @@ global _WEH_MruFallbackActive := false   ; True when MRU_Lite is running as WEH 
 ; kills the periodic timer (SetTimer(_WEH_ProcessBatch, BatchMs)), leaving pending
 ; hwnds stranded until the next event. This wrapper has its own timer slot.
 _WEH_FastPathBatch() {
-    _WEH_ProcessBatch()
+    Profiler.Enter("_WEH_FastPathBatch") ; @profile
+    static _errCount := 0, _backoffUntil := 0
+    if (A_TickCount < _backoffUntil) {
+        Profiler.Leave() ; @profile
+        return
+    }
+    try {
+        _WEH_ProcessBatch()
+    } catch as e {
+        global LOG_PATH_STORE
+        HandleTimerError(e, &_errCount, &_backoffUntil, LOG_PATH_STORE, "_WEH_FastPathBatch")
+    }
+    Profiler.Leave() ; @profile
 }
 
 ; Debug logging for focus events - controlled by DiagWinEventLog config flag

--- a/src/gui/d2d_shader.ahk
+++ b/src/gui/d2d_shader.ahk
@@ -1077,9 +1077,12 @@ Shader_PreRender(name, w, h, timeSec, darken := 0.0, desaturate := 0.0, opacity 
     global gShader_D3DCtx, gShader_VS, gShader_CBuffer, gShader_Sampler, gShader_Registry, gShader_Ready
     global gShader_FrameCount, gShader_StateDirty, gShader_BatchMode, cfg
     static dbgRendered := Map()
+    Profiler.Enter("Shader_PreRender") ; @profile
 
-    if (!gShader_Ready || !gShader_Registry.Has(name))
+    if (!gShader_Ready || !gShader_Registry.Has(name)) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     ; One-time log per shader name
     if (cfg.DiagShaderLog && !dbgRendered.Has(name)) {
@@ -1091,17 +1094,23 @@ Shader_PreRender(name, w, h, timeSec, darken := 0.0, desaturate := 0.0, opacity 
     }
 
     entry := gShader_Registry[name]
-    if (!entry.ps)
+    if (!entry.ps) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     ; Lazy create/resize render target
     if (entry.w != w || entry.h != h || !entry.tex) {
-        if (!_Shader_CreateRT(entry, w, h))
+        if (!_Shader_CreateRT(entry, w, h)) {
+            Profiler.Leave() ; @profile
             return false
+        }
     }
 
-    if (!entry.rtv || !entry.bitmap)
+    if (!entry.rtv || !entry.bitmap) {
+        Profiler.Leave() ; @profile
         return false
+    }
 
     ctx := gShader_D3DCtx
 
@@ -1118,8 +1127,10 @@ Shader_PreRender(name, w, h, timeSec, darken := 0.0, desaturate := 0.0, opacity 
     static mapped1 := Buffer(16, 0)
     ; Map (vtable 14): resource, subresource, mapType=WRITE_DISCARD(4), mapFlags, mappedResource
     hr := ComCall(14, ctx, "ptr", gShader_CBuffer, "uint", 0, "uint", 4, "uint", 0, "ptr", mapped1, "int")
-    if (hr < 0)
+    if (hr < 0) {
+        Profiler.Leave() ; @profile
         return false
+    }
     pData := NumGet(mapped1, 0, "ptr")
     if (pData) {
         ; Core params + mouse (offset 0-44, 12 values)
@@ -1277,6 +1288,7 @@ Shader_PreRender(name, w, h, timeSec, darken := 0.0, desaturate := 0.0, opacity 
     ; NOTE: The old staging-texture path had Map() here, which was an accidental GPU
     ; fence.  gui_paint.ahk's DwmFlush on grow resize compensates for its removal.
     ; If a GPU stall is ever re-added here, the DwmFlush becomes redundant but harmless.
+    Profiler.Leave() ; @profile
     return true
 }
 

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -123,6 +123,7 @@ Anim_CancelAll() {
 
 _Anim_UpdateTweens() {
     global gAnim_Tweens
+    Profiler.Enter("_Anim_UpdateTweens") ; @profile
     now := QPC()
     activeCount := 0
     for _, tw in gAnim_Tweens {
@@ -140,6 +141,7 @@ _Anim_UpdateTweens() {
             activeCount += 1
         }
     }
+    Profiler.Leave() ; @profile
     return activeCount
 }
 
@@ -348,6 +350,7 @@ _Anim_FramePace() {
 
 _Anim_SyncOverlayOpacity() {
     global gAnim_OverlayOpacity, gAnim_Tweens
+    Profiler.Enter("_Anim_SyncOverlayOpacity") ; @profile
     ; hideFade takes priority — when present it's the latest intent and the
     ; completed showFade tween is still in the map (never removed until CancelAll).
     if (gAnim_Tweens.Has("hideFade")) {
@@ -363,6 +366,7 @@ _Anim_SyncOverlayOpacity() {
             _Anim_RemoveLayered()
         }
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Apply gAnim_OverlayOpacity to the window via SetLayeredWindowAttributes.

--- a/src/gui/gui_bgimage.ahk
+++ b/src/gui/gui_bgimage.ahk
@@ -65,16 +65,22 @@ BGImg_EnsureCache(wPhys, hPhys) {
 ; Hot path: one DrawBitmap from the pre-rendered cache.
 BGImg_Draw() {
     global gBGImg_Ready, gBGImg_Cache, gD2D_RT, cfg
+    Profiler.Enter("BGImg_Draw") ; @profile
 
-    if (!gBGImg_Ready || !gD2D_RT || !gBGImg_Cache)
+    if (!gBGImg_Ready || !gD2D_RT || !gBGImg_Cache) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     opacity := cfg.BGImgOpacity
-    if (opacity <= 0.0)
+    if (opacity <= 0.0) {
+        Profiler.Leave() ; @profile
         return
+    }
 
     ; Single DrawBitmap blit — destRect=0 means full target, srcRect=0 means full source
     gD2D_RT.DrawBitmap(gBGImg_Cache, 0, opacity, 1, 0)
+    Profiler.Leave() ; @profile
 }
 
 ; Release all resources. Called from FX_GPU_Dispose().

--- a/src/gui/gui_data.ahk
+++ b/src/gui/gui_data.ahk
@@ -172,9 +172,12 @@ GUI_EvictDisplayItem(idx1) {
 ; Returns count of items removed.
 GUI_ReconcileDestroys() {
     global gGUI_State, gGUI_DisplayItems, gWS_Store
+    Profiler.Enter("GUI_ReconcileDestroys") ; @profile
 
-    if (gGUI_State != "ACTIVE")
+    if (gGUI_State != "ACTIVE") {
+        Profiler.Leave() ; @profile
         return 0
+    }
 
     Critical "On"
     removed := 0
@@ -197,6 +200,7 @@ GUI_ReconcileDestroys() {
         }
     }
 
+    Profiler.Leave() ; @profile
     return removed
 }
 

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -218,6 +218,7 @@ _FX_DrawSoftRect(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
 
     ; Cache effect properties — skip COM Set* calls when values unchanged (inner shadow is config-stable)
     static lastARGB := -1, lastX := "", lastY := "", lastW := "", lastH := "", lastBlur := ""
+    Profiler.Enter("_FX_DrawSoftRect") ; @profile
 
     corrected := _FX_HDRCorrectARGB(argb)
     if (corrected != lastARGB) {
@@ -241,6 +242,7 @@ _FX_DrawSoftRect(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
     } else {
         gD2D_RT.DrawImage(gFX_SoftRectBlurOut)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; Draw a soft rectangle using the secondary chain (flood2→crop2→blur2).
@@ -251,6 +253,7 @@ _FX_DrawSoftRect2(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
 
     ; Cache effect properties — skip COM Set* calls when values unchanged
     static lastARGB := -1, lastX := "", lastY := "", lastW := "", lastH := "", lastBlur := ""
+    Profiler.Enter("_FX_DrawSoftRect2") ; @profile
 
     corrected := _FX_HDRCorrectARGB(argb)
     if (corrected != lastARGB) {
@@ -273,6 +276,7 @@ _FX_DrawSoftRect2(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
     } else {
         gD2D_RT.DrawImage(gFX_SoftRect2BlurOut)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= GPU INNER SHADOW =========================
@@ -281,6 +285,7 @@ _FX_DrawSoftRect2(x, y, w, h, argb, blurStdDev, offsetX := 0, offsetY := 0) {
 FX_GPU_DrawInnerShadow(wPhys, hPhys, depth, alpha) {
     ; Pre-compute alpha multipliers — config-stable, only changes on config reload
     static cachedAlpha := -1, cachedEdge := 0, cachedBot := 0
+    Profiler.Enter("FX_GPU_DrawInnerShadow") ; @profile
     if (alpha != cachedAlpha) {
         cachedEdge := Round(alpha * 1.2)
         if (cachedEdge > 255) cachedEdge := 255
@@ -294,6 +299,7 @@ FX_GPU_DrawInnerShadow(wPhys, hPhys, depth, alpha) {
     ; Bottom
     botARGB := (cachedBot << 24) | 0x000000
     _FX_DrawSoftRect2(0, hPhys, wPhys, depth, botARGB, Float(depth * 0.8))
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= GPU HOVER =========================
@@ -301,9 +307,12 @@ FX_GPU_DrawInnerShadow(wPhys, hPhys, depth, alpha) {
 ; GPU-enhanced hover with soft glow behind the row.
 FX_GPU_DrawHover(x, y, w, h, rad) {
     global cfg
+    Profiler.Enter("FX_GPU_DrawHover") ; @profile
     baseARGB := cfg.GUI_HoverARGB
-    if ((baseARGB >> 24) = 0 && cfg.GUI_HovBorderWidthPx <= 0)
+    if ((baseARGB >> 24) = 0 && cfg.GUI_HovBorderWidthPx <= 0) {
+        Profiler.Leave() ; @profile
         return  ; fully transparent fill + no border — nothing to draw
+    }
     if ((baseARGB >> 24) > 0)
         D2D_FillRoundRect(x, y, w, h, rad, D2D_GetCachedBrush(baseARGB))
     bw := cfg.GUI_HovBorderWidthPx
@@ -311,6 +320,7 @@ FX_GPU_DrawHover(x, y, w, h, rad) {
         half := bw / 2
         D2D_StrokeRoundRect(x + half, y + half, w - bw, h - bw, rad, D2D_GetCachedBrush(cfg.GUI_HovBorderARGB), bw)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= HDR COMPENSATION =========================

--- a/src/gui/gui_interceptor.ahk
+++ b/src/gui/gui_interceptor.ahk
@@ -237,14 +237,17 @@ _INT_Tab_Up(*) {
     Critical "On"  ; Prevent other hotkeys from interrupting
     global gINT_TabHeld, gINT_TabPending
     global FR_EV_TAB_UP, gFR_Enabled
+    Profiler.Enter("_INT_Tab_Up") ; @profile
     if (gFR_Enabled)
         FR_Record(FR_EV_TAB_UP, gINT_TabHeld)
 
     if (gINT_TabHeld) {
         ; Released from Alt+Tab step
         gINT_TabHeld := false
+        Profiler.Leave() ; @profile
         return
     }
+    Profiler.Leave() ; @profile
 }
 
 _INT_Tab_Decide() {
@@ -330,12 +333,14 @@ _INT_Escape_Down(*) {
     Critical "On"  ; Prevent other hotkeys from interrupting
     global gINT_SessionActive, gINT_PressCount, gINT_TabHeld, TABBY_EV_ESCAPE
     global FR_EV_ESC, gFR_Enabled
+    Profiler.Enter("_INT_Escape_Down") ; @profile
     if (gFR_Enabled)
         FR_Record(FR_EV_ESC, gINT_SessionActive, gINT_PressCount)
 
     ; Only consume Escape if in active Alt+Tab session
     if (!gINT_SessionActive || gINT_PressCount < 1) {
         Send("{Escape}")
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -346,6 +351,7 @@ _INT_Escape_Down(*) {
     gINT_SessionActive := false
     gINT_PressCount := 0
     gINT_TabHeld := false
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= FPS DEBUG OVERLAY TOGGLE =========================

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -812,18 +812,26 @@ D2D_Present(syncInterval := 0) {
 ; Does NOT commit — caller batches with other DComp changes then calls D2D_Commit().
 D2D_SetClipRect(wPhys, hPhys) {
     global gDComp_ClipVisual
-    if (!gDComp_ClipVisual)
+    Profiler.Enter("D2D_SetClipRect") ; @profile
+    if (!gDComp_ClipVisual) {
+        Profiler.Leave() ; @profile
         return
+    }
     clipRect := D2D_RectF(0, 0, wPhys, hPhys)
     gDComp_ClipVisual.SetClip(clipRect)
+    Profiler.Leave() ; @profile
 }
 
 ; Commit all pending DComp changes atomically.
 D2D_Commit() {
     global gDComp_Device
-    if (!gDComp_Device)
+    Profiler.Enter("D2D_Commit") ; @profile
+    if (!gDComp_Device) {
+        Profiler.Leave() ; @profile
         return
+    }
     gDComp_Device.Commit()
+    Profiler.Leave() ; @profile
 }
 
 ; Query all monitors and return the largest physical pixel dimensions.

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -826,12 +826,15 @@ _GUI_DrawActionButtons(wPhys, yRow, rowHPhys, scale, Mx) {
 
 _GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, scrollTop, count, scale) {
     global cfg
+    Profiler.Enter("_GUI_DrawScrollbar") ; @profile
     if (!cfg.GUI_ScrollBarEnabled || count <= 0 || rowsDrawn <= 0 || rowHPhys <= 0) {
+        Profiler.Leave() ; @profile
         return
     }
 
     trackH := rowsDrawn * rowHPhys
     if (trackH <= 0) {
+        Profiler.Leave() ; @profile
         return
     }
 
@@ -872,12 +875,14 @@ _GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, scrollTop, count, sc
             D2D_FillRoundRect(x, y, trackW, h2, r, thumbBr)
         }
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ========================= FOOTER =========================
 
 _GUI_DrawFooter(wPhys, hPhys, scale, shadowP, shadowBr) {
     global gGUI_FooterText, gGUI_LeftArrowRect, gGUI_RightArrowRect, gGUI_HoverBtn, cfg, gD2D_Res
+    Profiler.Enter("_GUI_DrawFooter") ; @profile
 
     ; Use cached metrics (avoids per-frame Round() calls)
     cl := GUI_GetCachedLayout(scale)
@@ -960,6 +965,7 @@ _GUI_DrawFooter(wPhys, hPhys, scale, shadowP, shadowBr) {
     } else {
         D2D_DrawTextCentered(gGUI_FooterText, textX, fy, textW, fh, brFooterText, tfFooter)
     }
+    Profiler.Leave() ; @profile
 }
 
 ; ---- Text Shadow ----
@@ -986,11 +992,16 @@ _FX_GetShadowParams(fx, scale) {
     static sFx := -1, sScale := -1, sAlpha := -1, sDist := -1
 
     global cfg
-    if (!fx || !cfg.GUI_UseTextShadow)
+    Profiler.Enter("_FX_GetShadowParams") ; @profile
+    if (!fx || !cfg.GUI_UseTextShadow) {
+        Profiler.Leave() ; @profile
         return sDisabled
+    }
     alpha := cfg.GUI_TextShadowAlpha
-    if (alpha <= 0)
+    if (alpha <= 0) {
+        Profiler.Leave() ; @profile
         return sDisabled
+    }
 
     dist := cfg.GUI_TextShadowDistancePx
     if (fx != sFx || scale != sScale || alpha != sAlpha || dist != sDist) {
@@ -1003,6 +1014,7 @@ _FX_GetShadowParams(fx, scale) {
         sEnabled.offY := off
         sEnabled.argb := (alpha << 24) | 0x000000
     }
+    Profiler.Leave() ; @profile
     return sEnabled
 }
 

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -592,6 +592,7 @@ _GUI_FilterDisplayItems(items) {
 ; change is a context switch — the moved/focused window is what the user wants.
 GUI_RefilterForWorkspaceChange() {
     global gGUI_DisplayItems, gGUI_Sel, gGUI_ScrollTop, gGUI_ToggleBase
+    Profiler.Enter("GUI_RefilterForWorkspaceChange") ; @profile
     gGUI_DisplayItems := _GUI_FilterDisplayItems(gGUI_ToggleBase)
     gGUI_ScrollTop := 0
     gGUI_Sel := 1
@@ -605,6 +606,7 @@ GUI_RefilterForWorkspaceChange() {
         }
     }
     GUI_ClampSelection(gGUI_DisplayItems)
+    Profiler.Leave() ; @profile
 }
 
 ; Re-filter display items after workspace mode toggle.

--- a/src/shared/ipc_pipe.ahk
+++ b/src/shared/ipc_pipe.ahk
@@ -237,8 +237,11 @@ _IPC_Server_ReadClients(server) {
 ; ============================ Client internals =============================
 
 IPC__ClientTick(client) {
-    if (!client.hPipe)
+    Profiler.Enter("IPC__ClientTick") ; @profile
+    if (!client.hPipe) {
+        Profiler.Leave() ; @profile
         return
+    }
     readStatus := _IPC_ReadPipeLines(client.hPipe, client, client.onMessage)
     if (readStatus < 0) {
         if (_IPC_IsLogEnabled())
@@ -247,9 +250,11 @@ IPC__ClientTick(client) {
         client.hPipe := 0
         if (client.timerFn)
             SetTimer(client.timerFn, 0)
+        Profiler.Leave() ; @profile
         return
     }
     _IPC_Client_AdjustTimer(client, readStatus)
+    Profiler.Leave() ; @profile
 }
 
 ; ============================== Pipe helpers ===============================

--- a/src/shared/stats.ahk
+++ b/src/shared/stats.ahk
@@ -156,13 +156,20 @@ Stats_Init() {
 Stats_FlushToDisk() {
     global gStats_Lifetime, gStats_Session, STATS_LIFETIME_KEYS, STATS_INI_PATH, cfg
     global gStats_Dirty, gGUI_State
+    Profiler.Enter("Stats_FlushToDisk") ; @profile
 
-    if (!cfg.StatsTrackingEnabled)
+    if (!cfg.StatsTrackingEnabled) {
+        Profiler.Leave() ; @profile
         return
-    if (!gStats_Dirty)
+    }
+    if (!gStats_Dirty) {
+        Profiler.Leave() ; @profile
         return
-    if (gGUI_State = "ALT_PENDING" || gGUI_State = "ACTIVE")
+    }
+    if (gGUI_State = "ALT_PENDING" || gGUI_State = "ACTIVE") {
+        Profiler.Leave() ; @profile
         return  ; Defer to next housekeeping cycle
+    }
 
     statsPath := STATS_INI_PATH
 
@@ -191,12 +198,14 @@ Stats_FlushToDisk() {
     ; Try pump offload first (pipe write ~10-15μs vs 10-75ms of IniWrite loop)
     if (_Stats_TrySendToPump(statsPath, content)) {
         gStats_Dirty := false
+        Profiler.Leave() ; @profile
         return
     }
 
     ; Fallback: direct write (pump not connected or send failed)
     _Stats_DirectWrite(statsPath, content)
     gStats_Dirty := false
+    Profiler.Leave() ; @profile
 }
 
 ; Force-flush stats directly to disk (bypass dirty flag, state gate, and pump offload).


### PR DESCRIPTION
## Summary

- Instrument 20 functions across 12 files, closing the major profiler blind spots identified in a full coverage audit
- **D3D11/compositor pipeline**: `Shader_PreRender` (40+ COM calls/frame/shader), `FX_GPU_DrawInnerShadow`, `FX_GPU_DrawHover`, `_FX_DrawSoftRect/2`, `BGImg_Draw`, `D2D_SetClipRect`, `D2D_Commit`
- **Paint sub-phases**: `_GUI_DrawFooter`, `_GUI_DrawScrollbar`, `_FX_GetShadowParams`
- **Animation frame loop**: `_Anim_UpdateTweens`, `_Anim_SyncOverlayOpacity`
- **Interceptor callbacks**: `_INT_Tab_Up`, `_INT_Escape_Down` (completes 6/6 key callback coverage)
- **State/data layer**: `GUI_RefilterForWorkspaceChange`, `GUI_ReconcileDestroys`, `_WEH_FastPathBatch`
- **Critical-holding background timers**: `Stats_FlushToDisk`, `IPC__ClientTick`
- Added try-catch error boundary to `_WEH_FastPathBatch` (required by static analysis for timer callbacks)

Closes #340

## Test plan

- [x] Static analysis: all 85 checks pass (including `profiler_balance` for Enter/Leave matching)
- [x] Unit tests: 942/942 pass
- [ ] `--profile` build: verify new spans appear in speedscope flame graph
- [ ] Release build: verify `; @profile` lines are stripped (zero runtime cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)