### PR TITLE
Fix XML injection in admin task and stats flush data loss

### DIFF
--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -331,6 +331,16 @@ _ProcessGetExitCode(pid) {
 ; TASK SCHEDULER (ADMIN MODE)
 ; ============================================================
 
+; Escape XML-special characters in a string for safe embedding in XML elements.
+; Prevents malformed XML when paths contain & (legal in Windows directory/user names).
+_XmlEscape(str) {
+    str := StrReplace(str, "&", "&amp;")
+    str := StrReplace(str, "<", "&lt;")
+    str := StrReplace(str, ">", "&gt;")
+    str := StrReplace(str, '"', "&quot;")
+    return str
+}
+
 ; Create a scheduled task with highest privileges (UAC-free admin)
 ; Includes InstallationId in description for identification
 ; Returns false if user cancels due to existing task conflict
@@ -376,7 +386,7 @@ CreateAdminTask(exePath, installId := "", taskNameOverride := "") {
     xml := '<?xml version="1.0" encoding="UTF-16"?>'
     xml .= '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">'
     xml .= '<RegistrationInfo>'
-    xml .= '<Description>' taskDesc '</Description>'
+    xml .= '<Description>' _XmlEscape(taskDesc) '</Description>'
     xml .= '</RegistrationInfo>'
     xml .= '<Principals><Principal id="Author">'
     xml .= '<LogonType>InteractiveToken</LogonType>'
@@ -393,7 +403,7 @@ CreateAdminTask(exePath, installId := "", taskNameOverride := "") {
     xml .= '<WakeToRun>false</WakeToRun>'
     xml .= '</Settings>'
     xml .= '<Actions><Exec>'
-    xml .= '<Command>"' exePath '"</Command>'
+    xml .= '<Command>"' _XmlEscape(exePath) '"</Command>'
     xml .= '</Exec></Actions>'
     xml .= '</Task>'
 

--- a/src/shared/stats.ahk
+++ b/src/shared/stats.ahk
@@ -203,8 +203,8 @@ Stats_FlushToDisk() {
     }
 
     ; Fallback: direct write (pump not connected or send failed)
-    _Stats_DirectWrite(statsPath, content)
-    gStats_Dirty := false
+    if (_Stats_DirectWrite(statsPath, content))
+        gStats_Dirty := false
     Profiler.Leave() ; @profile
 }
 
@@ -233,8 +233,8 @@ Stats_ForceFlushToDisk() {
     content .= "_FlushStatus=complete`n"
     Critical "Off"
 
-    _Stats_DirectWrite(STATS_INI_PATH, content)
-    gStats_Dirty := false
+    if (_Stats_DirectWrite(STATS_INI_PATH, content))
+        gStats_Dirty := false
 }
 
 ; Try to offload stats write to enrichment pump via IPC.
@@ -263,8 +263,10 @@ _Stats_DirectWrite(statsPath, content) {
         FileMove(tmpPath, statsPath, true)
         ; Success — remove backup
         try FileDelete(statsPath ".bak")
+        return true
     } catch as e {
         _Stats_LogError("stats flush failed: " e.Message)
+        return false
     }
 }
 


### PR DESCRIPTION
## Summary

- Escape XML-special characters (`&`, `<`, `>`, `"`) in exe path and task description when building schtasks XML in `CreateAdminTask()` — prevents malformed XML for users with `&` in directory or user names
- Return success/failure from `_Stats_DirectWrite()` and only clear the dirty flag on success — failed flushes now retry on the next heartbeat instead of silently losing stats

Found via comprehensive audit of 20+ user journey scenarios across all installation, admin, wizard, update, and mismatch flows. Everything else checked out clean.

Closes #372

## Test plan

- [x] All 1011 tests pass (unit, GUI, live, flight recorder, static analysis)
- [ ] Manual: verify admin task creation with `&` in directory name
- [ ] Manual: verify stats retry on next heartbeat after write failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)