### PR TITLE
Fix gGUI_InGraceCallback: activate one-shot timer guard

### DIFF
--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -394,6 +394,14 @@ GUI_OnInterceptorEvent(evCode, flags, lParam) {
 ; ========================= GRACE TIMER =========================
 
 _GUI_GraceTimerFired() {
+    ; RACE FIX: Set guard flag BEFORE any code that could yield. Hotkeys that fire
+    ; during _GUI_ShowOverlayWithFrozen (via STA pump or before gGUI_OverlayVisible
+    ; is set) check this flag to skip SetTimer(_GUI_GraceTimerFired, 0) — calling
+    ; SetTimer(fn, 0) on an already-fired one-shot corrupts timer dispatch (#303).
+    ; try/finally guarantees cleanup on all exit paths (pattern: gPaint_RepaintInProgress).
+    global gGUI_InGraceCallback
+    gGUI_InGraceCallback := true
+    try {
     Profiler.Enter("_GUI_GraceTimerFired") ; @profile
     ; Hold Critical only for the atomic state check — NOT for the heavy D2D paint.
     ; Previous: Critical covered the entire show+paint sequence. D2D COM calls pump
@@ -432,6 +440,9 @@ _GUI_GraceTimerFired() {
     }
     Critical "Off"
     Profiler.Leave() ; @profile
+    } finally {
+        gGUI_InGraceCallback := false
+    }
 }
 
 ; ========================= ACTIVE-STATE WATCHDOG (#303) =========================

--- a/tests/gui_tests_state.ahk
+++ b/tests/gui_tests_state.ahk
@@ -26,6 +26,7 @@ RunGUITests_State() {
     global gStats_AltTabs, gStats_QuickSwitches, gStats_TabSteps, gStats_Cancellations
     global gGUI_MonitorMode, gGUI_OverlayMonitorHandle, gStats_MonitorToggles
     global gINT_AltIsDown, gMock_AltPhysicallyDown, gMock_RecoverLostAltUpCalls  ; #303
+    global gGUI_InGraceCallback
 
     GUI_Log("`n=== GUI State Machine Tests ===`n")
 
@@ -366,6 +367,7 @@ RunGUITests_State() {
 
     ; Overlay should NOT have shown - grace timer should have aborted
     GUI_AssertEq(gGUI_OverlayVisible, false, "Grace timer correctly aborted (state was IDLE)")
+    GUI_AssertEq(gGUI_InGraceCallback, false, "Grace callback guard cleared after state-mismatch abort")
 
     ; ----- Test: Grace timer race - ShowOverlay aborts cleanly when state changed to IDLE -----
     GUI_Log("Test: Grace timer race - ShowOverlay aborts with force-hide")
@@ -382,6 +384,7 @@ RunGUITests_State() {
     ; OverlayVisible must be false after abort
     GUI_AssertEq(gGUI_OverlayVisible, false, "Race fix: overlay not visible after late grace fire")
     GUI_AssertEq(gGUI_State, "IDLE", "Race fix: state still IDLE after late grace fire")
+    GUI_AssertEq(gGUI_InGraceCallback, false, "Grace callback guard cleared after late-fire abort")
     ; Mock GUI windows must not be visible (force-hide cleans up in-flight Show)
     GUI_AssertEq(gGUI_Base.visible, false, "Race fix: gGUI_Base not visible after abort")
     GUI_AssertEq(gGUI_Overlay.visible, false, "Race fix: gGUI_Overlay not visible after abort")
@@ -679,6 +682,7 @@ RunGUITests_State() {
     ; Recovery is deferred to a fresh timer thread to avoid corrupting AHK's timer state.
     _GUI_GraceTimerFired()
     GUI_AssertEq(gGUI_OverlayVisible, false, "#303 L2: overlay never shown")
+    GUI_AssertEq(gGUI_InGraceCallback, false, "Grace callback guard cleared after lost-Alt recovery")
     ; Recovery is deferred (-1ms timer) — wait for it to fire
     Sleep(50)
     GUI_AssertEq(gGUI_State, "IDLE", "#303 L2: state recovered to IDLE")
@@ -700,6 +704,7 @@ RunGUITests_State() {
     GUI_AssertEq(gGUI_State, "ACTIVE", "#303 normal: state stays ACTIVE (Alt held)")
     GUI_AssertEq(gGUI_OverlayVisible, true, "#303 normal: overlay shown")
     GUI_AssertTrue(gMock_RecoverLostAltUpCalls.Length = 0, "#303 normal: no recovery called")
+    GUI_AssertEq(gGUI_InGraceCallback, false, "Grace callback guard cleared after normal show")
 
     ; ----- Test: Watchdog stops when leaving ACTIVE via ALT_UP -----
     GUI_Log("Test: #303 Watchdog stops on normal ALT_UP")


### PR DESCRIPTION
## Summary

- Activate the `gGUI_InGraceCallback` guard flag that was declared and checked but never set to `true` — dead code since #303
- Wrap `_GUI_GraceTimerFired()` in `try/finally` to set the flag before any yieldable code and clear it on all 3 exit paths
- Prevents `SetTimer(_GUI_GraceTimerFired, 0)` from being called on an already-fired one-shot during STA message pump, which corrupts AHK v2's timer dispatch permanently
- Add 4 test assertions covering all exit paths (state-mismatch, late-fire, lost-Alt recovery, normal show)

Closes #370

## Test plan

- [x] Static analysis pre-gate passes (86 checks)
- [x] GUI tests pass (355/355) including 4 new `gGUI_InGraceCallback` assertions
- [x] All unit tests pass (564/564)
- [x] All live tests pass (64/64)
- [x] Full suite: 1015/1015 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)