### PR TITLE
Optimize query tool runtime 35-47% (internal-only)

### DIFF
--- a/.claude/skills/review-tool-speed/SKILL.md
+++ b/.claude/skills/review-tool-speed/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 ---
 Enter planning mode. Investigate query tool runtime and find optimization opportunities.
 
-The query tools (`query_*.ps1` in project root) are critical for keeping context bloat down and getting programmatic answers.
+The query tools (`query_*.ps1` in `tools/`) are critical for keeping context bloat down and getting programmatic answers.
 
 1. Investigate each query tool for potential optimizations to decrease runtime. Optimizations must be **internal only** — no change to output, function, or contract of the tool.
 2. For each recommendation, include an analysis statement explaining why it's internal-only and doesn't change the tool's job or contract.
@@ -14,4 +14,26 @@ The query tools (`query_*.ps1` in project root) are critical for keeping context
 
 Research the query tools deeply. Write a plan for all optimizations found. Ignore any existing plans — create a fresh one.
 
-Include in the plan a verification step - Run timing comparison (before vs after) each change. Theoretical changes have provably been hidden regressions. Validate. 
+## Measurement & Verification Tools
+
+Two tools in `tools/` support this workflow. Use them — do not reinvent timing or golden-output infrastructure.
+
+### `tools/bench_query.ps1` — Timing benchmark
+Runs all query tools with representative args, reports external and internal timing.
+```
+powershell -File tools/bench_query.ps1                  # 3 iterations, full report
+powershell -File tools/bench_query.ps1 -InternalOnly    # internal timing only
+powershell -File tools/bench_query.ps1 -Iterations 5    # more iterations for stability
+```
+
+### `tools/verify_query.ps1` — Golden output capture & verification
+Captures tool output before changes, verifies output is unchanged after. Strips timing lines automatically. 22 test cases across all query tools.
+```
+powershell -File tools/verify_query.ps1 -Capture        # save golden (prints dir path)
+powershell -File tools/verify_query.ps1 -Verify <dir>   # compare against golden
+```
+
+### Required workflow
+1. **Before changes:** Run `verify_query.ps1 -Capture` and `bench_query.ps1` for baseline
+2. **After each change:** Run `verify_query.ps1 -Verify <golden-dir>` — must pass
+3. **After all changes:** Run `bench_query.ps1` — compare against baseline, no regressions

--- a/tools/_query_helpers.ps1
+++ b/tools/_query_helpers.ps1
@@ -42,6 +42,29 @@ function Clean-Line {
     return $cleaned
 }
 
+# Batch version of Clean-Line: eliminates per-line function call overhead (~30k calls -> 1 call)
+# Returns string[] identical to calling Clean-Line on each element individually.
+function Bulk-CleanLines {
+    param([string[]]$Lines)
+    $count = $Lines.Count
+    $result = [string[]]::new($count)
+    for ($i = 0; $i -lt $count; $i++) {
+        $trimmed = $Lines[$i].TrimStart()
+        if ($trimmed.Length -eq 0 -or $trimmed[0] -eq ';') {
+            $result[$i] = ''
+            continue
+        }
+        if ($trimmed.IndexOf('"') -lt 0 -and $trimmed.IndexOf("'") -lt 0 -and $trimmed.IndexOf(';') -lt 0) {
+            $result[$i] = $trimmed
+            continue
+        }
+        $cleaned = $script:_rxDblQuote.Replace($trimmed, '""')
+        $cleaned = $script:_rxSglQuote.Replace($cleaned, "''")
+        $result[$i] = $script:_rxComment.Replace($cleaned, '')
+    }
+    return ,$result
+}
+
 function Strip-Nested {
     param([string]$s)
     $result = [System.Text.StringBuilder]::new($s.Length)

--- a/tools/bench_query.ps1
+++ b/tools/bench_query.ps1
@@ -1,69 +1,163 @@
-# bench_query.ps1 - Benchmark query tools
+# bench_query.ps1 - Benchmark all query tools
 #
-# Runs each of the slowest query tools 3 times, captures "Completed in Xms"
-# from output, and reports min/avg/max.
+# Runs each query tool with representative arguments, captures both
+# external (wall clock) and internal (tool-reported) timing.
+# Used by /review-tool-speed to establish baselines and measure impact.
 #
 # Usage:
-#   powershell -File tools/bench_query.ps1
+#   powershell -File tools/bench_query.ps1              (3 iterations, all tools)
+#   powershell -File tools/bench_query.ps1 -Iterations 5
+#   powershell -File tools/bench_query.ps1 -InternalOnly
 
 param(
-    [int]$Iterations = 3
+    [int]$Iterations = 3,
+    [switch]$InternalOnly
 )
 
 $ErrorActionPreference = 'Stop'
 
-# Define the benchmark targets with representative arguments
+# === Curated test table: representative args that exercise main code paths ===
+# Add new query tools here when created
 $benchmarks = @(
-    @{ Name = "query_visibility";           Cmd = "powershell -File `"$PSScriptRoot\query_visibility.ps1`"" }
-    @{ Name = "query_callchain";            Cmd = "powershell -File `"$PSScriptRoot\query_callchain.ps1`" GUI_Repaint" }
-    @{ Name = "query_impact";               Cmd = "powershell -File `"$PSScriptRoot\query_impact.ps1`" GUI_Repaint" }
-    @{ Name = "query_function_visibility";  Cmd = "powershell -File `"$PSScriptRoot\query_function_visibility.ps1`" -Discover" }
-    @{ Name = "query_timers";               Cmd = "powershell -File `"$PSScriptRoot\query_timers.ps1`"" }
-    @{ Name = "query_messages";             Cmd = "powershell -File `"$PSScriptRoot\query_messages.ps1`"" }
+    @{ Tool = 'query_config.ps1';               Args = @() },
+    @{ Tool = 'query_state.ps1';                Args = @('ACTIVE', 'TAB_STEP') },
+    @{ Tool = 'query_events.ps1';               Args = @('focus') },
+    @{ Tool = 'query_function.ps1';             Args = @('GUI_Repaint') },
+    @{ Tool = 'query_callchain.ps1';            Args = @('GUI_Repaint') },
+    @{ Tool = 'query_function_visibility.ps1';  Args = @('GUI_Repaint') },
+    @{ Tool = 'query_global_ownership.ps1';     Args = @('gGUI_State') },
+    @{ Tool = 'query_impact.ps1';               Args = @('GUI_Repaint') },
+    @{ Tool = 'query_mutations.ps1';            Args = @('gGUI_State') },
+    @{ Tool = 'query_visibility.ps1';           Args = @() },
+    @{ Tool = 'query_interface.ps1';            Args = @('gui_state.ahk') },
+    @{ Tool = 'query_timers.ps1';               Args = @() },
+    @{ Tool = 'query_includes.ps1';             Args = @('gui_state.ahk') },
+    @{ Tool = 'query_ipc.ps1';                  Args = @('IPC_MSG_SNAPSHOT') },
+    @{ Tool = 'query_messages.ps1';             Args = @('0x0312') },
+    @{ Tool = 'query_instrumentation.ps1';      Args = @() },
+    @{ Tool = 'query_shader.ps1';               Args = @() }
 )
 
-# Extract milliseconds from "Completed in Xms" output
 $rxCompleted = [regex]::new('Completed in (\d+)ms')
+$rxPass = [regex]::new('pass1:\s*(\d+)ms.*pass2:\s*(\d+)ms')
+
+# === Coverage check: detect stale table vs actual query_*.ps1 files ===
+$knownTools = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+foreach ($b in $benchmarks) { [void]$knownTools.Add($b.Tool) }
+
+$actualFiles = Get-ChildItem $PSScriptRoot -Filter "query_*.ps1" | ForEach-Object { $_.Name }
+$coverageWarnings = $false
+
+foreach ($f in $actualFiles) {
+    if (-not $knownTools.Contains($f)) {
+        if (-not $coverageWarnings) { Write-Host ""; $coverageWarnings = $true }
+        Write-Host "  NOTE: Uncovered query tool '$f' - add to benchmark table?" -ForegroundColor Yellow
+    }
+}
+foreach ($b in $benchmarks) {
+    if (-not (Test-Path (Join-Path $PSScriptRoot $b.Tool))) {
+        if (-not $coverageWarnings) { Write-Host ""; $coverageWarnings = $true }
+        Write-Host "  NOTE: Expected query tool '$($b.Tool)' missing - remove from benchmark table?" -ForegroundColor Yellow
+    }
+}
 
 Write-Host ""
 Write-Host "  === Query Tool Benchmark ($Iterations iterations) ===" -ForegroundColor Cyan
 Write-Host ""
 
-$results = @()
+$results = [System.Collections.ArrayList]::new()
 
 foreach ($bench in $benchmarks) {
-    $times = @()
-    Write-Host "  $($bench.Name)..." -NoNewline -ForegroundColor White
+    $script = Join-Path $PSScriptRoot $bench.Tool
+    if (-not (Test-Path $script)) {
+        Write-Host "  SKIP $($bench.Tool) - not found" -ForegroundColor Red
+        continue
+    }
 
-    for ($i = 0; $i -lt $Iterations; $i++) {
-        $output = & cmd /c $bench.Cmd 2>&1 | Out-String
+    $argLabel = if ($bench.Args.Count -gt 0) { " " + ($bench.Args -join ' ') } else { "" }
+    $label = "$($bench.Tool)$argLabel"
+    Write-Host "  $label..." -NoNewline -ForegroundColor White
+
+    $externalTimes = @()
+    $internalTimes = @()
+    $passDetails = ""
+
+    for ($r = 0; $r -lt $Iterations; $r++) {
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        if ($bench.Args.Count -gt 0) {
+            $output = & powershell -NoProfile -File $script @($bench.Args) 2>&1 | Out-String
+        } else {
+            $output = & powershell -NoProfile -File $script 2>&1 | Out-String
+        }
+        $sw.Stop()
+        $externalTimes += $sw.ElapsedMilliseconds
+
         $m = $rxCompleted.Match($output)
         if ($m.Success) {
-            $times += [int]$m.Groups[1].Value
-        } else {
-            Write-Host " ERROR (no timing in output)" -ForegroundColor Red
-            Write-Host $output -ForegroundColor DarkGray
-            break
+            $internalTimes += [int]$m.Groups[1].Value
+        }
+
+        # Capture pass details from last run
+        if ($r -eq $Iterations - 1) {
+            $pm = $rxPass.Match($output)
+            if ($pm.Success) {
+                $passDetails = " (p1: $($pm.Groups[1].Value)ms, p2: $($pm.Groups[2].Value)ms)"
+            }
         }
     }
 
-    if ($times.Count -eq $Iterations) {
-        $min = ($times | Measure-Object -Minimum).Minimum
-        $max = ($times | Measure-Object -Maximum).Maximum
-        $avg = [math]::Round(($times | Measure-Object -Average).Average)
-        Write-Host " min=$($min)ms  avg=$($avg)ms  max=$($max)ms" -ForegroundColor Green
-        $results += @{ Name = $bench.Name; Min = $min; Avg = $avg; Max = $max; Times = $times }
+    # Report median (middle value of sorted array)
+    $sortedExt = $externalTimes | Sort-Object
+    $medianIdx = [math]::Floor($Iterations / 2)
+    $extMedian = $sortedExt[$medianIdx]
+
+    if ($InternalOnly) {
+        if ($internalTimes.Count -eq $Iterations) {
+            $sortedInt = $internalTimes | Sort-Object
+            $intMedian = $sortedInt[$medianIdx]
+            Write-Host " ${intMedian}ms${passDetails}" -ForegroundColor Green
+        } else {
+            Write-Host " (no internal timing)" -ForegroundColor DarkGray
+        }
+    } else {
+        $intStr = ""
+        if ($internalTimes.Count -eq $Iterations) {
+            $sortedInt = $internalTimes | Sort-Object
+            $intMedian = $sortedInt[$medianIdx]
+            $intStr = "  internal: ${intMedian}ms${passDetails}"
+        }
+        Write-Host " ${extMedian}ms${intStr}" -ForegroundColor Green
     }
+
+    [void]$results.Add(@{
+        Label = $label
+        ExtMedian = $extMedian
+        IntMedian = if ($internalTimes.Count -eq $Iterations) { ($internalTimes | Sort-Object)[$medianIdx] } else { -1 }
+        PassDetails = $passDetails
+    })
 }
 
 # Summary table
 Write-Host ""
-Write-Host "  === Summary ===" -ForegroundColor Cyan
-Write-Host "  $("Tool".PadRight(32)) $("Min".PadLeft(6))  $("Avg".PadLeft(6))  $("Max".PadLeft(6))" -ForegroundColor White
-Write-Host "  $("-" * 58)" -ForegroundColor DarkGray
+Write-Host "  === Summary (median of $Iterations runs) ===" -ForegroundColor Cyan
 
-foreach ($r in $results) {
-    $color = if ($r.Avg -gt 1000) { "Yellow" } elseif ($r.Avg -gt 500) { "White" } else { "Green" }
-    Write-Host "  $($r.Name.PadRight(32)) $("$($r.Min)ms".PadLeft(6))  $("$($r.Avg)ms".PadLeft(6))  $("$($r.Max)ms".PadLeft(6))" -ForegroundColor $color
+if ($InternalOnly) {
+    Write-Host "  $("Tool".PadRight(50)) $("Internal".PadLeft(10))" -ForegroundColor White
+    Write-Host "  $("-" * 62)" -ForegroundColor DarkGray
+    foreach ($r in $results) {
+        $intStr = if ($r.IntMedian -ge 0) { "$($r.IntMedian)ms" } else { "n/a" }
+        $color = if ($r.IntMedian -gt 800) { "Yellow" } elseif ($r.IntMedian -gt 400) { "White" } else { "Green" }
+        Write-Host "  $($r.Label.PadRight(50)) $($intStr.PadLeft(10))" -ForegroundColor $color
+    }
+} else {
+    Write-Host "  $("Tool".PadRight(50)) $("External".PadLeft(10))  $("Internal".PadLeft(10))" -ForegroundColor White
+    Write-Host "  $("-" * 74)" -ForegroundColor DarkGray
+    foreach ($r in $results) {
+        $intStr = if ($r.IntMedian -ge 0) { "$($r.IntMedian)ms" } else { "n/a" }
+        $color = if ($r.IntMedian -gt 800) { "Yellow" } elseif ($r.IntMedian -gt 400) { "White" } else { "Green" }
+        Write-Host "  $($r.Label.PadRight(50)) $("$($r.ExtMedian)ms".PadLeft(10))  $($intStr.PadLeft(10))" -ForegroundColor $color
+    }
 }
+
 Write-Host ""

--- a/tools/query_callchain.ps1
+++ b/tools/query_callchain.ps1
@@ -62,6 +62,8 @@ $funcRegistry = @{}
 $fileCache = @{}
 # cleanedCache: filePath -> string[] (cleaned lines, parallel to fileCache)
 $cleanedCache = @{}
+# braceDeltaCache: filePath -> int[] (brace open-close delta per line, reused in Pass 2)
+$braceDeltaCache = @{}
 
 foreach ($file in $srcFiles) {
     $text = [System.IO.File]::ReadAllText($file.FullName)
@@ -71,13 +73,11 @@ foreach ($file in $srcFiles) {
 
     # Pre-clean all lines and cache for Pass 2 reuse
     $lineCount = $lines.Count
-    $cleaned_arr = [string[]]::new($lineCount)
-    for ($i = 0; $i -lt $lineCount; $i++) {
-        $cleaned_arr[$i] = Clean-Line $lines[$i]
-    }
+    $cleaned_arr = Bulk-CleanLines $lines
     $cleanedCache[$file.FullName] = $cleaned_arr
 
     $depth = 0
+    $brace_arr = [int[]]::new($lineCount)
 
     for ($i = 0; $i -lt $lineCount; $i++) {
         $cleaned = $cleaned_arr[$i]
@@ -113,9 +113,12 @@ foreach ($file in $srcFiles) {
         }
 
         if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
-        $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
+        $delta = ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
+        $brace_arr[$i] = $delta
+        $depth += $delta
         if ($depth -lt 0) { $depth = 0 }
     }
+    $braceDeltaCache[$file.FullName] = $brace_arr
 }
 
 # Build lookup set for fast matching
@@ -165,6 +168,7 @@ $hasCallbackKeyword = $false
 foreach ($file in $srcFiles) {
     $lines = $fileCache[$file.FullName]
     $cleaned_arr = $cleanedCache[$file.FullName]
+    $brace_arr = $braceDeltaCache[$file.FullName]
 
     $depth = 0
     $inFunc = $false
@@ -207,7 +211,7 @@ foreach ($file in $srcFiles) {
         }
 
         if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
-        $depth += ($cleaned.Length - $cleaned.Replace('{','').Length) - ($cleaned.Length - $cleaned.Replace('}','').Length)
+        $depth += $brace_arr[$i]
         if ($depth -lt 0) { $depth = 0 }
 
         if ($inFunc -and $depth -le $funcDepth) {

--- a/tools/query_events.ps1
+++ b/tools/query_events.ps1
@@ -89,9 +89,13 @@ if ($events.Count -eq 0) {
     exit 1
 }
 
-# === Find emitters if requested ===
+# === Emitter scan helper (deferred for queries that won't display emitters) ===
 $emitterMap = @{}
-if ($Emitters.IsPresent -or $Query) {
+$emitterScanned = $false
+
+function Scan-Emitters {
+    if ($script:emitterScanned) { return }
+    $script:emitterScanned = $true
     $allFiles = Get-AhkSourceFiles $srcDir
     foreach ($file in $allFiles) {
         $fileText = [System.IO.File]::ReadAllText($file.FullName)
@@ -109,14 +113,17 @@ if ($Emitters.IsPresent -or $Query) {
                 $evName = $Matches[1]
                 $funcName = Find-EnclosingFunction $funcBounds $i
                 $lineNum = $i + 1
-                if (-not $emitterMap.ContainsKey($evName)) {
-                    $emitterMap[$evName] = [System.Collections.ArrayList]::new()
+                if (-not $script:emitterMap.ContainsKey($evName)) {
+                    $script:emitterMap[$evName] = [System.Collections.ArrayList]::new()
                 }
-                [void]$emitterMap[$evName].Add(@{ File = $relPath; Line = $lineNum; Func = $funcName })
+                [void]$script:emitterMap[$evName].Add(@{ File = $relPath; Line = $lineNum; Func = $funcName })
             }
         }
     }
 }
+
+# Eager scan when -Emitters flag is set
+if ($Emitters.IsPresent) { Scan-Emitters }
 
 # === Apply query filter ===
 $filtered = $events
@@ -145,6 +152,11 @@ if ($filtered.Count -eq 0 -and $Query) {
     Write-Host "`n  No events matching '$Query'" -ForegroundColor Red
     Write-Host "  Total: $($events.Count) event types"
     Write-Host ""; exit 1
+}
+
+# Deferred emitter scan: only when detail mode will display them
+if (-not $emitterScanned -and $Query -and $filtered.Count -le 5 -and $filtered.Count -gt 0) {
+    Scan-Emitters
 }
 
 # === Output ===

--- a/tools/query_function_visibility.ps1
+++ b/tools/query_function_visibility.ps1
@@ -95,10 +95,7 @@ foreach ($file in $srcFiles) {
 
     # Pre-clean all lines and cache for Pass 2 reuse
     $lineCount = $lines.Count
-    $cleaned_arr = [string[]]::new($lineCount)
-    for ($ci = 0; $ci -lt $lineCount; $ci++) {
-        $cleaned_arr[$ci] = Clean-Line $lines[$ci]
-    }
+    $cleaned_arr = Bulk-CleanLines $lines
     $cleanedCache[$file.FullName] = $cleaned_arr
 
     $depth = 0
@@ -321,11 +318,7 @@ if ($Query) {
             $qSplitLines = Split-Lines $fileCacheText[$file.FullName]
             $fileCache[$file.FullName] = $qSplitLines
             # Also build cleaned cache for lazily-split files
-            $qLineCount = $qSplitLines.Count
-            $qCleanedArr = [string[]]::new($qLineCount)
-            for ($qci = 0; $qci -lt $qLineCount; $qci++) {
-                $qCleanedArr[$qci] = Clean-Line $qSplitLines[$qci]
-            }
+            $qCleanedArr = Bulk-CleanLines $qSplitLines
             $cleanedCache[$file.FullName] = $qCleanedArr
         }
         $qLines = $fileCache[$file.FullName]

--- a/tools/query_impact.ps1
+++ b/tools/query_impact.ps1
@@ -71,10 +71,7 @@ foreach ($file in $srcFiles) {
 
     # Pre-clean all lines and cache for later step reuse
     $lineCount = $lines.Count
-    $cleaned_arr = [string[]]::new($lineCount)
-    for ($ci = 0; $ci -lt $lineCount; $ci++) {
-        $cleaned_arr[$ci] = Clean-Line $lines[$ci]
-    }
+    $cleaned_arr = Bulk-CleanLines $lines
     $cleanedCache[$file.FullName] = $cleaned_arr
 
     $depth = 0
@@ -249,8 +246,9 @@ $globalsWrittenSet = [System.Collections.Generic.HashSet[string]]::new(
 # First find which globals are declared in this function's scope
 $funcGlobalDecls = [System.Collections.Generic.HashSet[string]]::new(
     [System.StringComparer]::OrdinalIgnoreCase)
-foreach ($bodyLine in $funcBody) {
-    $cleaned = Clean-Line $bodyLine
+$funcCleanedArr = $cleanedCache[$funcFile]
+for ($bi = 0; $bi -lt $funcBody.Count; $bi++) {
+    $cleaned = $funcCleanedArr[$funcBodyStartIdx + $bi]
     if ($cleaned -match '^\s*global\s+(.+)') {
         $declPart = $Matches[1]
         $stripped = Strip-Nested $declPart
@@ -277,8 +275,8 @@ foreach ($gName in $funcGlobalDecls) {
         [regex]::new("\b$e\.\w+\s*[:+\-\*\/\.]+\=")
     )
 
-    foreach ($bodyLine in $funcBody) {
-        $cleaned = Clean-Line $bodyLine
+    for ($bi = 0; $bi -lt $funcBody.Count; $bi++) {
+        $cleaned = $funcCleanedArr[$funcBodyStartIdx + $bi]
         if ($cleaned -eq '') { continue }
 
         $isMutation = $mutPatterns[0].IsMatch($cleaned) -or
@@ -300,18 +298,30 @@ foreach ($gName in $funcGlobalDecls) {
 
 # ============================================================
 # Step 4: Find downstream readers of written globals
+# Batched: scan each file ONCE for ALL written globals (O(F) not O(G*F))
 # ============================================================
 $downstreamReaders = @{}  # globalName -> ArrayList of @{ RelPath; Func }
 
-foreach ($gw in $globalsWritten) {
-    $gName = $gw.Name
-    $readers = [System.Collections.ArrayList]::new()
-    $seenReaders = [System.Collections.Generic.HashSet[string]]::new(
-        [System.StringComparer]::OrdinalIgnoreCase)
+if ($globalsWritten.Count -gt 0) {
+    # Pre-build per-global tracking
+    $seenReadersAll = @{}
+    foreach ($gw in $globalsWritten) {
+        $downstreamReaders[$gw.Name] = [System.Collections.ArrayList]::new()
+        $seenReadersAll[$gw.Name] = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase)
+    }
 
     foreach ($file in $srcFiles) {
         $text = $fileCacheText[$file.FullName]
-        if ($text.IndexOf($gName, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
+
+        # Per-file pre-filter: which written globals appear in this file?
+        $relevantGlobals = [System.Collections.ArrayList]::new()
+        foreach ($gw in $globalsWritten) {
+            if ($text.IndexOf($gw.Name, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                [void]$relevantGlobals.Add($gw.Name)
+            }
+        }
+        if ($relevantGlobals.Count -eq 0) { continue }
 
         $lines = $fileCache[$file.FullName]
         $cleaned_arr = $cleanedCache[$file.FullName]
@@ -323,11 +333,12 @@ foreach ($gw in $globalsWritten) {
             $boundaryCache[$file.FullName] = $bounds
         }
 
-        # Check if any function in this file declares global <gName>
+        # Single pass: track function context + check all relevant globals
         $inFunc = $false
         $funcDepth = -1
         $curFunc = ""
-        $curFuncDeclaresGlobal = $false
+        $curFuncDeclaredGlobals = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::OrdinalIgnoreCase)
         $depth = 0
 
         for ($i = 0; $i -lt $lines.Count; $i++) {
@@ -351,7 +362,7 @@ foreach ($gw in $globalsWritten) {
                             $inFunc = $true
                             $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
                             $curFunc = $fn
-                            $curFuncDeclaresGlobal = $false
+                            $curFuncDeclaredGlobals.Clear()
                         }
                     }
                 }
@@ -368,19 +379,24 @@ foreach ($gw in $globalsWritten) {
 
             if (-not $inFunc) { continue }
 
-            # Check for global declaration inside function
-            if ($cleaned -match '^\s*global\s+' -and $cleaned -match "(?<!\w)$([regex]::Escape($gName))(?!\w)") {
-                $curFuncDeclaresGlobal = $true
+            # Check for global declarations of our target globals
+            if ($cleaned -match '^\s*global\s+') {
+                foreach ($gName in $relevantGlobals) {
+                    if ($cleaned -match "(?<!\w)$([regex]::Escape($gName))(?!\w)") {
+                        [void]$curFuncDeclaredGlobals.Add($gName)
+                    }
+                }
+                continue
             }
 
-            # Check for read reference (non-mutation, non-declaration line)
-            if ($curFuncDeclaresGlobal -and $cleaned -match "(?<![.\w])$([regex]::Escape($gName))(?!\w)") {
-                $isGlobalDeclLine = $cleaned -match '^\s*global\s+'
-                if (-not $isGlobalDeclLine) {
+            # Check for read references (non-declaration lines)
+            foreach ($gName in $relevantGlobals) {
+                if (-not $curFuncDeclaredGlobals.Contains($gName)) { continue }
+                if ($cleaned -match "(?<![.\w])$([regex]::Escape($gName))(?!\w)") {
                     $readerKey = "${relPath}:${curFunc}"
-                    if (-not $seenReaders.Contains($readerKey)) {
-                        [void]$seenReaders.Add($readerKey)
-                        [void]$readers.Add(@{
+                    if (-not $seenReadersAll[$gName].Contains($readerKey)) {
+                        [void]$seenReadersAll[$gName].Add($readerKey)
+                        [void]$downstreamReaders[$gName].Add(@{
                             RelPath = $relPath
                             Func    = $curFunc
                         })
@@ -390,9 +406,9 @@ foreach ($gw in $globalsWritten) {
         }
     }
 
-    if ($readers.Count -gt 0) {
-        $downstreamReaders[$gName] = $readers
-    }
+    # Remove empty entries
+    $emptyKeys = @($downstreamReaders.Keys | Where-Object { $downstreamReaders[$_].Count -eq 0 })
+    foreach ($k in $emptyKeys) { $downstreamReaders.Remove($k) }
 }
 
 # ============================================================

--- a/tools/query_mutations.ps1
+++ b/tools/query_mutations.ps1
@@ -49,11 +49,13 @@ $MUTATING_METHODS = 'Push|Pop|Delete|InsertAt|RemoveAt|Set|Clear'
 # ============================================================
 $declaration = $null
 $fileCache = @{}
+$fileCacheText = @{}
 
 foreach ($file in $srcFiles) {
     $text = [System.IO.File]::ReadAllText($file.FullName)
     if ($text.IndexOf($GlobalName, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
 
+    $fileCacheText[$file.FullName] = $text
     $lines = Split-Lines $text
     $fileCache[$file.FullName] = $lines
     $relPath = $file.FullName.Replace("$projectRoot\", '')
@@ -168,7 +170,13 @@ $literalValues = [System.Collections.Generic.HashSet[string]]::new(
     [System.StringComparer]::OrdinalIgnoreCase)
 
 foreach ($file in $srcFiles) {
-    $text = [System.IO.File]::ReadAllText($file.FullName)
+    if ($fileCacheText.ContainsKey($file.FullName)) {
+        $text = $fileCacheText[$file.FullName]
+    } else {
+        $text = [System.IO.File]::ReadAllText($file.FullName)
+        if ($text.IndexOf($GlobalName, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
+        $fileCacheText[$file.FullName] = $text
+    }
     if ($text.IndexOf($GlobalName, [StringComparison]::OrdinalIgnoreCase) -lt 0) { continue }
 
     if (-not $fileCache.ContainsKey($file.FullName)) {

--- a/tools/query_state.ps1
+++ b/tools/query_state.ps1
@@ -71,6 +71,16 @@ if ($funcStart -eq -1) {
 }
 if ($funcEnd -eq -1) { $funcEnd = $lines.Count - 1 }
 
+# Pre-clean function lines once (avoids 3x duplicate string cleaning in brace-tracking loops)
+$cleanedLines = [string[]]::new($lines.Count)
+for ($i = $funcStart; $i -le $funcEnd; $i++) {
+    $cl = $lines[$i] -replace '"[^"]*"', '""'
+    $cl = $cl -replace "'[^']*'", "''"
+    $cl = $cl -replace '\s;.*$', ''
+    if ($cl -match '^\s*;') { $cl = '' }
+    $cleanedLines[$i] = $cl
+}
+
 # === Parse event branches ===
 # The function uses top-level `if (evCode = TABBY_EV_*)` blocks.
 # Inside those, `if (gGUI_State = "STATE")` blocks handle per-state logic.
@@ -99,10 +109,7 @@ for ($i = $funcStart + 1; $i -lt $funcEnd; $i++) {
         $evDepth = 0
         $evBlockEnd = $i
         for ($j = $i; $j -le $funcEnd; $j++) {
-            $cl = $lines[$j] -replace '"[^"]*"', '""'
-            $cl = $cl -replace "'[^']*'", "''"
-            $cl = $cl -replace '\s;.*$', ''
-            if ($cl -match '^\s*;') { $cl = '' }
+            $cl = $cleanedLines[$j]
             foreach ($c in $cl.ToCharArray()) {
                 if ($c -eq '{') { $evDepth++ }
                 elseif ($c -eq '}') { $evDepth-- }
@@ -128,10 +135,7 @@ for ($i = $funcStart + 1; $i -lt $funcEnd; $i++) {
                 $stDepth = 0
                 $stBlockEnd = $k
                 for ($m = $k; $m -lt $evBlockEnd; $m++) {
-                    $scl = $lines[$m] -replace '"[^"]*"', '""'
-                    $scl = $scl -replace "'[^']*'", "''"
-                    $scl = $scl -replace '\s;.*$', ''
-                    if ($scl -match '^\s*;') { $scl = '' }
+                    $scl = $cleanedLines[$m]
                     foreach ($c in $scl.ToCharArray()) {
                         if ($c -eq '{') { $stDepth++ }
                         elseif ($c -eq '}') { $stDepth-- }

--- a/tools/query_visibility.ps1
+++ b/tools/query_visibility.ps1
@@ -48,9 +48,10 @@ foreach ($file in $srcFiles) {
 
     $depth = 0
     $lineCount = $lines.Count
+    $cleaned_arr = Bulk-CleanLines $lines
 
     for ($i = 0; $i -lt $lineCount; $i++) {
-        $cleaned = Clean-Line $lines[$i]
+        $cleaned = $cleaned_arr[$i]
         if ($cleaned -eq '') { continue }
 
         # Function definition at file scope (depth 0), public only (no _ prefix)

--- a/tools/verify_query.ps1
+++ b/tools/verify_query.ps1
@@ -1,0 +1,246 @@
+# verify_query.ps1 - Golden output capture and verification for query tools
+#
+# Captures "golden" output before internal changes, then verifies output
+# is unchanged after. Essential for /review-tool-speed where all changes
+# must be internal-only (no output/contract changes).
+#
+# Usage:
+#   powershell -File tools/verify_query.ps1 -Capture           (save golden to temp dir)
+#   powershell -File tools/verify_query.ps1 -Verify <dir>      (compare against golden)
+#
+# Workflow:
+#   1. Run -Capture before making changes (prints golden dir path)
+#   2. Make optimization changes
+#   3. Run -Verify <golden-dir> to confirm output unchanged
+
+param(
+    [switch]$Capture,
+    [string]$Verify
+)
+
+$ErrorActionPreference = 'Stop'
+
+# === Test cases: multiple modes per tool to exercise different code paths ===
+# Each entry: tool, args, output filename
+$testCases = @(
+    # query_state: index + specific branch
+    @{ Tool = 'query_state.ps1';                Args = @();                         Out = 'state_index.txt' },
+    @{ Tool = 'query_state.ps1';                Args = @('ACTIVE', 'TAB_STEP');     Out = 'state_branch.txt' },
+
+    # query_mutations: full analysis
+    @{ Tool = 'query_mutations.ps1';            Args = @('gGUI_State');             Out = 'mutations.txt' },
+
+    # query_events: index + query + emitters
+    @{ Tool = 'query_events.ps1';               Args = @();                         Out = 'events_index.txt' },
+    @{ Tool = 'query_events.ps1';               Args = @('focus');                  Out = 'events_query.txt' },
+    @{ Tool = 'query_events.ps1';               Args = @('-Emitters');              Out = 'events_emitters.txt' },
+
+    # query_impact: blast radius
+    @{ Tool = 'query_impact.ps1';               Args = @('GUI_Repaint');            Out = 'impact.txt' },
+
+    # query_callchain: forward + reverse
+    @{ Tool = 'query_callchain.ps1';            Args = @('GUI_Repaint');            Out = 'callchain_fwd.txt' },
+    @{ Tool = 'query_callchain.ps1';            Args = @('GUI_Repaint', '-Reverse'); Out = 'callchain_rev.txt' },
+
+    # query_visibility: full scan
+    @{ Tool = 'query_visibility.ps1';           Args = @();                         Out = 'visibility.txt' },
+
+    # query_function_visibility: single function
+    @{ Tool = 'query_function_visibility.ps1';  Args = @('GUI_Repaint');            Out = 'funcvis.txt' },
+
+    # query_global_ownership: single global
+    @{ Tool = 'query_global_ownership.ps1';     Args = @('gGUI_State');             Out = 'ownership.txt' },
+
+    # query_config: index + search + section
+    @{ Tool = 'query_config.ps1';               Args = @();                         Out = 'config_index.txt' },
+    @{ Tool = 'query_config.ps1';               Args = @('theme');                  Out = 'config_search.txt' },
+
+    # query_function: body extraction
+    @{ Tool = 'query_function.ps1';             Args = @('GUI_Repaint');            Out = 'function.txt' },
+
+    # query_interface: file interface
+    @{ Tool = 'query_interface.ps1';            Args = @('gui_state.ahk');          Out = 'interface.txt' },
+
+    # query_timers: all timers
+    @{ Tool = 'query_timers.ps1';               Args = @();                         Out = 'timers.txt' },
+
+    # query_includes: dependency tree
+    @{ Tool = 'query_includes.ps1';             Args = @('gui_state.ahk');          Out = 'includes.txt' },
+
+    # query_ipc: message flow
+    @{ Tool = 'query_ipc.ps1';                  Args = @('IPC_MSG_SNAPSHOT');       Out = 'ipc.txt' },
+
+    # query_messages: windows messages
+    @{ Tool = 'query_messages.ps1';             Args = @('0x0312');                 Out = 'messages.txt' },
+
+    # query_instrumentation: profiler coverage
+    @{ Tool = 'query_instrumentation.ps1';      Args = @();                         Out = 'instrumentation.txt' },
+
+    # query_shader: shader metadata
+    @{ Tool = 'query_shader.ps1';               Args = @();                         Out = 'shader.txt' }
+)
+
+# Lines matching these patterns are stripped before comparison (timing varies between runs)
+$stripPatterns = 'Completed in \d+ms|Scanning \d+ source|pass1:\s*\d+ms|pass2:\s*\d+ms'
+
+function Run-Tool {
+    param([string]$Tool, [string[]]$ToolArgs)
+    $script = Join-Path $PSScriptRoot $Tool
+    if ($ToolArgs.Count -gt 0) {
+        return & powershell -NoProfile -File $script @ToolArgs 2>&1
+    } else {
+        return & powershell -NoProfile -File $script 2>&1
+    }
+}
+
+function Strip-TimingLines {
+    param($Lines)
+    return $Lines | Where-Object { $_ -notmatch $stripPatterns }
+}
+
+# === Coverage check: detect stale table vs actual query_*.ps1 files ===
+$knownTools = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+foreach ($tc in $testCases) { [void]$knownTools.Add($tc.Tool) }
+
+$actualFiles = Get-ChildItem $PSScriptRoot -Filter "query_*.ps1" | ForEach-Object { $_.Name }
+
+foreach ($f in $actualFiles) {
+    if (-not $knownTools.Contains($f)) {
+        Write-Host "  NOTE: Uncovered query tool '$f' - add to test cases?" -ForegroundColor Yellow
+    }
+}
+foreach ($tool in $knownTools) {
+    if (-not (Test-Path (Join-Path $PSScriptRoot $tool))) {
+        Write-Host "  NOTE: Expected query tool '$tool' missing - remove from test cases?" -ForegroundColor Yellow
+    }
+}
+
+# === Capture mode ===
+if ($Capture) {
+    $goldenDir = Join-Path ([System.IO.Path]::GetTempPath()) "query_golden_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+    [void][System.IO.Directory]::CreateDirectory($goldenDir)
+
+    Write-Host ""
+    Write-Host "  === Capturing Golden Output ===" -ForegroundColor Cyan
+    Write-Host "  Dir: $goldenDir" -ForegroundColor DarkGray
+    Write-Host ""
+
+    $captured = 0
+    $skipped = 0
+
+    foreach ($tc in $testCases) {
+        $script = Join-Path $PSScriptRoot $tc.Tool
+        if (-not (Test-Path $script)) {
+            Write-Host "  SKIP $($tc.Tool) - not found" -ForegroundColor Red
+            $skipped++
+            continue
+        }
+
+        $argLabel = if ($tc.Args.Count -gt 0) { " " + ($tc.Args -join ' ') } else { "" }
+        Write-Host "  $($tc.Tool)$argLabel -> $($tc.Out)" -NoNewline -ForegroundColor White
+
+        $output = Run-Tool $tc.Tool $tc.Args
+        $filtered = Strip-TimingLines $output
+        $filtered | Out-File (Join-Path $goldenDir $tc.Out) -Encoding utf8
+        $captured++
+
+        Write-Host " OK" -ForegroundColor Green
+    }
+
+    Write-Host ""
+    Write-Host "  Captured $captured test cases ($skipped skipped)" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  Golden dir: $goldenDir" -ForegroundColor White
+    Write-Host "  To verify:  powershell -File tools/verify_query.ps1 -Verify `"$goldenDir`"" -ForegroundColor DarkGray
+    Write-Host ""
+    exit 0
+}
+
+# === Verify mode ===
+if ($Verify) {
+    if (-not (Test-Path $Verify)) {
+        Write-Host "  ERROR: Golden directory not found: $Verify" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host ""
+    Write-Host "  === Verifying Against Golden Output ===" -ForegroundColor Cyan
+    Write-Host "  Golden: $Verify" -ForegroundColor DarkGray
+    Write-Host ""
+
+    $passed = 0
+    $failed = 0
+    $skipped = 0
+    $failures = [System.Collections.ArrayList]::new()
+
+    foreach ($tc in $testCases) {
+        $goldenFile = Join-Path $Verify $tc.Out
+        if (-not (Test-Path $goldenFile)) {
+            $skipped++
+            continue
+        }
+
+        $script = Join-Path $PSScriptRoot $tc.Tool
+        if (-not (Test-Path $script)) {
+            $skipped++
+            continue
+        }
+
+        $argLabel = if ($tc.Args.Count -gt 0) { " " + ($tc.Args -join ' ') } else { "" }
+
+        $output = Run-Tool $tc.Tool $tc.Args
+        $filtered = Strip-TimingLines $output
+        $golden = Get-Content $goldenFile -Encoding utf8
+
+        $diff = Compare-Object $golden $filtered
+
+        if ($diff) {
+            Write-Host "  FAIL  $($tc.Tool)$argLabel" -ForegroundColor Red
+            $failed++
+            [void]$failures.Add(@{
+                Label = "$($tc.Tool)$argLabel"
+                Diff  = $diff | Select-Object -First 3
+            })
+        } else {
+            Write-Host "  PASS  $($tc.Tool)$argLabel" -ForegroundColor Green
+            $passed++
+        }
+    }
+
+    # Show failure details
+    if ($failures.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  === Failure Details ===" -ForegroundColor Red
+        foreach ($f in $failures) {
+            Write-Host "  $($f.Label):" -ForegroundColor Yellow
+            foreach ($d in $f.Diff) {
+                $marker = if ($d.SideIndicator -eq '<=') { "expected" } else { "actual" }
+                Write-Host "    ${marker}: $($d.InputObject)" -ForegroundColor DarkGray
+            }
+        }
+    }
+
+    Write-Host ""
+    $total = $passed + $failed
+    if ($failed -eq 0) {
+        Write-Host "  ALL $total TESTS PASSED" -ForegroundColor Green
+    } else {
+        Write-Host "  $failed/$total FAILED ($skipped skipped)" -ForegroundColor Red
+    }
+    Write-Host ""
+    exit $(if ($failed -gt 0) { 1 } else { 0 })
+}
+
+# === No mode specified ===
+Write-Host ""
+Write-Host "  Usage:" -ForegroundColor Yellow
+Write-Host "    verify_query.ps1 -Capture           Save golden output (before changes)" -ForegroundColor DarkGray
+Write-Host "    verify_query.ps1 -Verify <dir>      Compare against golden (after changes)" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "  Workflow:" -ForegroundColor White
+Write-Host "    1. -Capture before making changes" -ForegroundColor DarkGray
+Write-Host "    2. Make internal optimizations" -ForegroundColor DarkGray
+Write-Host "    3. -Verify <golden-dir> to confirm output unchanged" -ForegroundColor DarkGray
+Write-Host ""
+exit 1


### PR DESCRIPTION
## Summary

- Add `Bulk-CleanLines` to `_query_helpers.ps1` — batch function eliminating ~30k per-line function call overhead per tool invocation
- Adopt in 4 heaviest tools: query_callchain (-37.7%), query_impact (-47.4%), query_visibility (-39.1%), query_function_visibility (-35.0%)
- Cache brace deltas in query_callchain Pass 1 for Pass 2 reuse (avoids ~40k temporary string allocations)
- Batch query_impact Step 4 reader scan from O(G×F) to O(F) — single pass over files for all written globals
- Pre-clean lines once in query_state (was 3x duplicate), cache file text in query_mutations (was re-reading in Pass 2), defer emitter scan in query_events
- Replace `bench_query.ps1` with full 17-tool benchmark (external + internal timing, auto-detects uncovered/missing tools)
- Add `verify_query.ps1` for golden output capture & verification (22 test cases across all query tools)
- Update `/review-tool-speed` skill to document bench/verify tools and prescribe capture-change-verify workflow

All changes are internal-only — no output, argument, or contract changes. Verified via golden output comparison (22 test cases, all pass).

Closes #350

## Test plan

- [x] Golden output captured before changes, verified identical after (22 test cases via `verify_query.ps1`)
- [x] Internal timing benchmarked before and after (via `bench_query.ps1`)
- [x] No regressions in any tool timing
- [x] `bench_query.ps1` coverage check detects uncovered/missing tools
- [x] `verify_query.ps1 -Capture` and `-Verify` workflow tested end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)