### PR TITLE
Fix unpruned paint subtitle cache and add GDI+ shutdown

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -26,6 +26,7 @@ gAnim_HidePending: gui_animation, gui_overlay
 gD2D_RT: gui_bgimage, gui_overlay, gui_paint
 gFX_AmbientTime: gui_animation, gui_effects
 gGUI_CurrentWSName: gui_activation, gui_state
+_gPaint_SubCache: gui_gdip, gui_paint
 gGUI_DisplayItems: gui_animation, gui_data, gui_state
 gGUI_EventBuffer: gui_activation, gui_state
 gGUI_FocusBeforeShow: gui_paint, gui_state

--- a/src/gui/d2d_shader.ahk
+++ b/src/gui/d2d_shader.ahk
@@ -22,6 +22,7 @@ global gShader_Ready := false    ; true after Shader_Init succeeds
 global gShader_FrameCount := 0   ; frame counter for cbuffer
 global gShader_StateDirty := true ; dirty flag: D3D11 common state needs re-binding
 global gShader_BatchMode := false  ; when true, defer RT/SRV unbind to Shader_EndBatch
+global _gShader_GdipToken := 0    ; GDI+ startup token (for shutdown on cleanup)
 
 ; Mark D3D11 common pipeline state as needing re-binding.
 ; Call after D2D operations that share the device context (e.g., BeginDraw).
@@ -1387,6 +1388,13 @@ Shader_Cleanup() {
 
     gShader_Ready := false
     gShader_FrameCount := 0
+
+    ; Shut down GDI+ if it was initialized for texture loading
+    global _gShader_GdipToken
+    if (_gShader_GdipToken) {
+        DllCall("gdiplus\GdiplusShutdown", "ptr", _gShader_GdipToken)
+        _gShader_GdipToken := 0
+    }
 }
 
 ; ========================= GDI+ INIT =========================
@@ -1394,10 +1402,14 @@ Shader_Cleanup() {
 ; One-shot GDI+ startup for texture loading. The main D2D pipeline doesn't use GDI+,
 ; but we need it here to decode PNG files into pixel data for D3D11 textures.
 _Shader_InitGdiplus() {
+    global _gShader_GdipToken
+    if (_gShader_GdipToken)
+        return _gShader_GdipToken
     si := Buffer(24, 0)  ; GdiplusStartupInput (x64)
     NumPut("uint", 1, si, 0)  ; GdiplusVersion = 1
     token := 0
     DllCall("gdiplus\GdiplusStartup", "ptr*", &token, "ptr", si, "ptr", 0)
+    _gShader_GdipToken := token
     return token
 }
 

--- a/src/gui/gui_gdip.ahk
+++ b/src/gui/gui_gdip.ahk
@@ -303,6 +303,7 @@ _D2D_SetEllipsisTrimming(tf) {
 ; Dispose all D2D resources. COM wrappers auto-release via __Delete.
 D2D_DisposeResources() {
     global gD2D_Res, gD2D_ResScale, gGdip_ResScale, gD2D_BrushCache, gGdip_IconCache
+    global _gPaint_SubCache
 
     ; Clear named resources — COM wrapper __Delete releases each object
     gD2D_Res := Map()
@@ -314,6 +315,9 @@ D2D_DisposeResources() {
 
     ; Clear icon cache — D2D bitmap wrappers auto-release
     _D2D_ClearIconCache()
+
+    ; Clear paint subtitle cache (hwnd → "Class: ..." strings)
+    _gPaint_SubCache := Map()
 }
 
 ; ========================= ICON CACHE =========================


### PR DESCRIPTION
## Summary

- Clear `_gPaint_SubCache` in `D2D_DisposeResources()` alongside brush and icon caches — entries accumulated unbounded across overlay cycles for windows without a processName
- Move shader GDI+ token from function-local `static` to file-scope `_gShader_GdipToken` so `Shader_Cleanup()` can call `GdiplusShutdown()`
- Add `_gPaint_SubCache` to `ownership.manifest` for the new cross-file write from `gui_gdip`

Closes #368

## Test plan

- [x] Full test suite passes (1011/1011 — unit, GUI, live, flight recorder)
- [x] Static analysis pre-gate passes (86 checks including ownership manifest validation)
- [ ] Manual: run with shaders enabled, verify no regression on overlay show/hide cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)