### PR TITLE
Skip zero-opacity layers and reduce per-frame Map lookups in paint path

### DIFF
--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -383,7 +383,7 @@ FX_PreRenderShaderLayers(w, h) {
     ambientSec := gFX_AmbientTime / 1000.0
 
     for _, layer in gFX_ShaderLayers {
-        if (layer.key = "")
+        if (layer.key = "" || layer.opacity <= 0.0)
             continue
 
         ; Compute effective time: (ambient / 1000) * speed + offset + carry
@@ -426,7 +426,7 @@ FX_DrawShaderLayers(wPhys, hPhys) { ; lint-ignore: dead-param
     }
 
     for _, layer in gFX_ShaderLayers {
-        if (layer.key = "")
+        if (layer.key = "" || layer.opacity <= 0.0)
             continue
         pBitmap := Shader_GetBitmap(layer.renderKey)
         if (pBitmap)
@@ -444,7 +444,7 @@ FX_PreRenderMouseEffect(w, h) {
     global gFX_MouseX, gFX_MouseY, gFX_MouseInWindow, cfg
     global gFX_MousePrevX, gFX_MousePrevY, gFX_MouseVelX, gFX_MouseVelY, gFX_MouseSpeed, gFX_MousePrevValid
 
-    if (gFX_MouseEffect.key = "" || !gShader_Ready || !gFX_GPUReady) {
+    if (gFX_MouseEffect.key = "" || gFX_MouseEffect.opacity <= 0.0 || !gShader_Ready || !gFX_GPUReady) {
         Profiler.Leave() ; @profile
         return
     }
@@ -524,7 +524,7 @@ FX_DrawMouseEffect(wPhys, hPhys) { ; lint-ignore: dead-param
     Profiler.Enter("FX_DrawMouseEffect") ; @profile
     global gD2D_RT, gFX_MouseEffect, gShader_Ready
 
-    if (gFX_MouseEffect.key = "" || !gShader_Ready) {
+    if (gFX_MouseEffect.key = "" || gFX_MouseEffect.opacity <= 0.0 || !gShader_Ready) {
         Profiler.Leave() ; @profile
         return
     }
@@ -1263,9 +1263,15 @@ FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: d
         ; Draw border on top (outside clip layer so it's not masked)
         bw := cfg.GUI_HovBorderWidthPx
         if (bw > 0) {
+            static _hovCachedBorderARGB := 0, _hovCachedBorderBrush := 0
+            borderARGB := cfg.GUI_HovBorderARGB
+            if (borderARGB != _hovCachedBorderARGB || !_hovCachedBorderBrush) {
+                _hovCachedBorderBrush := D2D_GetCachedBrush(borderARGB)
+                _hovCachedBorderARGB := borderARGB
+            }
             half := bw / 2
             D2D_StrokeRoundRect(selX + half, selY + half, selW - bw, selH - bw, rad,
-                D2D_GetCachedBrush(cfg.GUI_HovBorderARGB), bw)
+                _hovCachedBorderBrush, bw)
         }
     } else {
         gD2D_RT.DrawImage(pBitmap)

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -695,9 +695,8 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
             sub := cur.processName
             if (sub = "") {
                 ; Lazy-cache: concat "Class: " only once per display cycle, not per-frame
-                if (_gPaint_SubCache.Has(cur.hwnd))
-                    sub := _gPaint_SubCache[cur.hwnd]
-                else {
+                sub := _gPaint_SubCache.Get(cur.hwnd, "")
+                if (sub = "") {
                     sub := "Class: " cur.class
                     _gPaint_SubCache[cur.hwnd] := sub
                 }


### PR DESCRIPTION
Closes #364

## Summary

Deep audit of the D2D paint pipeline (120-240fps). The pipeline is well-optimized — this PR addresses the remaining edge cases:

- **Opacity-zero guard on shader/mouse pre-render and draw** — if a user configures a shader layer or mouse effect with 0 opacity, skip the D3D11 dispatch (~50-100μs) and D2D DrawImage (~1-2μs) entirely. Four guard additions across `FX_PreRenderShaderLayers`, `FX_DrawShaderLayers`, `FX_PreRenderMouseEffect`, `FX_DrawMouseEffect`
- **Cache hover border brush** — `FX_DrawHoverEffect` called `D2D_GetCachedBrush()` every frame for the hover border; now mirrors the static-cached pattern already used by `FX_DrawSelectionEffect` (lines 665-670)
- **Single `.Get()` instead of `.Has()` + `[]` in subtitle cache** — row-loop Map double-lookup replaced with single `.Get(key, "")` call

## Test plan

- [x] All 1011 tests pass (unit, GUI, live, flight recorder)
- [ ] Manual: configure a shader layer with Opacity=0, verify no GPU work via paint timing log
- [ ] Manual: hover over rows with BG-shader-as-hover + border enabled, verify border renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)