### PR TITLE
Make 2 internal-only functions private in gui_state.ahk

### DIFF
--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -484,7 +484,7 @@ GUI_OnWorkspaceFlips() {
             if (wsName != "" && wsName != gGUI_CurrentWSName) {
                 gGUI_CurrentWSName := wsName
                 GUI_UpdateFooterText()
-                GUI_HandleWorkspaceSwitch()
+                _GUI_HandleWorkspaceSwitch()
             }
             Critical "Off"
         }
@@ -529,8 +529,8 @@ GUI_DismissOverlay() {
 ; Handle workspace context switch during ACTIVE state.
 ; Resets selection to top, marks sticky context switch, and requests fresh
 ; display list when frozen. Caller must hold Critical "On".
-GUI_HandleWorkspaceSwitch() {
-    Profiler.Enter("GUI_HandleWorkspaceSwitch") ; @profile
+_GUI_HandleWorkspaceSwitch() {
+    Profiler.Enter("_GUI_HandleWorkspaceSwitch") ; @profile
     global gGUI_State, gGUI_Sel, gGUI_ScrollTop, gGUI_WSContextSwitch
     global gGUI_CurrentWSName, gGUI_ToggleBase, gGUI_DisplayItems, gGUI_OverlayVisible
     global cfg, gGUI_WorkspaceMode, WS_MODE_CURRENT
@@ -549,7 +549,7 @@ GUI_HandleWorkspaceSwitch() {
     ; Just re-filter to show the right windows.
 
     ; Re-filter display items and select foreground window
-    GUI_RefilterForWorkspaceChange()
+    _GUI_RefilterForWorkspaceChange()
 
     ; Repaint if overlay is visible.  GUI_Repaint handles resize internally
     ; with deferred SetWindowPos (right before ULW) so DWM can't present a
@@ -592,9 +592,9 @@ _GUI_FilterDisplayItems(items) {
 ; Re-filter display items for a workspace change (window moved or workspace switched).
 ; Resets scroll/selection and tries to select the foreground window, since a workspace
 ; change is a context switch — the moved/focused window is what the user wants.
-GUI_RefilterForWorkspaceChange() {
+_GUI_RefilterForWorkspaceChange() {
     global gGUI_DisplayItems, gGUI_Sel, gGUI_ScrollTop, gGUI_ToggleBase
-    Profiler.Enter("GUI_RefilterForWorkspaceChange") ; @profile
+    Profiler.Enter("_GUI_RefilterForWorkspaceChange") ; @profile
     gGUI_DisplayItems := _GUI_FilterDisplayItems(gGUI_ToggleBase)
     gGUI_ScrollTop := 0
     gGUI_Sel := 1
@@ -612,7 +612,7 @@ GUI_RefilterForWorkspaceChange() {
 }
 
 ; Re-filter display items after workspace mode toggle.
-; Unlike RefilterForWorkspaceChange (which selects foreground window),
+; Unlike _GUI_RefilterForWorkspaceChange (which selects foreground window),
 ; this preserves MRU-based selection since the user is browsing, not switching.
 GUI_ApplyWorkspaceFilter() {
     _GUI_ApplyFilter("GUI_ApplyWorkspaceFilter")

--- a/tests/gui_tests_data.ahk
+++ b/tests/gui_tests_data.ahk
@@ -187,7 +187,7 @@ RunGUITests_Data() {
     gGUI_WSContextSwitch := false
 
     ; Simulate workspace change (direct state + production function)
-    GUI_HandleWorkspaceSwitch()
+    _GUI_HandleWorkspaceSwitch()
 
     GUI_AssertEq(gGUI_Sel, 1, "WS change: sel reset to 1")
     GUI_AssertEq(gGUI_WSContextSwitch, true, "WS change: WSContextSwitch set to true")
@@ -209,7 +209,7 @@ RunGUITests_Data() {
 
     ; Trigger WS change to set the flag (switch to "Other" which has 6 items)
     gGUI_CurrentWSName := "Other"
-    GUI_HandleWorkspaceSwitch()
+    _GUI_HandleWorkspaceSwitch()
     GUI_AssertEq(gGUI_WSContextSwitch, true, "WSContextSwitch persist: flag set")
     GUI_AssertEq(gGUI_Sel, 1, "WSContextSwitch persist: initial sel=1")
 
@@ -230,7 +230,7 @@ RunGUITests_Data() {
     gGUI_Sel := 3  ; Start at non-1 to verify production code resets it
     SetupTestItems(1)
 
-    GUI_HandleWorkspaceSwitch()
+    _GUI_HandleWorkspaceSwitch()
 
     GUI_AssertEq(gGUI_Sel, 1, "WS change single: sel=1")
 
@@ -786,7 +786,7 @@ RunGUITests_Data() {
     }
 
     ; ============================================================
-    ; GUI_HandleWorkspaceSwitch WORKSPACE DATA PATCHING TESTS
+    ; _GUI_HandleWorkspaceSwitch WORKSPACE DATA PATCHING TESTS
     ; ============================================================
 
     ; ----- Test: Frozen record refs have live workspace data after switch -----
@@ -811,7 +811,7 @@ RunGUITests_Data() {
     gGUI_ToggleBase := items
     gGUI_DisplayItems := items.Clone()
 
-    GUI_HandleWorkspaceSwitch()
+    _GUI_HandleWorkspaceSwitch()
 
     GUI_AssertEq(items[1].workspaceName, "New", "WSPatch: item 1 workspaceName is 'New'")
     GUI_AssertEq(items[1].isOnCurrentWorkspace, true, "WSPatch: item 1 isOnCurrentWorkspace true")
@@ -833,7 +833,7 @@ RunGUITests_Data() {
     gGUI_ToggleBase := items
     gGUI_DisplayItems := items.Clone()
 
-    GUI_HandleWorkspaceSwitch()
+    _GUI_HandleWorkspaceSwitch()
 
     GUI_AssertEq(items[1].workspaceName, "Main", "WSPatch noop: workspaceName unchanged")
     GUI_AssertEq(items[1].isOnCurrentWorkspace, true, "WSPatch noop: isOnCurrentWorkspace still true")
@@ -921,7 +921,7 @@ RunGUITests_Data() {
     gGUI_ToggleBase := items
     gGUI_DisplayItems := items.Clone()
 
-    GUI_HandleWorkspaceSwitch()
+    _GUI_HandleWorkspaceSwitch()
 
     GUI_AssertEq(gGUI_HoverRow, 0, "WSHover: gGUI_HoverRow cleared to 0")
     GUI_AssertEq(gGUI_HoverBtn, "", "WSHover: gGUI_HoverBtn cleared to empty")
@@ -941,7 +941,7 @@ RunGUITests_Data() {
     gGUI_ToggleBase := items
     gGUI_DisplayItems := items.Clone()
 
-    GUI_HandleWorkspaceSwitch()
+    _GUI_HandleWorkspaceSwitch()
 
     GUI_AssertEq(gGUI_HoverRow, 0, "WSHoverFull: hover row cleared")
     GUI_AssertEq(gGUI_HoverBtn, "", "WSHoverFull: hover btn cleared")
@@ -1022,7 +1022,7 @@ RunGUITests_Data() {
     ; ============================================================
     ; GUI_OnWorkspaceFlips CALLBACK TESTS
     ; Covers the workspace change entry point that reads gWS_Meta
-    ; and calls GUI_HandleWorkspaceSwitch.
+    ; and calls _GUI_HandleWorkspaceSwitch.
     ; ============================================================
 
     ; ----- Test: OnWorkspaceFlips detects workspace change -----


### PR DESCRIPTION
## Summary

- Renamed `GUI_HandleWorkspaceSwitch` → `_GUI_HandleWorkspaceSwitch` and `GUI_RefilterForWorkspaceChange` → `_GUI_RefilterForWorkspaceChange` — both had zero external callers
- Updated all call sites, profiler strings, and comments in `gui_state.ahk`
- Updated test references in `gui_tests_data.ahk`

Closes #342

## Test plan

- [x] `query_visibility.ps1` reports 0 zero-caller public functions
- [x] Static analysis passes (86/86 checks)
- [x] All 1011 tests pass (`.\tests\test.ps1 --live`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)