### PR TITLE
Speed up static analysis pre-gate bottlenecks

### DIFF
--- a/tests/check_batch_guards.ps1
+++ b/tests/check_batch_guards.ps1
@@ -158,13 +158,55 @@ foreach ($file in $allFiles) {
     $isCritical = $criticalFiles.Contains($file.FullName)
 
     # For critical files, pre-process all lines (reused by critical_leaks)
+    # Inline BC_CleanLine/BC_StripComments/BC_CountBraces to eliminate ~36K function dispatches
     if ($isCritical) {
         $lineData = [System.Collections.ArrayList]::new($lines.Count)
         for ($li = 0; $li -lt $lines.Count; $li++) {
             $rawLine = $lines[$li]
-            $cleaned = BC_CleanLine $rawLine
-            $stripped = if ($cleaned -ne '') { BC_StripComments $rawLine } else { '' }
-            $braces = if ($cleaned -ne '') { BC_CountBraces $cleaned } else { @(0, 0) }
+
+            # Inline BC_CleanLine
+            $_trimmed = $rawLine.TrimStart()
+            if ($_trimmed.Length -eq 0 -or $_trimmed[0] -eq ';') {
+                $cleaned = ''
+            } else {
+                $cleaned = $rawLine
+                if ($rawLine.IndexOf('"') -ge 0) {
+                    $cleaned = $script:RX_DBL_STR.Replace($cleaned, '""')
+                }
+                if ($rawLine.IndexOf("'") -ge 0) {
+                    $cleaned = $script:RX_SGL_STR.Replace($cleaned, "''")
+                }
+                if ($cleaned.IndexOf(';') -ge 0) {
+                    $cleaned = $script:RX_CMT_TAIL.Replace($cleaned, '')
+                }
+            }
+
+            if ($cleaned -ne '') {
+                # Inline BC_StripComments
+                if ($rawLine.IndexOf(';') -ge 0) {
+                    $_stTrimmed = $rawLine.TrimStart()
+                    if ($_stTrimmed.Length -gt 0 -and $_stTrimmed[0] -ne ';') {
+                        $stripped = $script:RX_CMT_TAIL.Replace($rawLine, '')
+                    } else {
+                        $stripped = ''
+                    }
+                } else {
+                    $stripped = $rawLine
+                }
+
+                # Inline BC_CountBraces
+                $_opens = 0; $_closes = 0
+                for ($_ci = 0; $_ci -lt $cleaned.Length; $_ci++) {
+                    $_ch = $cleaned[$_ci]
+                    if ($_ch -eq '{') { $_opens++ }
+                    elseif ($_ch -eq '}') { $_closes++ }
+                }
+                $braces = @($_opens, $_closes)
+            } else {
+                $stripped = ''
+                $braces = @(0, 0)
+            }
+
             [void]$lineData.Add(@{ Raw = $rawLine; Cleaned = $cleaned; Stripped = $stripped; Braces = $braces })
         }
         $sharedLineData[$file.FullName] = $lineData
@@ -1104,11 +1146,37 @@ foreach ($file in $allFiles) {
     $funcGlobals = [System.Collections.Generic.HashSet[string]]::new(
         [System.StringComparer]::OrdinalIgnoreCase)
 
+    # Reuse $sharedLineData for critical files (avoids redundant BC_CleanLine/BC_CountBraces)
+    $_gtfHasLineData = $sharedLineData.ContainsKey($file.FullName)
+    $_gtfLineData = if ($_gtfHasLineData) { $sharedLineData[$file.FullName] } else { $null }
+
     for ($i = 0; $i -lt $lines.Count; $i++) {
-        $raw = $lines[$i]
-        if ($raw -match '^\s*;') { continue }
-        $cleaned = BC_CleanLine $raw
-        if ($cleaned -eq '') { continue }
+        if ($_gtfHasLineData) {
+            $_ld = $_gtfLineData[$i]
+            $cleaned = $_ld.Cleaned
+            if ($cleaned -eq '') { continue }
+            $raw = $_ld.Raw
+            $_brO = $_ld.Braces[0]; $_brC = $_ld.Braces[1]
+        } else {
+            $raw = $lines[$i]
+            if ($raw -match '^\s*;') { continue }
+            # Inline BC_CleanLine
+            $_tr = $raw.TrimStart()
+            if ($_tr.Length -eq 0 -or $_tr[0] -eq ';') { $cleaned = '' }
+            else {
+                $cleaned = $raw
+                if ($raw.IndexOf('"') -ge 0) { $cleaned = $script:RX_DBL_STR.Replace($cleaned, '""') }
+                if ($raw.IndexOf("'") -ge 0) { $cleaned = $script:RX_SGL_STR.Replace($cleaned, "''") }
+                if ($cleaned.IndexOf(';') -ge 0) { $cleaned = $script:RX_CMT_TAIL.Replace($cleaned, '') }
+            }
+            if ($cleaned -eq '') { continue }
+            # Inline BC_CountBraces
+            $_brO = 0; $_brC = 0
+            for ($_bi = 0; $_bi -lt $cleaned.Length; $_bi++) {
+                $_bc = $cleaned[$_bi]
+                if ($_bc -eq '{') { $_brO++ } elseif ($_bc -eq '}') { $_brC++ }
+            }
+        }
 
         # Detect function definitions (not inside another function)
         if (-not $inFunc -and $cleaned -match '^\s*(?:static\s+)?([A-Za-z_]\w*)\s*\(') {
@@ -1123,8 +1191,7 @@ foreach ($file in $allFiles) {
             }
         }
 
-        $braces = BC_CountBraces $cleaned
-        $depth += $braces[0] - $braces[1]
+        $depth += $_brO - $_brC
 
         if ($inFunc) {
             # Track global declarations
@@ -1248,11 +1315,36 @@ foreach ($cand in $gtfCandidates) {
     $falseLineSet = [System.Collections.Generic.HashSet[int]]::new()
     foreach ($fl in $cand.FalseLines) { [void]$falseLineSet.Add($fl) }
 
+    # Reuse $sharedLineData if available for this candidate's file
+    $_gtf2HasLD = $sharedLineData.ContainsKey($cand.File)
+    $_gtf2LD = if ($_gtf2HasLD) { $sharedLineData[$cand.File] } else { $null }
+
     for ($i = $firstTrueLine + 1; $i -le $cand.FuncEnd; $i++) {
-        $raw = $lines[$i]
-        if ($raw -match '^\s*;') { continue }
-        $cleaned = BC_CleanLine $raw
-        if ($cleaned -eq '') { continue }
+        if ($_gtf2HasLD) {
+            $_ld2 = $_gtf2LD[$i]
+            $cleaned = $_ld2.Cleaned
+            if ($cleaned -eq '') { continue }
+            $_brO2 = $_ld2.Braces[0]; $_brC2 = $_ld2.Braces[1]
+        } else {
+            $raw = $lines[$i]
+            if ($raw -match '^\s*;') { continue }
+            # Inline BC_CleanLine
+            $_tr2 = $raw.TrimStart()
+            if ($_tr2.Length -eq 0 -or $_tr2[0] -eq ';') { $cleaned = '' }
+            else {
+                $cleaned = $raw
+                if ($raw.IndexOf('"') -ge 0) { $cleaned = $script:RX_DBL_STR.Replace($cleaned, '""') }
+                if ($raw.IndexOf("'") -ge 0) { $cleaned = $script:RX_SGL_STR.Replace($cleaned, "''") }
+                if ($cleaned.IndexOf(';') -ge 0) { $cleaned = $script:RX_CMT_TAIL.Replace($cleaned, '') }
+            }
+            if ($cleaned -eq '') { continue }
+            # Inline BC_CountBraces
+            $_brO2 = 0; $_brC2 = 0
+            for ($_bi2 = 0; $_bi2 -lt $cleaned.Length; $_bi2++) {
+                $_bc2 = $cleaned[$_bi2]
+                if ($_bc2 -eq '{') { $_brO2++ } elseif ($_bc2 -eq '}') { $_brC2++ }
+            }
+        }
 
         # Detect try { opening (before depth adjustment)
         if ($script:RX_TRY_OPEN.IsMatch($cleaned)) {
@@ -1270,8 +1362,7 @@ foreach ($cand in $gtfCandidates) {
         }
 
         # Adjust depth
-        $braces = BC_CountBraces $cleaned
-        $localDepth += $braces[0] - $braces[1]
+        $localDepth += $_brO2 - $_brC2
 
         # Pop finished finally blocks
         while ($finallyStack.Count -gt 0 -and $localDepth -le $finallyStack.Peek()) {
@@ -1437,6 +1528,7 @@ $script:RX_PROF_LEAVE  = [regex]::new('Profiler\.Leave\(\)', 'Compiled')
 foreach ($file in $profilerFiles) {
     $lines = $fileCache[$file.FullName]
     $relPath = $file.FullName.Replace("$projectRoot\", '')
+    $_pbUseCache = $criticalFiles.Contains($file.FullName)
 
     $depth = 0
     $inFunc = $false
@@ -1449,12 +1541,32 @@ foreach ($file in $profilerFiles) {
     $returnLines = [System.Collections.ArrayList]::new()
 
     for ($i = 0; $i -lt $lines.Count; $i++) {
-        $raw = $lines[$i]
-        $trimmed = $raw.TrimStart()
-        if ($trimmed.Length -eq 0 -or $trimmed[0] -eq ';') { continue }
-
-        $cleaned = BC_CleanLine $raw
-        if ($cleaned -eq '') { continue }
+        if ($_pbUseCache) {
+            $_pbLd = $sharedLineData[$file.FullName][$i]
+            $cleaned = $_pbLd.Cleaned
+            if (-not $cleaned) { continue }
+            $trimmed = $lines[$i].TrimStart()
+            $_pbBrO = $_pbLd.Braces[0]; $_pbBrC = $_pbLd.Braces[1]
+        } else {
+            $raw = $lines[$i]
+            $trimmed = $raw.TrimStart()
+            if ($trimmed.Length -eq 0 -or $trimmed[0] -eq ';') { continue }
+            # Inline BC_CleanLine
+            $_pbTr = $trimmed
+            if ($_pbTr.IndexOf('"') -ge 0 -or $_pbTr.IndexOf("'") -ge 0 -or $_pbTr.IndexOf(';') -ge 0) {
+                $cleaned = $raw
+                if ($raw.IndexOf('"') -ge 0) { $cleaned = $script:RX_DBL_STR.Replace($cleaned, '""') }
+                if ($raw.IndexOf("'") -ge 0) { $cleaned = $script:RX_SGL_STR.Replace($cleaned, "''") }
+                if ($cleaned.IndexOf(';') -ge 0) { $cleaned = $script:RX_CMT_TAIL.Replace($cleaned, '') }
+            } else { $cleaned = $raw }
+            if ($cleaned -eq '') { continue }
+            # Inline BC_CountBraces
+            $_pbBrO = 0; $_pbBrC = 0
+            for ($_pbi = 0; $_pbi -lt $cleaned.Length; $_pbi++) {
+                $_pbc = $cleaned[$_pbi]
+                if ($_pbc -eq '{') { $_pbBrO++ } elseif ($_pbc -eq '}') { $_pbBrC++ }
+            }
+        }
 
         if (-not $inFunc -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
             $fname = $Matches[1]
@@ -1469,8 +1581,7 @@ foreach ($file in $profilerFiles) {
             }
         }
 
-        $braces = BC_CountBraces $cleaned
-        $depth += $braces[0] - $braces[1]
+        $depth += [int]$_pbBrO - [int]$_pbBrC
 
         if ($inFunc) {
             if (-not $hasEnter -and $script:RX_PROF_ENTER.IsMatch($trimmed)) {
@@ -1588,7 +1699,17 @@ $heavyDirect = [System.Collections.Generic.HashSet[string]]::new(
 
 foreach ($file in $allFiles) {
     $lines = $fileCache[$file.FullName]
-    $hasLineData = $sharedLineData.ContainsKey($file.FullName)
+    $_chHasLD = $sharedLineData.ContainsKey($file.FullName)
+
+    # Pre-filter: skip non-critical files that don't contain any heavy call patterns
+    if (-not $_chHasLD) {
+        $_chText = $fileCacheText[$file.FullName]
+        if ($_chText.IndexOf('BeginDraw') -lt 0 -and $_chText.IndexOf('EndDraw') -lt 0 -and
+            $_chText.IndexOf('DrawBitmap') -lt 0 -and $_chText.IndexOf('CreateEffect') -lt 0 -and
+            $_chText.IndexOf('ShowWindow') -lt 0 -and $_chText.IndexOf('SetWindowPos') -lt 0 -and
+            $_chText.IndexOf('DwmFlush') -lt 0 -and $_chText.IndexOf('ProcessExist') -lt 0 -and
+            $_chText.IndexOf('RunWait') -lt 0) { continue }
+    }
 
     $depth = 0
     $inFunc = $false
@@ -1597,16 +1718,40 @@ foreach ($file in $allFiles) {
     $hasHeavy = $false
 
     for ($i = 0; $i -lt $lines.Count; $i++) {
-        if ($hasLineData) {
+        if ($_chHasLD) {
             $ld = $sharedLineData[$file.FullName][$i]
             $cleaned = $ld.Cleaned
             $stripped = $ld.Stripped
             $braceData = $ld.Braces
         } else {
             $rawLine = $lines[$i]
-            $cleaned = BC_CleanLine $rawLine
-            $stripped = if ($cleaned -ne '') { BC_StripComments $rawLine } else { '' }
-            $braceData = if ($cleaned -ne '') { BC_CountBraces $cleaned } else { @(0, 0) }
+            # Inline BC_CleanLine
+            $_chTr = $rawLine.TrimStart()
+            if ($_chTr.Length -eq 0 -or $_chTr[0] -eq ';') { $cleaned = '' }
+            else {
+                $cleaned = $rawLine
+                if ($rawLine.IndexOf('"') -ge 0) { $cleaned = $script:RX_DBL_STR.Replace($cleaned, '""') }
+                if ($rawLine.IndexOf("'") -ge 0) { $cleaned = $script:RX_SGL_STR.Replace($cleaned, "''") }
+                if ($cleaned.IndexOf(';') -ge 0) { $cleaned = $script:RX_CMT_TAIL.Replace($cleaned, '') }
+            }
+            # Inline BC_StripComments
+            if ($cleaned -ne '') {
+                if ($rawLine.IndexOf(';') -ge 0) {
+                    $_chSt = $rawLine.TrimStart()
+                    $stripped = if ($_chSt.Length -gt 0 -and $_chSt[0] -ne ';') {
+                        $script:RX_CMT_TAIL.Replace($rawLine, '')
+                    } else { '' }
+                } else { $stripped = $rawLine }
+            } else { $stripped = '' }
+            # Inline BC_CountBraces
+            if ($cleaned -ne '') {
+                $_chO = 0; $_chC = 0
+                for ($_chi = 0; $_chi -lt $cleaned.Length; $_chi++) {
+                    $_chCh = $cleaned[$_chi]
+                    if ($_chCh -eq '{') { $_chO++ } elseif ($_chCh -eq '}') { $_chC++ }
+                }
+                $braceData = @($_chO, $_chC)
+            } else { $braceData = @(0, 0) }
         }
 
         if ($cleaned -eq '') {

--- a/tools/query_global_ownership.ps1
+++ b/tools/query_global_ownership.ps1
@@ -305,6 +305,8 @@ $fileCache = @{}
 $fileCacheText = @{}
 # cleanedLineCache: filePath -> array of [cleaned_line, brace_delta] per line
 $cleanedLineCache = @{}
+# funcNameCacheMap: filePath -> string[] of enclosing function name per line ('' = file scope)
+$funcNameCacheMap = @{}
 
 foreach ($file in $srcFiles) {
     $text = [System.IO.File]::ReadAllText($file.FullName)
@@ -320,13 +322,26 @@ foreach ($file in $srcFiles) {
     $depth = 0
     $inFunc = $false
     $funcDepth = -1
+    $funcName = ""
 
-    # Build per-line cache: [cleaned_line, brace_delta]
+    # Build per-line cache: [cleaned_line, brace_delta] + function name map
     $lineCount = $lines.Count
     $cachedLines = [object[]]::new($lineCount)
+    $funcNames = [string[]]::new($lineCount)
 
     for ($i = 0; $i -lt $lineCount; $i++) {
-        $cleaned = Clean-Line $lines[$i]
+        # Inline Clean-Line (eliminates ~41K function call dispatches)
+        $_raw = $lines[$i]
+        $_trimmed = $_raw.TrimStart()
+        if ($_trimmed.Length -eq 0 -or $_trimmed[0] -eq ';') {
+            $cleaned = ''
+        } elseif ($_trimmed.IndexOf('"') -lt 0 -and $_trimmed.IndexOf("'") -lt 0 -and $_trimmed.IndexOf(';') -lt 0) {
+            $cleaned = $_trimmed
+        } else {
+            $cleaned = $script:_rxDblQuote.Replace($_trimmed, '""')
+            $cleaned = $script:_rxSglQuote.Replace($cleaned, "''")
+            $cleaned = $script:_rxComment.Replace($cleaned, '')
+        }
         if ($cleaned -eq '') {
             $cachedLines[$i] = @('', 0)
             continue
@@ -352,6 +367,7 @@ foreach ($file in $srcFiles) {
                 if ($hasBody) {
                     $inFunc = $true
                     $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
+                    $funcName = $fname
                 }
             }
         }
@@ -362,7 +378,10 @@ foreach ($file in $srcFiles) {
         if ($inFunc -and $depth -le $funcDepth) {
             $inFunc = $false
             $funcDepth = -1
+            $funcName = ""
         }
+
+        $funcNames[$i] = $funcName
 
         # File-scope global declarations (outside any function)
         if (-not $inFunc -and $cleaned -match '^\s*global\s+(.+)') {
@@ -387,6 +406,7 @@ foreach ($file in $srcFiles) {
     }
 
     $cleanedLineCache[$file.FullName] = $cachedLines
+    $funcNameCacheMap[$file.FullName] = $funcNames
 }
 
 # Build lookup set for fast matching
@@ -459,24 +479,47 @@ foreach ($file in $srcFiles) {
     if (-not $hasCachedLines) {
         $lineCount = $lines.Count
         $cachedLines = [object[]]::new($lineCount)
+        $_fnNames = [string[]]::new($lineCount)
+        $_d = 0; $_inF = $false; $_fD = -1; $_fN = ""
         for ($ci = 0; $ci -lt $lineCount; $ci++) {
             $cleaned = Clean-Line $lines[$ci]
             if ($cleaned -eq '') {
                 $cachedLines[$ci] = @('', 0)
             } else {
-                $opens = $cleaned.Length - $cleaned.Replace('{','').Length
-                $closes = $cleaned.Length - $cleaned.Replace('}','').Length
-                $cachedLines[$ci] = @($cleaned, $opens - $closes)
+                $_o = $cleaned.Length - $cleaned.Replace('{','').Length
+                $_c = $cleaned.Length - $cleaned.Replace('}','').Length
+                $cachedLines[$ci] = @($cleaned, $_o - $_c)
+
+                if (-not $_inF -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
+                    $_fn = $Matches[1]
+                    if (-not $AHK_KEYWORDS_SET.Contains($_fn)) {
+                        $_hb = $cleaned.Contains('{')
+                        if (-not $_hb) {
+                            for ($_la = $ci + 1; $_la -lt [Math]::Min($ci + 10, $lineCount); $_la++) {
+                                $_pk = $lines[$_la].Trim()
+                                if ($_pk -eq '' -or $_pk.StartsWith(';')) { continue }
+                                if ($_pk.Contains('{')) { $_hb = $true; break }
+                            }
+                        }
+                        if ($_hb) {
+                            $_inF = $true
+                            $_fD = if ($cleaned.Contains('{')) { $_d } else { -2 }
+                            $_fN = $_fn
+                        }
+                    }
+                }
+                if ($_inF -and $_fD -eq -2 -and $cleaned.Contains('{')) { $_fD = $_d }
+                $_d += $_o - $_c
+                if ($_inF -and $_d -le $_fD) { $_inF = $false; $_fD = -1; $_fN = "" }
+                $_fnNames[$ci] = $_fN
             }
         }
         $cleanedLineCache[$file.FullName] = $cachedLines
+        $funcNameCacheMap[$file.FullName] = $_fnNames
     }
     $cachedLines = $cleanedLineCache[$file.FullName]
+    $_funcNames = $funcNameCacheMap[$file.FullName]
 
-    $depth = 0
-    $inFunc = $false
-    $funcDepth = -1
-    $funcName = ""
     $seen = [System.Collections.Generic.HashSet[string]]::new(
         [System.StringComparer]::OrdinalIgnoreCase)
 
@@ -484,37 +527,12 @@ foreach ($file in $srcFiles) {
         $entry = $cachedLines[$i]
         $cleaned = $entry[0]
         if ($cleaned -eq '') { continue }
-        $delta = $entry[1]
 
-        if (-not $inFunc -and $cleaned -match '^\s*(?:static\s+)?(\w+)\s*\(') {
-            $fname = $Matches[1]
-            if (-not $AHK_KEYWORDS_SET.Contains($fname)) {
-                $hasBody = $cleaned.Contains('{')
-                if (-not $hasBody) {
-                    for ($la = $i + 1; $la -lt [Math]::Min($i + 10, $lines.Count); $la++) {
-                        $peek = $lines[$la].Trim()
-                        if ($peek -eq '' -or $peek.StartsWith(';')) { continue }
-                        if ($peek.Contains('{')) { $hasBody = $true; break }
-                    }
-                }
-                if ($hasBody) {
-                    $inFunc = $true
-                    $funcDepth = if ($cleaned.Contains('{')) { $depth } else { -2 }
-                    $funcName = $fname
-                }
-            }
-        }
-
-        if ($inFunc -and $funcDepth -eq -2 -and $cleaned.Contains('{')) { $funcDepth = $depth }
-        $depth += $delta
-
-        if ($inFunc -and $depth -le $funcDepth) {
-            $inFunc = $false
-            $funcDepth = -1
-        }
+        # Use pre-computed function name from Pass 1 (or lazy cache above)
+        $funcName = $_funcNames[$i]
 
         # Only scan inside function bodies
-        if (-not $inFunc) { continue }
+        if ($funcName -eq '' -or $funcName -eq $null) { continue }
 
         # Line-level pre-filter: skip lines that can't possibly be mutations
         # (no assignment, increment, or mutating method operator present)
@@ -527,56 +545,72 @@ foreach ($file in $srcFiles) {
                     $cleaned.Contains('.InsertAt(') -or $cleaned.Contains('.RemoveAt(') -or
                     $cleaned.Contains('.Set(')
 
-        # In enforcement mode (non-Query), skip lines without mutation operators entirely
-        if (-not $Query -and -not $hasMutOp) { continue }
+        if ($Query) {
+            # Query mode: need word extraction for read tracking + mutation detection
+            $isGlobalDeclLine = $cleaned -match '^\s*global\s+'
+            $wordMatches = $script:_rxWord.Matches($cleaned)
+            $seen.Clear()
 
-        # Check if this is a global declaration line (not a read)
-        $isGlobalDeclLine = $cleaned -match '^\s*global\s+'
+            foreach ($wm in $wordMatches) {
+                $wName = $wm.Value
+                if ($seen.Contains($wName)) { continue }
+                [void]$seen.Add($wName)
+                if (-not $globalSet.Contains($wName)) { continue }
 
-        # Find word tokens that match known globals, then test for mutation
-        $wordMatches = $script:_rxWord.Matches($cleaned)
-        $seen.Clear()
-
-        foreach ($wm in $wordMatches) {
-            $wName = $wm.Value
-            if ($seen.Contains($wName)) { continue }
-            [void]$seen.Add($wName)
-            if (-not $globalSet.Contains($wName)) { continue }
-
-            # Test mutation using generic patterns + HashSet verification
-            # Each pattern captures (\w+) at the mutation position; we check all
-            # matches on the line to see if $wName appears as a mutation target.
-            # Short-circuits on first pattern that confirms a match.
-            $isMutation = $false
-            if ($hasMutOp) {
-                :mutCheck foreach ($rxMut in @($_rxMut1, $_rxMut2, $_rxMut3, $_rxMut4, $_rxMut5)) {
-                    foreach ($rm in $rxMut.Matches($cleaned)) {
-                        if ($rm.Groups[1].Value -eq $wName) {
-                            $isMutation = $true
-                            break mutCheck
+                $isMutation = $false
+                if ($hasMutOp) {
+                    :mutCheck foreach ($rxMut in @($_rxMut1, $_rxMut2, $_rxMut3, $_rxMut4, $_rxMut5)) {
+                        foreach ($rm in $rxMut.Matches($cleaned)) {
+                            if ($rm.Groups[1].Value -eq $wName) {
+                                $isMutation = $true
+                                break mutCheck
+                            }
                         }
                     }
                 }
-            }
 
-            if ($isMutation) {
-                [void]$mutations.Add(@{
-                    Global  = $wName
-                    File    = $file.FullName
-                    RelPath = $relPath
-                    Line    = ($i + 1)
-                    Code    = $lines[$i].Trim()
-                    Func    = $funcName
-                })
-            }
-
-            # Track non-mutation, non-declaration references as reads (Query mode only)
-            if ($Query -and -not $isMutation -and -not $isGlobalDeclLine) {
-                if (-not $reads.ContainsKey($wName)) {
-                    $reads[$wName] = [System.Collections.Generic.HashSet[string]]::new(
-                        [System.StringComparer]::OrdinalIgnoreCase)
+                if ($isMutation) {
+                    [void]$mutations.Add(@{
+                        Global  = $wName
+                        File    = $file.FullName
+                        RelPath = $relPath
+                        Line    = ($i + 1)
+                        Code    = $lines[$i].Trim()
+                        Func    = $funcName
+                    })
                 }
-                [void]$reads[$wName].Add($file.FullName)
+
+                if (-not $isMutation -and -not $isGlobalDeclLine) {
+                    if (-not $reads.ContainsKey($wName)) {
+                        $reads[$wName] = [System.Collections.Generic.HashSet[string]]::new(
+                            [System.StringComparer]::OrdinalIgnoreCase)
+                    }
+                    [void]$reads[$wName].Add($file.FullName)
+                }
+            }
+        } else {
+            # Enforcement mode: skip word extraction, run mutation regex directly.
+            # Reverses the approach: instead of "find all words → filter to globals →
+            # check if mutation", we do "find all mutations → check if target is a global".
+            # Eliminates ~52K word iterations per run.
+            if (-not $hasMutOp) { continue }
+
+            $seen.Clear()
+            foreach ($rxMut in @($_rxMut1, $_rxMut2, $_rxMut3, $_rxMut4, $_rxMut5)) {
+                foreach ($rm in $rxMut.Matches($cleaned)) {
+                    $_vName = $rm.Groups[1].Value
+                    if ($seen.Contains($_vName)) { continue }
+                    if (-not $globalSet.Contains($_vName)) { continue }
+                    [void]$seen.Add($_vName)
+                    [void]$mutations.Add(@{
+                        Global  = $_vName
+                        File    = $file.FullName
+                        RelPath = $relPath
+                        Line    = ($i + 1)
+                        Code    = $lines[$i].Trim()
+                        Func    = $funcName
+                    })
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Optimize the two tied-bottleneck bundles in the static analysis pre-gate (both at 7.9s)
- `check_batch_guards`: 7.9s → 5.6s (-29%) via shared_pass inlining, sub-check `$sharedLineData` reuse, and text-level pre-filtering
- `query_global_ownership`: 7.9s → 7.2s (-9%) via function boundary caching, Clean-Line inlining, and reversed mutation detection
- Pre-gate wall-clock: 10.0s → 9.2s (-8%)
- All 86 checks pass, output unchanged — internal-only optimizations

Closes #358

## Test plan

- [x] All 86 static analysis checks pass
- [x] `query_global_ownership -Check` output identical (1303 mutations, 1112 globals, 25 manifest entries)
- [x] `query_global_ownership` query mode output identical (gGUI_State, cfg)
- [x] Full test suite passes (unit, GUI, live, flight recorder)
- [x] Standalone timing validated for both bottleneck bundles
- [x] Multiple full `--timing` runs confirm improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)