### PR TITLE
Reduce ownership manifest coupling (20 -> 16 entries)

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -23,8 +23,7 @@
 cfg: launcher_tray, config_loader, setup_utils
 gAnim_DeferredTimerStart: gui_animation, gui_paint
 gAnim_HidePending: gui_animation, gui_overlay
-gBGImg_EffectsReady: gui_bgimage, gui_effects
-gD2D_RT: gui_animation, gui_bgimage, gui_overlay, gui_paint
+gD2D_RT: gui_bgimage, gui_overlay, gui_paint
 gFX_AmbientTime: gui_animation, gui_effects
 gGUI_CurrentWSName: gui_activation, gui_state
 gGUI_DisplayItems: gui_animation, gui_data, gui_state
@@ -37,6 +36,3 @@ gGUI_Revealed: gui_animation, gui_overlay, gui_paint, gui_state
 gGUI_ScrollTop: gui_data, gui_input, gui_paint, gui_state
 gGUI_Sel: gui_data, gui_input, gui_state
 gGUI_ToggleBase: gui_data, gui_state
-gPaint_RepaintInProgress: gui_animation, gui_overlay, gui_paint
-gWS_IconQueue: gui_pump, window_list
-gWS_IconQueueDedup: gui_pump, window_list

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -446,9 +446,9 @@ Anim_ForceCompleteHide() {
 
 _Anim_DoActualHide() {
     Profiler.Enter("_Anim_DoActualHide") ; @profile
-    global gGUI_OverlayVisible, gGUI_Base, gGUI_BaseH, gGUI_Revealed, gD2D_RT
+    global gGUI_OverlayVisible, gGUI_Base, gGUI_BaseH, gGUI_Revealed
     global cfg, GUI_LOG_TRIM_EVERY_N_HIDES
-    global gGUI_DisplayItems, gPaint_RepaintInProgress
+    global gGUI_DisplayItems
     static hideCount := 0
 
     if (!gGUI_OverlayVisible) {
@@ -462,32 +462,9 @@ _Anim_DoActualHide() {
 
     GUI_ClearHoverState()
 
-    ; Clear D2D surface — ensures clean swap chain buffer for next Show.
-    ; Skip when a paint is in progress: if called during an outer paint's
-    ; STA pump (e.g., ForceCompleteHide from TAB_DN during hide-fade paint),
-    ; nested AcquireBackBuffer overwrites gD2D_BackBuffer and nested BeginDraw
-    ; fails (D2DERR_WRONG_STATE), corrupting the outer paint's D2D state.
-    ; The next show's first paint will clear the surface.  The window is about
-    ; to be hidden anyway, so skipping the clear has no visible effect.
-    ; When NOT in a paint, the guard blocks nested GUI_Repaint from timer
-    ; callbacks dispatched during this block's STA pump.
-    if (gD2D_RT && !gPaint_RepaintInProgress) {
-        gPaint_RepaintInProgress := true
-        try {
-            if (D2D_AcquireBackBuffer()) {
-                gD2D_RT.BeginDraw()
-                gD2D_RT.Clear(D2D_ColorF(0x00000000))
-                gD2D_RT.EndDraw()
-                D2D_ReleaseBackBuffer()
-                D2D_Present(0)  ; Immediate — about to hide
-            }
-        } catch {
-            try gD2D_RT.EndDraw()   ; Best-effort: don't leave D2D in BeginDraw state
-            D2D_ReleaseBackBuffer()
-        } finally {
-            gPaint_RepaintInProgress := false
-        }
-    }
+    ; Clear D2D swap chain for clean buffer on next Show.
+    ; Paint_ClearSurface handles the repaint guard + D2D error recovery.
+    Paint_ClearSurface()
 
     try {
         gGUI_Base.Hide()

--- a/src/gui/gui_bgimage.ahk
+++ b/src/gui/gui_bgimage.ahk
@@ -102,6 +102,13 @@ BGImg_Dispose() {
     ; GDI+ token intentionally kept alive — no need to shut down/restart for reload
 }
 
+; Signal that GPU effects for background image processing are available.
+; Called by FX_GPU_Init after creating bgimage-specific D2D effect chains.
+BGImg_NotifyEffectsReady() {
+    global gBGImg_EffectsReady
+    gBGImg_EffectsReady := true
+}
+
 ; ============================================================
 ; PRIVATE — Cache Management
 ; ============================================================

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -120,7 +120,6 @@ FX_GPU_Init() {
         ; --- Background image effect chain: Blur → Saturation → ColorMatrix ---
         ; Wrapped in try/catch: failure falls back to direct DrawBitmap (no effects)
         try {
-            global gBGImg_EffectsReady
             gFX_GPU["bgImgBlur"]  := gD2D_RT.CreateEffect(CLSID_D2D1GaussianBlur)
             gFX_GPU["bgImgSat"]   := gD2D_RT.CreateEffect(CLSID_D2D1Saturation)
             gFX_GPU["bgImgColor"] := gD2D_RT.CreateEffect(CLSID_D2D1ColorMatrix)
@@ -130,7 +129,7 @@ FX_GPU_Init() {
             gFX_GPUOutput["bgImgColor"] := gFX_GPU["bgImgColor"].GetOutput()
             ; Shadow effect (independent — not part of blur/sat/color chain)
             gFX_GPU["bgImgShadow"] := gD2D_RT.CreateEffect(CLSID_D2D1Shadow)
-            gBGImg_EffectsReady := true
+            BGImg_NotifyEffectsReady()
         } catch {
             ; Background image effects unavailable — BGImg_Draw falls back to direct DrawBitmap
         }

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -107,8 +107,8 @@ _GUI_ApplyCornerStyle(hWnd) {
 GUI_HideOverlay() {
     Profiler.Enter("GUI_HideOverlay") ; @profile
     global gGUI_OverlayVisible, gGUI_Base, gGUI_BaseH, gGUI_Revealed
-    global cfg, GUI_LOG_TRIM_EVERY_N_HIDES, gD2D_RT
-    global gAnim_HidePending, gPaint_RepaintInProgress, gGUI_CachedVisibleRows
+    global cfg, GUI_LOG_TRIM_EVERY_N_HIDES
+    global gAnim_HidePending, gGUI_CachedVisibleRows
     static hideCount := 0
 
     if (!gGUI_OverlayVisible) {
@@ -144,31 +144,9 @@ GUI_HideOverlay() {
     ; Stop hover polling and clear hover state
     GUI_ClearHoverState()
 
-    ; Clear D2D surface BEFORE hiding — ensures a clean swap chain buffer
-    ; for the next Show().  SwapChain.Present() works for hidden windows
-    ; (unlike HwndRenderTarget), so the clear actually commits.
-    ; Skip when a paint is in progress: nested AcquireBackBuffer overwrites
-    ; gD2D_BackBuffer and nested BeginDraw fails (D2DERR_WRONG_STATE),
-    ; corrupting the outer paint's D2D state.  The next show's first paint
-    ; will clear the surface.  When NOT in a paint, the guard blocks nested
-    ; GUI_Repaint from timer callbacks dispatched during this block's STA pump.
-    if (gD2D_RT && !gPaint_RepaintInProgress) {
-        gPaint_RepaintInProgress := true
-        try {
-            if (D2D_AcquireBackBuffer()) {
-                gD2D_RT.BeginDraw()
-                gD2D_RT.Clear(D2D_ColorF(0x00000000))
-                gD2D_RT.EndDraw()
-                D2D_ReleaseBackBuffer()
-                D2D_Present(0)  ; Immediate — about to hide
-            }
-        } catch {
-            try gD2D_RT.EndDraw()   ; Best-effort: don't leave D2D in BeginDraw state
-            D2D_ReleaseBackBuffer()
-        } finally {
-            gPaint_RepaintInProgress := false
-        }
-    }
+    ; Clear D2D swap chain for clean buffer on next Show.
+    ; Paint_ClearSurface handles the repaint guard + D2D error recovery.
+    Paint_ClearSurface()
 
     try {
         gGUI_Base.Hide()

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -51,6 +51,35 @@ Paint_LogStartSession() {
     }
 }
 
+; ========================= CLEAR SURFACE =========================
+; Clear D2D swap chain to transparent and present.
+; Used by hide paths to ensure a clean buffer for the next Show.
+; Preserves both guard layers:
+;   1. Outer check — prevents nested D2D corruption (nested AcquireBackBuffer
+;      overwrites gD2D_BackBuffer, nested BeginDraw fails D2DERR_WRONG_STATE)
+;   2. Inner try/finally — prevents guard from getting stuck if any D2D call throws
+
+Paint_ClearSurface() {
+    global gD2D_RT, gPaint_RepaintInProgress
+    if (!gD2D_RT || gPaint_RepaintInProgress)
+        return
+    gPaint_RepaintInProgress := true
+    try {
+        if (D2D_AcquireBackBuffer()) {
+            gD2D_RT.BeginDraw()
+            gD2D_RT.Clear(D2D_ColorF(0x00000000))
+            gD2D_RT.EndDraw()
+            D2D_ReleaseBackBuffer()
+            D2D_Present(0)  ; Immediate — about to hide
+        }
+    } catch {
+        try gD2D_RT.EndDraw()   ; Best-effort: don't leave D2D in BeginDraw state
+        D2D_ReleaseBackBuffer()
+    } finally {
+        gPaint_RepaintInProgress := false
+    }
+}
+
 ; ========================= MAIN REPAINT =========================
 
 GUI_Repaint() {

--- a/src/gui/gui_pump.ahk
+++ b/src/gui/gui_pump.ahk
@@ -459,10 +459,12 @@ _GUIPump_OnMessage(msg, hPipe) {
     ; Re-enqueue hwnds the pump returned nothing for (silently dropped).
     ; Without this, windows that failed enrichment (e.g., cloaked windows where
     ; WinGetPID fails transiently) are permanently lost from the icon queue.
-    global _gPump_LastSentHwnds, gWS_IconQueue, gWS_IconQueueDedup
+    global _gPump_LastSentHwnds
     if (_gPump_LastSentHwnds.Length > 0) {
         requeueCount := 0
-        Critical "On"
+        ; No outer Critical needed — WL_EnqueueIconDirect manages its own atomicity
+        ; for the dedup-check-then-insert. Loop variables (results, _gPump_LastSentHwnds)
+        ; are local/private, and WL_GetByHwnd is a read-only store lookup.
         for _, h in _gPump_LastSentHwnds {
             h := h + 0
             if (!h)
@@ -473,13 +475,9 @@ _GUIPump_OnMessage(msg, hPipe) {
             row := WL_GetByHwnd(h)
             if (!row || row.iconHicon || !row.present)
                 continue  ; Already has icon, or window gone
-            if (gWS_IconQueueDedup.Has(h))
-                continue  ; Already queued
-            gWS_IconQueue.Push(h)
-            gWS_IconQueueDedup[h] := true
+            WL_EnqueueIconDirect(h)
             requeueCount++
         }
-        Critical "Off"
         _gPump_LastSentHwnds := []
         if (requeueCount > 0 && cfg.DiagPumpLog)
             _GUIPump_Log("RETRY: re-enqueued " requeueCount " hwnds that pump returned nothing for")

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -981,6 +981,20 @@ _WS_EnqueueIfNeeded(row) {
     Critical "Off"
 }
 
+; Enqueue hwnd for icon enrichment without row-level checks.
+; Used by pump re-enqueue path where the caller has already validated eligibility.
+; Safe to call when already inside Critical (AHK's Critical is re-entrant).
+WL_EnqueueIconDirect(hwnd) {
+    global gWS_IconQueue, gWS_IconQueueDedup
+    hwnd := hwnd + 0
+    Critical "On"
+    if (!gWS_IconQueueDedup.Has(hwnd)) {
+        gWS_IconQueue.Push(hwnd)
+        gWS_IconQueueDedup[hwnd] := true
+    }
+    Critical "Off"
+}
+
 ; Enqueue window for icon refresh (called when window gains focus)
 ; This allows upgrading fallback icons or refreshing WM_GETICON icons that may have changed
 WL_EnqueueIconRefresh(hwnd) {


### PR DESCRIPTION
## Summary

- Extract duplicated D2D clear-and-present blocks from `gui_animation` and `gui_overlay` into `Paint_ClearSurface()` in `gui_paint` — eliminates `gPaint_RepaintInProgress` from manifest, narrows `gD2D_RT` from 4 to 3 writers
- Add `BGImg_NotifyEffectsReady()` so `gui_effects` signals bgimage readiness via function call instead of direct flag write — eliminates `gBGImg_EffectsReady` from manifest
- Add `WL_EnqueueIconDirect()` so `gui_pump` uses window_list's queue API instead of directly manipulating internal queue arrays — eliminates both `gWS_IconQueue` and `gWS_IconQueueDedup` from manifest
- Remove pump's outer Critical section that would have caused a critical-leak with the new function (caught by static analysis)

## Test plan

- [x] `query_global_ownership.ps1 -Generate` confirms manifest is up to date (16 entries)
- [x] All 86 static analysis checks pass (including critical-leak checker)
- [x] All 1011 tests pass (`test.ps1 --live` — unit, GUI, live, flight recorder)

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)