### PR TITLE
Fix nested D2D BeginDraw corruption in hide-path STA reentrancy

### DIFF
--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -439,12 +439,15 @@ _Anim_DoActualHide() {
     GUI_ClearHoverState()
 
     ; Clear D2D surface — ensures clean swap chain buffer for next Show.
-    ; STA reentrancy guard: BeginDraw/EndDraw/Present pump the message loop,
-    ; which can dispatch callbacks that reach GUI_Repaint (e.g., via
-    ; Anim_ForceCompleteHide during a new show sequence while state is ACTIVE).
-    ; Save/restore handles nesting when called from within an existing paint.
-    if (gD2D_RT) {
-        wasInProgress := gPaint_RepaintInProgress
+    ; Skip when a paint is in progress: if called during an outer paint's
+    ; STA pump (e.g., ForceCompleteHide from TAB_DN during hide-fade paint),
+    ; nested AcquireBackBuffer overwrites gD2D_BackBuffer and nested BeginDraw
+    ; fails (D2DERR_WRONG_STATE), corrupting the outer paint's D2D state.
+    ; The next show's first paint will clear the surface.  The window is about
+    ; to be hidden anyway, so skipping the clear has no visible effect.
+    ; When NOT in a paint, the guard blocks nested GUI_Repaint from timer
+    ; callbacks dispatched during this block's STA pump.
+    if (gD2D_RT && !gPaint_RepaintInProgress) {
         gPaint_RepaintInProgress := true
         try {
             if (D2D_AcquireBackBuffer()) {
@@ -455,9 +458,10 @@ _Anim_DoActualHide() {
                 D2D_Present(0)  ; Immediate — about to hide
             }
         } catch {
+            try gD2D_RT.EndDraw()   ; Best-effort: don't leave D2D in BeginDraw state
             D2D_ReleaseBackBuffer()
         } finally {
-            gPaint_RepaintInProgress := wasInProgress
+            gPaint_RepaintInProgress := false
         }
     }
 

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -146,11 +146,12 @@ GUI_HideOverlay() {
     ; Clear D2D surface BEFORE hiding — ensures a clean swap chain buffer
     ; for the next Show().  SwapChain.Present() works for hidden windows
     ; (unlike HwndRenderTarget), so the clear actually commits.
-    ; STA reentrancy guard: BeginDraw/EndDraw/Present pump the message loop,
-    ; which can dispatch callbacks that reach GUI_Repaint. Save/restore
-    ; handles nesting when called from within an existing paint.
-    if (gD2D_RT) {
-        wasInProgress := gPaint_RepaintInProgress
+    ; Skip when a paint is in progress: nested AcquireBackBuffer overwrites
+    ; gD2D_BackBuffer and nested BeginDraw fails (D2DERR_WRONG_STATE),
+    ; corrupting the outer paint's D2D state.  The next show's first paint
+    ; will clear the surface.  When NOT in a paint, the guard blocks nested
+    ; GUI_Repaint from timer callbacks dispatched during this block's STA pump.
+    if (gD2D_RT && !gPaint_RepaintInProgress) {
         gPaint_RepaintInProgress := true
         try {
             if (D2D_AcquireBackBuffer()) {
@@ -161,9 +162,10 @@ GUI_HideOverlay() {
                 D2D_Present(0)  ; Immediate — about to hide
             }
         } catch {
+            try gD2D_RT.EndDraw()   ; Best-effort: don't leave D2D in BeginDraw state
             D2D_ReleaseBackBuffer()
         } finally {
-            gPaint_RepaintInProgress := wasInProgress
+            gPaint_RepaintInProgress := false
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix D2D state corruption when `_Anim_DoActualHide` / `GUI_HideOverlay` run during an outer paint's STA pump (e.g., `ForceCompleteHide` from rapid Alt+Tab during hide-fade)
- Replace `wasInProgress` save/restore pattern with skip-when-painting guard: skip D2D clear entirely when `gPaint_RepaintInProgress` is already true
- Add best-effort `EndDraw` in catch blocks to avoid leaving D2D in BeginDraw state on partial failure

Closes #348

## Test plan

- [x] Static analysis pre-gate (86 checks pass)
- [x] Unit tests (564/564 pass)
- [x] GUI tests (351/351 pass)
- [x] Live tests (64/64 pass)
- [x] Flight recorder tests (32/32 pass)
- [x] Ownership manifest verified unchanged
- [ ] Manual: Alt+Tab → release Alt during fade-out → Alt+Tab again quickly — verify no blank frame flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)