### PR TITLE
Reduce per-frame waste in D2D paint pipeline

### DIFF
--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -391,6 +391,11 @@ _Anim_ApplyWindowAlpha() {
         alpha := 0
     if (alpha > 255)
         alpha := 255
+    ; Skip Win32 call when alpha unchanged from last frame
+    static prevAlpha := -1
+    if (alpha = prevAlpha)
+        return
+    prevAlpha := alpha
     DllCall("SetLayeredWindowAttributes", "ptr", gGUI_BaseH, "uint", 0, "uchar", alpha, "uint", 2)  ; LWA_ALPHA=2
 }
 

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -25,9 +25,9 @@ global gFX_ShaderTime := Map()       ; layerIndex → {offset, carry, accumulate
 global gFX_MouseEffect      ; Mouse effect state: {key, name, opacity}
 global gFX_SelectionEffect  ; Selection effect state: {key, name, opacity, darkness, desat, speed, isBGShader}
 global gFX_HoverEffect      ; Hover effect state: {key, name, opacity, darkness, desat, speed, isBGShader}
-gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0}
-gFX_SelectionEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
-gFX_HoverEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
+gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0, _bitmap: 0}
+gFX_SelectionEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
+gFX_HoverEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
 global gFX_MousePrevX := 0.0        ; Previous frame mouse X
 global gFX_MousePrevY := 0.0        ; Previous frame mouse Y
 global gFX_MouseVelX := 0.0         ; Smoothed velocity X (px/sec)
@@ -197,9 +197,9 @@ FX_GPU_Dispose() {
     ; Release shader resources
     gFX_ShaderTime := Map()
     gFX_ShaderLayers := []
-    gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0}
-    gFX_SelectionEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
-    gFX_HoverEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
+    gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0, _bitmap: 0}
+    gFX_SelectionEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
+    gFX_HoverEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
     Shader_Cleanup()
 }
 
@@ -396,7 +396,10 @@ FX_PreRenderShaderLayers(w, h) {
 
         try {
             Shader_PreRender(layer.renderKey, w, h, effectiveTime, layer.darkness, layer.desat, layer.opacity)
+            ; Cache bitmap ptr for draw phase (avoids Map+try lookup in FX_DrawShaderLayers)
+            layer._bitmap := Shader_GetBitmap(layer.renderKey)
         } catch as e {
+            layer._bitmap := 0
             global LOG_PATH_SHADER
             errDetail := "Shader ERR [" layer.renderKey "]: " e.Message " @ " e.What
             if (e.HasProp("Extra") && e.Extra != "")
@@ -428,7 +431,8 @@ FX_DrawShaderLayers(wPhys, hPhys) { ; lint-ignore: dead-param
     for _, layer in gFX_ShaderLayers {
         if (layer.key = "" || layer.opacity <= 0.0)
             continue
-        pBitmap := Shader_GetBitmap(layer.renderKey)
+        ; Use bitmap cached during pre-render (avoids Map+try lookup per layer)
+        pBitmap := layer._bitmap
         if (pBitmap)
             gD2D_RT.DrawImage(pBitmap)
     }
@@ -501,7 +505,10 @@ FX_PreRenderMouseEffect(w, h) {
         Shader_PreRender(gFX_MouseEffect.key, w, h, baseTime,
             gFX_MouseEffect.darkness, gFX_MouseEffect.desat, gFX_MouseEffect.opacity,
             gFX_MouseX, gFX_MouseY, gFX_MouseVelX, gFX_MouseVelY, gFX_MouseSpeed)
+        ; Cache bitmap ptr for draw phase (avoids Map+try lookup in FX_DrawMouseEffect)
+        gFX_MouseEffect._bitmap := Shader_GetBitmap(gFX_MouseEffect.key)
     } catch as e {
+        gFX_MouseEffect._bitmap := 0
         if (cfg.DiagShaderLog) {
             global LOG_PATH_SHADER
             errDetail := "Mouse shader ERR [" gFX_MouseEffect.key "]: " e.Message " @ " e.What
@@ -529,7 +536,8 @@ FX_DrawMouseEffect(wPhys, hPhys) { ; lint-ignore: dead-param
         return
     }
 
-    pBitmap := Shader_GetBitmap(gFX_MouseEffect.key)
+    ; Use bitmap cached during pre-render (avoids Map+try lookup)
+    pBitmap := gFX_MouseEffect._bitmap
     if (pBitmap)
         gD2D_RT.DrawImage(pBitmap)
     Profiler.Leave() ; @profile
@@ -609,7 +617,10 @@ FX_PreRenderSelectionEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, b
             selR, selG, selB, selA,
             bdrR, bdrG, bdrB, bdrA,
             borderWidth * 1.0, isHovered * 1.0, entranceT * 1.0, rowRadius * 1.0)
+        ; Cache bitmap ptr for draw phase (avoids Map+try lookup in FX_DrawSelectionEffect)
+        gFX_SelectionEffect._bitmap := Shader_GetBitmap(gFX_SelectionEffect.key)
     } catch as e {
+        gFX_SelectionEffect._bitmap := 0
         if (cfg.DiagShaderLog) {
             global LOG_PATH_SHADER
             errDetail := "Selection shader ERR [" gFX_SelectionEffect.key "]: " e.Message " @ " e.What
@@ -633,7 +644,8 @@ FX_DrawSelectionEffect(wPhys, hPhys, selX := 0, selY := 0, selW := 0, selH := 0,
         return
     }
 
-    pBitmap := Shader_GetBitmap(gFX_SelectionEffect.key)
+    ; Use bitmap cached during pre-render (avoids Map+try lookup)
+    pBitmap := gFX_SelectionEffect._bitmap
     if (!pBitmap) {
         Profiler.Leave() ; @profile
         return
@@ -641,6 +653,7 @@ FX_DrawSelectionEffect(wPhys, hPhys, selX := 0, selY := 0, selW := 0, selH := 0,
 
     if (gFX_SelectionEffect.isBGShader) {
         static srcRect := Buffer(16), tgtPt := Buffer(8), dstRect := Buffer(16)
+        static selBmpWrap := {ptr: 0}  ; reusable COM wrapper (avoids per-frame object alloc)
         ; Clip shader output to RowRadius rounded rect
         clipped := D2D_PushRoundRectClipLayer(selX, selY, selW, selH, rad)
         if (cfg.GUI_BGShaderAsSelectionSize = "Resize") {
@@ -649,7 +662,8 @@ FX_DrawSelectionEffect(wPhys, hPhys, selX := 0, selY := 0, selW := 0, selH := 0,
                    "float", Float(selX + selW), "float", Float(selY + selH), dstRect)
             NumPut("float", 0.0, "float", 0.0,
                    "float", Float(selW), "float", Float(selH), srcRect)
-            gD2D_RT.DrawBitmap({ptr: pBitmap}, dstRect, 1.0, 1, srcRect)
+            selBmpWrap.ptr := pBitmap
+            gD2D_RT.DrawBitmap(selBmpWrap, dstRect, 1.0, 1, srcRect)
         } else {
             ; Clip mode: shader rendered at full size — crop to selection rect
             NumPut("float", Float(selX), "float", Float(selY),
@@ -812,19 +826,19 @@ _FX_ResolveConfiguredShaders() {
                 darkness: cfg.MouseEffect_Darkness,
                 desat: cfg.MouseEffect_Desaturation,
                 speed: cfg.MouseEffect_Speed,
-                reactivity: cfg.MouseEffect_Reactivity}
+                reactivity: cfg.MouseEffect_Reactivity, _bitmap: 0}
             ; Set reactivity on the shader registry entry if already registered
             if (gShader_Registry.Has(mouseKey))
                 gShader_Registry[mouseKey].reactivity := cfg.MouseEffect_Reactivity
         } else {
-            gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0}
+            gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0, _bitmap: 0}
         }
     } else {
-        gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0}
+        gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0, _bitmap: 0}
     }
 
     ; Resolve selection effect — BG-as-selection overrides dedicated selection shaders
-    static _emptySelEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
+    static _emptySelEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
     if (!cfg.GUI_UseSelectionEffect) {
         gFX_SelectionEffect := _emptySelEffect
     } else if (cfg.GUI_UseBGShaderAsSelection) {
@@ -835,7 +849,7 @@ _FX_ResolveConfiguredShaders() {
                 darkness: cfg.GUI_SelectionDarkness,
                 desat: cfg.GUI_SelectionDesaturation,
                 speed: cfg.GUI_SelectionSpeed,
-                isBGShader: true}
+                isBGShader: true, _bitmap: 0}
         } else {
             gFX_SelectionEffect := _emptySelEffect
         }
@@ -848,7 +862,7 @@ _FX_ResolveConfiguredShaders() {
                     darkness: cfg.GUI_SelectionDarkness,
                     desat: cfg.GUI_SelectionDesaturation,
                     speed: cfg.GUI_SelectionSpeed,
-                    isBGShader: false}
+                    isBGShader: false, _bitmap: 0}
                 if (gShader_Registry.Has(selKey)) {
                     gShader_Registry[selKey].selGlow := cfg.GUI_SelectionGlow
                     gShader_Registry[selKey].selIntensity := cfg.GUI_SelectionIntensity
@@ -862,7 +876,7 @@ _FX_ResolveConfiguredShaders() {
     }
 
     ; Resolve hover effect — mirrors selection resolve with hover-specific config
-    static _emptyHovEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false}
+    static _emptyHovEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
     if (!cfg.GUI_UseHoverSelectionEffect) {
         gFX_HoverEffect := _emptyHovEffect
     } else if (cfg.GUI_UseBGShaderAsHoverSelection) {
@@ -873,7 +887,7 @@ _FX_ResolveConfiguredShaders() {
                 darkness: cfg.GUI_HoverSelectionDarkness,
                 desat: cfg.GUI_HoverSelectionDesaturation,
                 speed: cfg.GUI_HoverSelectionSpeed,
-                isBGShader: true}
+                isBGShader: true, _bitmap: 0}
         } else {
             gFX_HoverEffect := _emptyHovEffect
         }
@@ -886,7 +900,7 @@ _FX_ResolveConfiguredShaders() {
                     darkness: cfg.GUI_HoverSelectionDarkness,
                     desat: cfg.GUI_HoverSelectionDesaturation,
                     speed: cfg.GUI_HoverSelectionSpeed,
-                    isBGShader: false}
+                    isBGShader: false, _bitmap: 0}
                 if (gShader_Registry.Has(hovSelKey)) {
                     gShader_Registry[hovSelKey].selGlow := cfg.GUI_HoverSelectionGlow
                     gShader_Registry[hovSelKey].selIntensity := 1.0
@@ -1063,7 +1077,7 @@ FX_CycleMouseEffect() {
 
     if (currentIdx = 0) {
         gFX_MouseEffect := {key: "", name: "", opacity: 0.30, darkness: gFX_MouseEffect.darkness,
-            desat: gFX_MouseEffect.desat, speed: gFX_MouseEffect.speed, reactivity: gFX_MouseEffect.reactivity}
+            desat: gFX_MouseEffect.desat, speed: gFX_MouseEffect.speed, reactivity: gFX_MouseEffect.reactivity, _bitmap: 0}
     } else {
         newKey := MOUSE_SHADER_KEYS[currentIdx + 1]
         if (!gShader_Registry.Has(newKey))
@@ -1072,7 +1086,7 @@ FX_CycleMouseEffect() {
             gShader_Registry[newKey].reactivity := gFX_MouseEffect.reactivity
         gFX_MouseEffect := {key: newKey, name: MOUSE_SHADER_NAMES[currentIdx + 1],
             opacity: gFX_MouseEffect.opacity, darkness: gFX_MouseEffect.darkness,
-            desat: gFX_MouseEffect.desat, speed: gFX_MouseEffect.speed, reactivity: gFX_MouseEffect.reactivity}
+            desat: gFX_MouseEffect.desat, speed: gFX_MouseEffect.speed, reactivity: gFX_MouseEffect.reactivity, _bitmap: 0}
         ; Init time state for the new shader (keyed by name for mouse/selection)
         _FX_InitShaderTimeForKey(newKey)
     }
@@ -1114,7 +1128,7 @@ FX_CycleSelectionEffect() {
         gFX_SelectionEffect := {key: "", name: "",
             opacity: cfg.GUI_SelectionOpacity, darkness: cfg.GUI_SelectionDarkness,
             desat: cfg.GUI_SelectionDesaturation, speed: cfg.GUI_SelectionSpeed,
-            isBGShader: false}
+            isBGShader: false, _bitmap: 0}
     } else {
         newKey := keys[currentIdx + 1]
         if (!gShader_Registry.Has(newKey))
@@ -1122,7 +1136,7 @@ FX_CycleSelectionEffect() {
         gFX_SelectionEffect := {key: newKey, name: names[currentIdx + 1],
             opacity: cfg.GUI_SelectionOpacity, darkness: cfg.GUI_SelectionDarkness,
             desat: cfg.GUI_SelectionDesaturation, speed: cfg.GUI_SelectionSpeed,
-            isBGShader: useBG}
+            isBGShader: useBG, _bitmap: 0}
         if (!useBG && gShader_Registry.Has(newKey)) {
             gShader_Registry[newKey].selGlow := cfg.GUI_SelectionGlow
             gShader_Registry[newKey].selIntensity := cfg.GUI_SelectionIntensity
@@ -1213,7 +1227,10 @@ FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borde
             selR, selG, selB, selA,
             bdrR, bdrG, bdrB, bdrA,
             borderWidth * 1.0, hovIntensity * 1.0, entranceT * 1.0, rowRadius * 1.0)
+        ; Cache bitmap ptr for draw phase (avoids Map+try lookup in FX_DrawHoverEffect)
+        gFX_HoverEffect._bitmap := Shader_GetBitmap(gFX_HoverEffect.key)
     } catch as e {
+        gFX_HoverEffect._bitmap := 0
         if (cfg.DiagShaderLog) {
             global LOG_PATH_SHADER
             errDetail := "Hover shader ERR [" gFX_HoverEffect.key "]: " e.Message " @ " e.What
@@ -1236,7 +1253,8 @@ FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: d
         return
     }
 
-    pBitmap := Shader_GetBitmap(gFX_HoverEffect.key)
+    ; Use bitmap cached during pre-render (avoids Map+try lookup)
+    pBitmap := gFX_HoverEffect._bitmap
     if (!pBitmap) {
         Profiler.Leave() ; @profile
         return
@@ -1244,6 +1262,7 @@ FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: d
 
     if (gFX_HoverEffect.isBGShader) {
         static hov_srcRect := Buffer(16), hov_tgtPt := Buffer(8), hov_dstRect := Buffer(16)
+        static hovBmpWrap := {ptr: 0}  ; reusable COM wrapper (avoids per-frame object alloc)
         ; Clip shader output to RowRadius rounded rect
         clipped := D2D_PushRoundRectClipLayer(selX, selY, selW, selH, rad)
         if (cfg.GUI_HoverBGShaderAsSelectionSize = "Resize") {
@@ -1251,7 +1270,8 @@ FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: d
                    "float", Float(selX + selW), "float", Float(selY + selH), hov_dstRect)
             NumPut("float", 0.0, "float", 0.0,
                    "float", Float(selW), "float", Float(selH), hov_srcRect)
-            gD2D_RT.DrawBitmap({ptr: pBitmap}, hov_dstRect, 1.0, 1, hov_srcRect)
+            hovBmpWrap.ptr := pBitmap
+            gD2D_RT.DrawBitmap(hovBmpWrap, hov_dstRect, 1.0, 1, hov_srcRect)
         } else {
             NumPut("float", Float(selX), "float", Float(selY),
                    "float", Float(selX + selW), "float", Float(selY + selH), hov_srcRect)
@@ -1309,7 +1329,7 @@ FX_CycleHoverEffect() {
         gFX_HoverEffect := {key: "", name: "",
             opacity: cfg.GUI_HoverSelectionOpacity, darkness: cfg.GUI_HoverSelectionDarkness,
             desat: cfg.GUI_HoverSelectionDesaturation, speed: cfg.GUI_HoverSelectionSpeed,
-            isBGShader: false}
+            isBGShader: false, _bitmap: 0}
     } else {
         newKey := keys[currentIdx + 1]
         if (!gShader_Registry.Has(newKey))
@@ -1317,7 +1337,7 @@ FX_CycleHoverEffect() {
         gFX_HoverEffect := {key: newKey, name: names[currentIdx + 1],
             opacity: cfg.GUI_HoverSelectionOpacity, darkness: cfg.GUI_HoverSelectionDarkness,
             desat: cfg.GUI_HoverSelectionDesaturation, speed: cfg.GUI_HoverSelectionSpeed,
-            isBGShader: useBG}
+            isBGShader: useBG, _bitmap: 0}
         if (!useBG && gShader_Registry.Has(newKey)) {
             gShader_Registry[newKey].selGlow := cfg.GUI_HoverSelectionGlow
             gShader_Registry[newKey].selIntensity := 1.0

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -558,6 +558,13 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
         i := 0
         yRow := y
 
+        ; Pre-check column existence once per paint (avoids HasOwnProp per-row per-col)
+        if (cols.Length > 0) {
+            sample := items[start0 + 1]
+            for _, col in cols
+                col._exists := sample.HasOwnProp(col.key)
+        }
+
         ; Use cached layout metrics (computed once per scale change above)
         titleY := cachedLayout.titleY
         titleH := cachedLayout.titleH
@@ -586,6 +593,10 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
         selW := wPhys - 2 * Mx + selExpandX * 2
         selH := RowH
         selX := Mx - selExpandX
+
+        ; Hoist entrance animation value (used by both selection and hover shader paths)
+        entranceT := Anim_GetValue("fx_sel_entrance", 1.0)
+
         if (selIndex > 0 && selIndex <= count) {
             ; Compute the "snap" Y (where the selection IS in the current layout)
             baseSelY := Anim_CalcSelY(selIndex, scrollTop, contentTopY, RowH, count, selExpandY)
@@ -602,7 +613,6 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
             global gFX_SelectionEffect
             if (gFX_SelectionEffect.key != "" && gFX_GPUReady) {
                 ; Shader-based selection effect
-                entranceT := Anim_GetValue("fx_sel_entrance", 1.0)
                 FX_PreRenderSelectionEffect(wPhys, hPhys, selX, selY, selW, selH,
                     cfg.GUI_SelARGB, cfg.GUI_SelBorderARGB, cfg.GUI_SelBorderWidthPx, 1.0, entranceT, Rad)
                 FX_DrawSelectionEffect(wPhys, hPhys, selX, selY, selW, selH, Rad)
@@ -631,15 +641,13 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
                 hoverW := wPhys - 2 * Mx + selExpandX * 2
                 if (gFX_HoverEffect.key != "" && gFX_GPUReady) {
                     ; Path 1: Independent hover shader
-                    hoverEntranceT := Anim_GetValue("fx_sel_entrance", 1.0)
                     FX_PreRenderHoverEffect(wPhys, hPhys, hoverX, hoverY, hoverW, RowH,
-                        cfg.GUI_HoverARGB, cfg.GUI_HovBorderARGB, cfg.GUI_HovBorderWidthPx, hoverEntranceT, Rad)
+                        cfg.GUI_HoverARGB, cfg.GUI_HovBorderARGB, cfg.GUI_HovBorderWidthPx, entranceT, Rad)
                     FX_DrawHoverEffect(wPhys, hPhys, hoverX, hoverY, hoverW, RowH, Rad)
                 } else if (!cfg.GUI_UseHoverSelectionEffect && gFX_SelectionEffect.key != "" && gFX_GPUReady) {
                     ; Path 2: Reuse selection shader at SelectionIntensityForHover (only when hover independence is off)
-                    hoverEntranceT := Anim_GetValue("fx_sel_entrance", 1.0)
                     FX_PreRenderSelectionEffect(wPhys, hPhys, hoverX, hoverY, hoverW, RowH,
-                        cfg.GUI_SelARGB, cfg.GUI_SelBorderARGB, cfg.GUI_SelBorderWidthPx, cfg.GUI_SelectionIntensityForHover, hoverEntranceT, Rad)
+                        cfg.GUI_SelARGB, cfg.GUI_SelBorderARGB, cfg.GUI_SelBorderWidthPx, cfg.GUI_SelectionIntensityForHover, entranceT, Rad)
                     FX_DrawSelectionEffect(wPhys, hPhys, hoverX, hoverY, hoverW, RowH, Rad)
                 } else if (gFX_GPUReady) {
                     ; Path 3: GPU flat fill + border
@@ -706,18 +714,14 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
                 _FX_DrawTextLeftShadow(title, textX, yRow + titleY, textW, titleH, brMainUse, tfMainUse, shadowBr, sOffX, sOffY)
                 _FX_DrawTextLeftShadow(sub, textX, yRow + subY, textW, subH, brSubUse, tfSubUse, shadowBr, sOffX, sOffY)
                 for _, col in cols {
-                    val := ""
-                    if (cur.HasOwnProp(col.key))
-                        val := cur.%col.key%
+                    val := col._exists ? cur.%col.key% : ""
                     _FX_DrawTextLeftShadow(val, col.x, yRow + colY, col.w, colH, brColUse, tfColUse, shadowBr, sOffX, sOffY)
                 }
             } else {
                 D2D_DrawTextLeft(title, textX, yRow + titleY, textW, titleH, brMainUse, tfMainUse)
                 D2D_DrawTextLeft(sub, textX, yRow + subY, textW, subH, brSubUse, tfSubUse)
                 for _, col in cols {
-                    val := ""
-                    if (cur.HasOwnProp(col.key))
-                        val := cur.%col.key%
+                    val := col._exists ? cur.%col.key% : ""
                     D2D_DrawTextLeft(val, col.x, yRow + colY, col.w, colH, brColUse, tfColUse)
                 }
             }
@@ -752,10 +756,15 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
     if (diagTiming)
         tPO_Footer := QPC() - t1
 
-    ; Inner shadow — config-driven depth and opacity
-    if (gFX_GPUReady && cfg.GUI_UseInnerShadow && cfg.GUI_InnerShadowAlpha > 0) {
-        shadowDepth := Round(cfg.GUI_InnerShadowDepthPx * scale)
-        FX_GPU_DrawInnerShadow(wPhys, hPhys, shadowDepth, cfg.GUI_InnerShadowAlpha)
+    ; Inner shadow — config-driven depth and opacity (cached — config-stable)
+    static _isEnabled := -1, _isAlpha := 0, _isDepthPx := 0
+    if (_isEnabled = -1) {
+        _isEnabled := cfg.GUI_UseInnerShadow
+        _isAlpha := cfg.GUI_InnerShadowAlpha
+        _isDepthPx := cfg.GUI_InnerShadowDepthPx
+    }
+    if (gFX_GPUReady && _isEnabled && _isAlpha > 0) {
+        FX_GPU_DrawInnerShadow(wPhys, hPhys, Round(_isDepthPx * scale), _isAlpha)
     }
 
     ; FPS debug overlay (toggled by F key)
@@ -801,38 +810,47 @@ GUI_GetActionBtnMetrics(scale) {
 }
 
 ; Draw a single action button and update btnX position
-; Parameters:
-;   &btnX     - ByRef x position (decremented after drawing)
-;   btnY      - y position
-;   size      - button size in pixels
-;   rad       - corner radius in pixels
-;   scale     - DPI scale factor
-;   btnName   - button identifier ("close", "kill", "blacklist")
-;   showProp  - config property name for show toggle (e.g., "GUI_ShowCloseButton")
-;   bgProp    - config property prefix for colors (e.g., "GUI_CloseButton")
-;   glyph     - text/glyph to draw
-;   borderPx  - border thickness (from config)
-;   gap       - gap between buttons in pixels
-_GUI_DrawOneActionButton(&btnX, btnY, size, rad, scale, btnName, showProp, bgProp, glyph, borderPx, gap) {
-    global gGUI_HoverBtn, cfg, gD2D_Res
+_GUI_DrawOneActionButton(&btnX, btnY, size, rad, scale, bc, gap, tfAction) {
+    global gGUI_HoverBtn
 
-    if (!cfg.%showProp%)
+    if (!bc.show)
         return
 
-    hovered := (gGUI_HoverBtn = btnName)
-    bgCol := hovered ? cfg.%bgProp "BGHoverARGB"% : cfg.%bgProp "BGARGB"%
-    txCol := hovered ? cfg.%bgProp "TextHoverARGB"% : cfg.%bgProp "TextARGB"%
+    hovered := (gGUI_HoverBtn = bc.name)
+    bgCol := hovered ? bc.bgHov : bc.bg
+    txCol := hovered ? bc.txHov : bc.tx
 
     D2D_FillRoundRect(btnX, btnY, size, size, rad, D2D_GetCachedBrush(bgCol))
-    if (borderPx > 0) {
-        D2D_StrokeRoundRect(btnX + 0.5, btnY + 0.5, size - 1, size - 1, rad, D2D_GetCachedBrush(cfg.%bgProp "BorderARGB"%), Round(borderPx * scale))
+    if (bc.borderPx > 0) {
+        D2D_StrokeRoundRect(btnX + 0.5, btnY + 0.5, size - 1, size - 1, rad, D2D_GetCachedBrush(bc.border), Round(bc.borderPx * scale))
     }
-    D2D_DrawTextCentered(glyph, btnX, btnY, size, size, D2D_GetCachedBrush(txCol), gD2D_Res["tfAction"])
+    D2D_DrawTextCentered(bc.glyph, btnX, btnY, size, size, D2D_GetCachedBrush(txCol), tfAction)
     btnX := btnX - (size + gap)
 }
 
 _GUI_DrawActionButtons(wPhys, yRow, rowHPhys, scale, Mx) {
-    global gGUI_HoverBtn, cfg
+    global gGUI_HoverBtn, cfg, gD2D_Res
+
+    ; Pre-build button configs once (config-stable — process restarts on config change)
+    ; Eliminates per-frame dynamic property concat + lookup (3 buttons × ~5 dynamic accesses)
+    static btnCfg := 0, tfAction := 0
+    if (!btnCfg) {
+        tfAction := gD2D_Res["tfAction"]
+        btnCfg := [
+            {name: "close", show: cfg.GUI_ShowCloseButton,
+             bg: cfg.GUI_CloseButtonBGARGB, bgHov: cfg.GUI_CloseButtonBGHoverARGB,
+             tx: cfg.GUI_CloseButtonTextARGB, txHov: cfg.GUI_CloseButtonTextHoverARGB,
+             border: cfg.GUI_CloseButtonBorderARGB, glyph: cfg.GUI_CloseButtonGlyph, borderPx: cfg.GUI_CloseButtonBorderPx},
+            {name: "kill", show: cfg.GUI_ShowKillButton,
+             bg: cfg.GUI_KillButtonBGARGB, bgHov: cfg.GUI_KillButtonBGHoverARGB,
+             tx: cfg.GUI_KillButtonTextARGB, txHov: cfg.GUI_KillButtonTextHoverARGB,
+             border: cfg.GUI_KillButtonBorderARGB, glyph: cfg.GUI_KillButtonGlyph, borderPx: cfg.GUI_KillButtonBorderPx},
+            {name: "blacklist", show: cfg.GUI_ShowBlacklistButton,
+             bg: cfg.GUI_BlacklistButtonBGARGB, bgHov: cfg.GUI_BlacklistButtonBGHoverARGB,
+             tx: cfg.GUI_BlacklistButtonTextARGB, txHov: cfg.GUI_BlacklistButtonTextHoverARGB,
+             border: cfg.GUI_BlacklistButtonBorderARGB, glyph: cfg.GUI_BlacklistButtonGlyph, borderPx: cfg.GUI_BlacklistButtonBorderPx}
+        ]
+    }
 
     metrics := GUI_GetActionBtnMetrics(scale)
     size := metrics.size
@@ -843,14 +861,8 @@ _GUI_DrawActionButtons(wPhys, yRow, rowHPhys, scale, Mx) {
     btnX := wPhys - marR - size
     btnY := yRow + (rowHPhys - size) // 2
 
-    _GUI_DrawOneActionButton(&btnX, btnY, size, rad, scale, "close",
-        "GUI_ShowCloseButton", "GUI_CloseButton", cfg.GUI_CloseButtonGlyph, cfg.GUI_CloseButtonBorderPx, gap)
-
-    _GUI_DrawOneActionButton(&btnX, btnY, size, rad, scale, "kill",
-        "GUI_ShowKillButton", "GUI_KillButton", cfg.GUI_KillButtonGlyph, cfg.GUI_KillButtonBorderPx, gap)
-
-    _GUI_DrawOneActionButton(&btnX, btnY, size, rad, scale, "blacklist",
-        "GUI_ShowBlacklistButton", "GUI_BlacklistButton", cfg.GUI_BlacklistButtonGlyph, cfg.GUI_BlacklistButtonBorderPx, gap)
+    for _, bc in btnCfg
+        _GUI_DrawOneActionButton(&btnX, btnY, size, rad, scale, bc, gap, tfAction)
 }
 
 ; ========================= SCROLLBAR =========================


### PR DESCRIPTION
## Summary

- Cache shader `_bitmap` ptrs on effect/layer objects during pre-render, eliminating up to 7 `Shader_GetBitmap()` Map+try lookups per frame from draw phase
- Replace `HasOwnProp(col.key)` in row×column inner loop (~100 calls/frame) with one-time sample-based `col._exists` check
- Pre-build action button config as static `btnCfg` array to remove per-frame dynamic property concatenation (`cfg.%bgProp "..."% `)
- Reuse static COM wrappers for BG-shader `DrawBitmap` (eliminates `{ptr: pBitmap}` per-frame object alloc)
- Hoist `entranceT` and `tfAction` lookups, cache inner shadow config reads, skip `SetLayeredWindowAttributes` when alpha unchanged

Estimated ~67-164μs/frame savings (~16-39ms/s at 240fps).

Closes #367

## Test plan

- [x] All 1011 tests pass (`.\tests\test.ps1 --live`)
- [ ] Visual verification: overlay renders correctly with shader layers active
- [ ] Selection/hover BG-shader-as-selection Resize mode renders correctly
- [ ] Action buttons render on hover (close, kill, blacklist)
- [ ] Column text displays for all column types (workspace, monitor, pid, hwnd)
- [ ] Inner shadow renders
- [ ] Fade animation still smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)