### PR TITLE
Reduce gui_animation ownership coupling (6→2 manifest entries)

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -24,15 +24,14 @@ cfg: launcher_tray, config_loader, setup_utils
 gAnim_DeferredTimerStart: gui_animation, gui_paint
 gAnim_HidePending: gui_animation, gui_overlay
 gD2D_RT: gui_bgimage, gui_overlay, gui_paint
-gFX_AmbientTime: gui_animation, gui_effects
 gGUI_CurrentWSName: gui_activation, gui_state
-gGUI_DisplayItems: gui_animation, gui_data, gui_state
+gGUI_DisplayItems: gui_data, gui_state
 gGUI_EventBuffer: gui_activation, gui_state
 gGUI_FocusBeforeShow: gui_paint, gui_state
 gGUI_LastRowsDesired: gui_paint, gui_state
 gGUI_LiveItems: gui_activation, gui_data
-gGUI_OverlayVisible: gui_animation, gui_overlay, gui_state
-gGUI_Revealed: gui_animation, gui_overlay, gui_paint, gui_state
+gGUI_OverlayVisible: gui_overlay, gui_state
+gGUI_Revealed: gui_overlay, gui_paint, gui_state
 gGUI_ScrollTop: gui_data, gui_input, gui_paint, gui_state
 gGUI_Sel: gui_data, gui_input, gui_state
 gGUI_ToggleBase: gui_data, gui_state

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -26,7 +26,6 @@ global gAnim_HidePending := false     ; Hide-fade in progress
 global gAnim_DeferredTimerStart := false  ; Deferred frame loop start (STA pump safety, #175)
 global gAnim_SelPrevIndex := 0        ; Previous selection index (for slide Y calc)
 global gAnim_SelNewIndex := 0         ; New selection index (for slide Y calc)
-global gFX_AmbientTime := 0.0         ; Cumulative ms for ambient loops (Full mode)
 
 ; FPS debug counter state
 global FPS_SAMPLE_INTERVAL_MS := 500  ; How often to update the debug FPS readout
@@ -113,11 +112,9 @@ _Anim_CancelTween(name) {
 }
 
 Anim_CancelAll() {
-    global gAnim_Tweens, gFX_AmbientTime, gAnim_HidePending
+    global gAnim_Tweens, gAnim_HidePending
     gAnim_Tweens := Map()
-    FX_SaveShaderTime()           ; Capture shader carry time before ambient resets
-    gFX_AmbientTime := 0.0
-    FX_ResetMouseVelocity()
+    FX_EndSession()
     gAnim_HidePending := false
     _Anim_StopTimer()
 }
@@ -446,9 +443,8 @@ Anim_ForceCompleteHide() {
 
 _Anim_DoActualHide() {
     Profiler.Enter("_Anim_DoActualHide") ; @profile
-    global gGUI_OverlayVisible, gGUI_Base, gGUI_BaseH, gGUI_Revealed
-    global cfg, GUI_LOG_TRIM_EVERY_N_HIDES
-    global gGUI_DisplayItems
+    global gGUI_OverlayVisible, gGUI_BaseH
+    global GUI_LOG_TRIM_EVERY_N_HIDES
     static hideCount := 0
 
     if (!gGUI_OverlayVisible) {
@@ -456,21 +452,9 @@ _Anim_DoActualHide() {
         return
     }
 
-    ; Release deferred display items — kept alive during hide-fade so the
-    ; frame loop paints the frozen list while fading out (not the live MRU).
-    gGUI_DisplayItems := []
-
-    GUI_ClearHoverState()
-
-    ; Clear D2D swap chain for clean buffer on next Show.
-    ; Paint_ClearSurface handles the repaint guard + D2D error recovery.
-    Paint_ClearSurface()
-
-    try {
-        gGUI_Base.Hide()
-    }
-    gGUI_OverlayVisible := false
-    gGUI_Revealed := false
+    ; State machine handles hide cleanup (display items, hover, paint surface,
+    ; window hide, visibility flags).
+    GUI_CompleteHideState()
 
     ; Remove WS_EX_LAYERED and reset alpha so next Show gets fresh DWM blur
     _Anim_RemoveLayered()

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -34,6 +34,7 @@ global gFX_MouseVelX := 0.0         ; Smoothed velocity X (px/sec)
 global gFX_MouseVelY := 0.0         ; Smoothed velocity Y (px/sec)
 global gFX_MouseSpeed := 0.0        ; Magnitude of velocity (px/sec)
 global gFX_MousePrevValid := false   ; False until first valid sample
+global gFX_AmbientTime := 0.0         ; Cumulative ms for ambient loops (Full mode)
 
 ; Initialize GPU effects. Call after gD2D_RT is valid.
 ; Returns true on success, false if effects unavailable.
@@ -900,8 +901,17 @@ _FX_ResolveConfiguredShaders() {
     }
 }
 
-; Save shader carry time before gFX_AmbientTime resets.
+; End-of-session cleanup: save shader carry time, reset ambient clock,
+; reset mouse velocity. Ordering matters — save BEFORE reset.
 ; Called from Anim_CancelAll (gui_animation.ahk) on overlay hide.
+FX_EndSession() {
+    global gFX_AmbientTime
+    FX_SaveShaderTime()
+    gFX_AmbientTime := 0.0
+    FX_ResetMouseVelocity()
+}
+
+; Save shader carry time before gFX_AmbientTime resets.
 FX_SaveShaderTime() {
     global gFX_ShaderTime, gFX_AmbientTime
     sessionSec := gFX_AmbientTime / 1000.0

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -663,6 +663,28 @@ _GUI_ResetSelectionToMRU(listRef := "") {
     return gGUI_Sel
 }
 
+; Complete hide after fade animation finishes. Called from _Anim_DoActualHide.
+; Clears display items (kept alive during fade for painting), hover state,
+; paint surface, hides window, and resets visibility flags.
+GUI_CompleteHideState() {
+    global gGUI_DisplayItems, gGUI_OverlayVisible, gGUI_Base, gGUI_Revealed
+
+    ; Release deferred display items — kept alive during hide-fade so the
+    ; frame loop paints the frozen list while fading out (not the live MRU).
+    gGUI_DisplayItems := []
+
+    GUI_ClearHoverState()
+
+    ; Clear D2D swap chain for clean buffer on next Show.
+    Paint_ClearSurface()
+
+    try {
+        gGUI_Base.Hide()
+    }
+    gGUI_OverlayVisible := false
+    gGUI_Revealed := false
+}
+
 ; Helper to abort a show sequence (hide windows and reset state flags).
 ; Called when state changes to non-ACTIVE during _GUI_ShowOverlayWithFrozen.
 _GUI_AbortShowSequence() {

--- a/tests/gui_tests_common.ahk
+++ b/tests/gui_tests_common.ahk
@@ -268,6 +268,8 @@ Paint_LogTrim() {
 }
 Paint_LogStartSession() {
 }
+Paint_ClearSurface() {
+}
 
 ; Animation mocks (gui_animation.ahk not included in tests)
 Anim_StartTween(name, from, to, durationMs, easingFunc) {


### PR DESCRIPTION
## Summary

- Extract `GUI_CompleteHideState()` in gui_state.ahk from `_Anim_DoActualHide` — moves 3 state-domain global writes (`gGUI_DisplayItems`, `gGUI_OverlayVisible`, `gGUI_Revealed`) out of gui_animation into their owning module
- Move `gFX_AmbientTime` declaration from gui_animation to gui_effects (sole reader/writer), eliminating the manifest entry entirely
- Create `FX_EndSession()` in gui_effects to encapsulate the save→reset→velocity session-end protocol with its ordering constraint
- Manifest: 17→16 entries, 43→37 file references, gui_animation 6→2 entries

Closes #374

## Test plan

- [x] Static analysis pre-gate passes (86 checks)
- [x] All 947 tests pass (unit, GUI, flight recorder)
- [x] `query_global_ownership.ps1 -Discover` confirms gui_animation appears in only 2 manifest entries
- [ ] Live test with overlay show/hide fade animation (verify `_Anim_DoActualHide` → `GUI_CompleteHideState()` path works)
- [ ] Verify shader ambient time carries across sessions (FX_EndSession save→reset ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)