### PR TITLE
Eliminate redundant lookups in hot paths

### DIFF
--- a/src/core/komorebi_state.ahk
+++ b/src/core/komorebi_state.ahk
@@ -29,8 +29,8 @@
 
 ; Get ring elements safely (returns empty array on failure)
 KSafe_Elements(ring) {
-    if (ring is Map && ring.Has("elements")) {
-        el := ring["elements"]
+    if (ring is Map) {
+        el := ring.Get("elements", "")
         if (el is Array)
             return el
     }
@@ -39,15 +39,15 @@ KSafe_Elements(ring) {
 
 ; Get ring focused index safely (returns -1 on failure)
 _KSafe_Focused(ring) {
-    if (ring is Map && ring.Has("focused"))
-        return ring["focused"]
+    if (ring is Map)
+        return ring.Get("focused", -1)
     return -1
 }
 
 ; Get string property safely (returns "" on failure)
 _KSafe_Str(obj, key) {
-    if (obj is Map && obj.Has(key)) {
-        val := obj[key]
+    if (obj is Map) {
+        val := obj.Get(key, "")
         if (val is String)
             return val
         return String(val)
@@ -57,8 +57,8 @@ _KSafe_Str(obj, key) {
 
 ; Get int property safely (returns 0 on failure)
 _KSafe_Int(obj, key) {
-    if (obj is Map && obj.Has(key)) {
-        val := obj[key]
+    if (obj is Map) {
+        val := obj.Get(key, 0)
         if (val is Integer)
             return val
         try return Integer(val)
@@ -69,8 +69,8 @@ _KSafe_Int(obj, key) {
 ; ========================= RING ACCESSORS =========================
 
 _KSub_GetMonitorsRing(stateObj) {
-    if (stateObj is Map && stateObj.Has("monitors"))
-        return stateObj["monitors"]
+    if (stateObj is Map)
+        return stateObj.Get("monitors", "")
     return ""
 }
 
@@ -85,8 +85,8 @@ KSub_GetFocusedMonitorIndex(stateObj) {
 }
 
 _KSub_GetWorkspacesRing(monObj) {
-    if (monObj is Map && monObj.Has("workspaces"))
-        return monObj["workspaces"]
+    if (monObj is Map)
+        return monObj.Get("workspaces", "")
     return ""
 }
 
@@ -144,44 +144,33 @@ _KSub_WorkspaceHasHwnd(wsObj, hwnd) {
         return false
 
     ; Check containers ring
-    if (wsObj.Has("containers")) {
-        containers := wsObj["containers"]
+    if (containers := wsObj.Get("containers", 0)) {
         for _, cont in KSafe_Elements(containers) {
             if !(cont is Map)
                 continue
-            if (cont.Has("windows")) {
-                for _, win in KSafe_Elements(cont["windows"]) {
-                    if (win is Map && win.Has("hwnd") && win["hwnd"] = hwnd)
-                        return true
-                }
-            }
-            ; Single window container
-            if (cont.Has("window")) {
-                winObj := cont["window"]
-                if (winObj is Map && winObj.Has("hwnd") && winObj["hwnd"] = hwnd)
+            for _, win in KSafe_Elements(cont.Get("windows", 0)) {
+                if (win is Map && win.Get("hwnd", 0) = hwnd)
                     return true
             }
+            ; Single window container
+            winObj := cont.Get("window", 0)
+            if (winObj is Map && winObj.Get("hwnd", 0) = hwnd)
+                return true
         }
     }
 
     ; Check monocle_container
-    if (wsObj.Has("monocle_container")) {
-        mono := wsObj["monocle_container"]
-        if (mono is Map) {
-            if (mono.Has("hwnd") && mono["hwnd"] = hwnd)
+    mono := wsObj.Get("monocle_container", 0)
+    if (mono is Map) {
+        if (mono.Get("hwnd", 0) = hwnd)
+            return true
+        winObj := mono.Get("window", 0)
+        if (winObj is Map && winObj.Get("hwnd", 0) = hwnd)
+            return true
+        ; Monocle may have windows ring
+        for _, win in KSafe_Elements(mono.Get("windows", 0)) {
+            if (win is Map && win.Get("hwnd", 0) = hwnd)
                 return true
-            if (mono.Has("window")) {
-                winObj := mono["window"]
-                if (winObj is Map && winObj.Has("hwnd") && winObj["hwnd"] = hwnd)
-                    return true
-            }
-            ; Monocle may have windows ring
-            if (mono.Has("windows")) {
-                for _, win in KSafe_Elements(mono["windows"]) {
-                    if (win is Map && win.Has("hwnd") && win["hwnd"] = hwnd)
-                        return true
-                }
-            }
         }
     }
 
@@ -194,37 +183,32 @@ _KSub_GetFocusedHwndFromWsObj(wsObj) {
     if !(wsObj is Map)
         return 0
 
-    if (wsObj.Has("containers")) {
-        containersRing := wsObj["containers"]
+    if (containersRing := wsObj.Get("containers", 0)) {
         contArr := KSafe_Elements(containersRing)
         focusedContIdx := _KSafe_Focused(containersRing)
         if (focusedContIdx >= 0 && focusedContIdx < contArr.Length) {
             contObj := contArr[focusedContIdx + 1]
-            if (contObj is Map && contObj.Has("windows")) {
-                windowsRing := contObj["windows"]
+            if (contObj is Map && (windowsRing := contObj.Get("windows", 0))) {
                 winArr := KSafe_Elements(windowsRing)
                 focusedWinIdx := _KSafe_Focused(windowsRing)
                 if (focusedWinIdx >= 0 && focusedWinIdx < winArr.Length)
                     return _KSafe_Int(winArr[focusedWinIdx + 1], "hwnd")
             }
-            if (contObj is Map && contObj.Has("window"))
-                return _KSafe_Int(contObj["window"], "hwnd")
+            if (contObj is Map && (winObj := contObj.Get("window", 0)))
+                return _KSafe_Int(winObj, "hwnd")
         }
     }
 
-    if (wsObj.Has("monocle_container")) {
-        mono := wsObj["monocle_container"]
-        if (mono is Map) {
-            if (mono.Has("windows")) {
-                windowsRing := mono["windows"]
-                winArr := KSafe_Elements(windowsRing)
-                focusedWinIdx := _KSafe_Focused(windowsRing)
-                if (focusedWinIdx >= 0 && focusedWinIdx < winArr.Length)
-                    return _KSafe_Int(winArr[focusedWinIdx + 1], "hwnd")
-            }
-            if (mono.Has("window"))
-                return _KSafe_Int(mono["window"], "hwnd")
+    mono := wsObj.Get("monocle_container", 0)
+    if (mono is Map) {
+        if (windowsRing := mono.Get("windows", 0)) {
+            winArr := KSafe_Elements(windowsRing)
+            focusedWinIdx := _KSafe_Focused(windowsRing)
+            if (focusedWinIdx >= 0 && focusedWinIdx < winArr.Length)
+                return _KSafe_Int(winArr[focusedWinIdx + 1], "hwnd")
         }
+        if (winObj := mono.Get("window", 0))
+            return _KSafe_Int(winObj, "hwnd")
     }
     return 0
 }

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -579,6 +579,16 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
         selExpandX := cachedLayout.selExpandX
         selExpandY := cachedLayout.selExpandY
 
+        ; Hoist cfg lookups used in selection + hover paths (like D2D_Res hoisting above)
+        cfgSelARGB := cfg.GUI_SelARGB
+        cfgSelBorderARGB := cfg.GUI_SelBorderARGB
+        cfgSelBorderW := cfg.GUI_SelBorderWidthPx
+        cfgHoverARGB := cfg.GUI_HoverARGB
+        cfgHovBorderARGB := cfg.GUI_HovBorderARGB
+        cfgHovBorderW := cfg.GUI_HovBorderWidthPx
+        cfgUseHoverSelEffect := cfg.GUI_UseHoverSelectionEffect
+        cfgSelIntensityHover := cfg.GUI_SelectionIntensityForHover
+
         ; ===== Selection highlight (drawn BEFORE row loop for correct Z-order) =====
         ; The highlight is a background element — text/icons draw on top.
         ; When animation is active, the highlight Y is interpolated between prev and new positions.
@@ -604,15 +614,15 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
                 ; Shader-based selection effect
                 entranceT := Anim_GetValue("fx_sel_entrance", 1.0)
                 FX_PreRenderSelectionEffect(wPhys, hPhys, selX, selY, selW, selH,
-                    cfg.GUI_SelARGB, cfg.GUI_SelBorderARGB, cfg.GUI_SelBorderWidthPx, 1.0, entranceT, Rad)
+                    cfgSelARGB, cfgSelBorderARGB, cfgSelBorderW, 1.0, entranceT, Rad)
                 FX_DrawSelectionEffect(wPhys, hPhys, selX, selY, selW, selH, Rad)
             } else {
                 ; Simple D2D fill + border (the "None" path)
-                D2D_FillRoundRect(selX, selY, selW, selH, Rad, D2D_GetCachedBrush(cfg.GUI_SelARGB))
-                bw := cfg.GUI_SelBorderWidthPx
+                D2D_FillRoundRect(selX, selY, selW, selH, Rad, D2D_GetCachedBrush(cfgSelARGB))
+                bw := cfgSelBorderW
                 if (bw > 0) {
                     half := bw / 2
-                    D2D_StrokeRoundRect(selX + half, selY + half, selW - bw, selH - bw, Rad, D2D_GetCachedBrush(cfg.GUI_SelBorderARGB), bw)
+                    D2D_StrokeRoundRect(selX + half, selY + half, selW - bw, selH - bw, Rad, D2D_GetCachedBrush(cfgSelBorderARGB), bw)
                 }
             }
         }
@@ -621,6 +631,10 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
             idx0 := Win_Wrap0(start0 + i, count)
             idx1 := idx0 + 1
             cur := items[idx1]
+            curHwnd := cur.hwnd
+            curIcon := cur.iconHicon
+            curTitle := cur.title
+            curProc := cur.processName
             isSel := (idx1 = selIndex)
 
             ; Hover highlight (non-selected rows) — 4-way path
@@ -633,26 +647,26 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
                     ; Path 1: Independent hover shader
                     hoverEntranceT := Anim_GetValue("fx_sel_entrance", 1.0)
                     FX_PreRenderHoverEffect(wPhys, hPhys, hoverX, hoverY, hoverW, RowH,
-                        cfg.GUI_HoverARGB, cfg.GUI_HovBorderARGB, cfg.GUI_HovBorderWidthPx, hoverEntranceT, Rad)
+                        cfgHoverARGB, cfgHovBorderARGB, cfgHovBorderW, hoverEntranceT, Rad)
                     FX_DrawHoverEffect(wPhys, hPhys, hoverX, hoverY, hoverW, RowH, Rad)
-                } else if (!cfg.GUI_UseHoverSelectionEffect && gFX_SelectionEffect.key != "" && gFX_GPUReady) {
+                } else if (!cfgUseHoverSelEffect && gFX_SelectionEffect.key != "" && gFX_GPUReady) {
                     ; Path 2: Reuse selection shader at SelectionIntensityForHover (only when hover independence is off)
                     hoverEntranceT := Anim_GetValue("fx_sel_entrance", 1.0)
                     FX_PreRenderSelectionEffect(wPhys, hPhys, hoverX, hoverY, hoverW, RowH,
-                        cfg.GUI_SelARGB, cfg.GUI_SelBorderARGB, cfg.GUI_SelBorderWidthPx, cfg.GUI_SelectionIntensityForHover, hoverEntranceT, Rad)
+                        cfgSelARGB, cfgSelBorderARGB, cfgSelBorderW, cfgSelIntensityHover, hoverEntranceT, Rad)
                     FX_DrawSelectionEffect(wPhys, hPhys, hoverX, hoverY, hoverW, RowH, Rad)
                 } else if (gFX_GPUReady) {
                     ; Path 3: GPU flat fill + border
                     FX_GPU_DrawHover(hoverX, hoverY, hoverW, RowH, Rad)
-                } else if ((cfg.GUI_HoverARGB >> 24) > 0 || cfg.GUI_HovBorderWidthPx > 0) {
+                } else if ((cfgHoverARGB >> 24) > 0 || cfgHovBorderW > 0) {
                     ; Path 4: CPU fallback fill + border
-                    hoverAlpha := cfg.GUI_HoverARGB >> 24
+                    hoverAlpha := cfgHoverARGB >> 24
                     if (hoverAlpha > 0)
-                        D2D_FillRoundRect(hoverX, hoverY, hoverW, RowH, Rad, D2D_GetCachedBrush(cfg.GUI_HoverARGB))
-                    bw := cfg.GUI_HovBorderWidthPx
+                        D2D_FillRoundRect(hoverX, hoverY, hoverW, RowH, Rad, D2D_GetCachedBrush(cfgHoverARGB))
+                    bw := cfgHovBorderW
                     if (bw > 0) {
                         half := bw / 2
-                        D2D_StrokeRoundRect(hoverX + half, hoverY + half, hoverW - bw, RowH - bw, Rad, D2D_GetCachedBrush(cfg.GUI_HovBorderARGB), bw)
+                        D2D_StrokeRoundRect(hoverX + half, hoverY + half, hoverW - bw, RowH - bw, Rad, D2D_GetCachedBrush(cfgHovBorderARGB), bw)
                     }
                 }
             }
@@ -670,7 +684,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
             ; #178: cur is a live store ref — iconHicon may be zeroed after window
             ; destruction.  Try the bitmap cache regardless so frozen display items
             ; keep their last-known icon.
-            iconDrawn := D2D_DrawCachedIcon(cur.hwnd, cur.iconHicon, ix, iy, ISize, &iconWasCacheHit)
+            iconDrawn := D2D_DrawCachedIcon(curHwnd, curIcon, ix, iy, ISize, &iconWasCacheHit)
             if (iconDrawn) {
                 if (iconWasCacheHit)
                     iconCacheHits += 1
@@ -691,14 +705,14 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
             brColUse := isSel ? brColHi : brCol
 
             ; Text drawing (with optional shadow)
-            title := cur.title
-            sub := cur.processName
+            title := curTitle
+            sub := curProc
             if (sub = "") {
                 ; Lazy-cache: concat "Class: " only once per display cycle, not per-frame
-                sub := _gPaint_SubCache.Get(cur.hwnd, "")
+                sub := _gPaint_SubCache.Get(curHwnd, "")
                 if (sub = "") {
                     sub := "Class: " cur.class
-                    _gPaint_SubCache[cur.hwnd] := sub
+                    _gPaint_SubCache[curHwnd] := sub
                 }
             }
 

--- a/src/gui/gui_pump.ahk
+++ b/src/gui/gui_pump.ahk
@@ -253,13 +253,15 @@ _GUIPump_CollectTick() {
         pids := WL_PopPidBatch(32)
         if (pids.Length > 0) {
             ; Find hwnds with these PIDs that aren't already in the batch
-            pidSet := Map()
+            static pidSet := Map() ; lint-ignore: static-in-timer
+            pidSet.Clear()
             for _, pid in pids
                 pidSet[pid] := true
             ; Get hwnds from store by PID
             pidHwnds := WL_GetHwndsByPids(pidSet)
             ; Merge, deduplicating
-            hwndSet := Map()
+            static hwndSet := Map() ; lint-ignore: static-in-timer
+            hwndSet.Clear()
             for _, h in hwnds
                 hwndSet[h] := true
             for _, h in pidHwnds {


### PR DESCRIPTION
## Summary

- Convert 23 `Map.Has()` + `Map[]` double-lookups to single `.Get()` calls across all komorebi state navigation helpers — halves hash operations per notification parse
- Hoist `cur.hwnd`/`iconHicon`/`title`/`processName` into locals at paint row loop entry, and 8 cfg selection/hover values before the selection block — extends the existing D2D resource hoisting pattern
- Reuse pump deduplication Maps (`pidSet`, `hwndSet`) via `static` + `.Clear()` instead of per-tick allocation

Closes #377

## Test plan

- [x] Static analysis pre-gate: 86/86 checks passed
- [x] Unit tests: 947/947 passed (including KSafe parsing tests covering all 4 base helpers)
- [x] GUI tests: 351/351 passed
- [ ] Visual verification via `--live` that overlay renders correctly
- [ ] Komorebi workspace switching still populates window list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)