### PR TITLE
Short-circuit no-change WinEventHook updates

### DIFF
--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -639,7 +639,10 @@ _WEH_ProcessBatch() {
                 result := _WEH_UpdateExisting(hwnd, locSnapshot.Has(hwnd))
                 if (result = -1)
                     ineligibleHwnds.Push(hwnd)
-                else if (IsObject(result)) {
+                else if (result = 0) {
+                    ; No fields changed — still alive, needs Z/icon processing
+                    updatedHwnds.Push(hwnd)
+                } else if (IsObject(result)) {
                     batchPatches[hwnd] := result
                     updatedHwnds.Push(hwnd)
                 }
@@ -856,6 +859,25 @@ _WEH_UpdateExisting(hwnd, hasLocationChange := true) {
     if (!Blacklist_IsWindowEligibleEx(hwnd, title, class, &isVisible, &isMin, &isCloaked)) {
         Profiler.Leave() ; @profile
         return -1
+    }
+
+    ; PERF: Early-out when nothing changed — avoids Object allocation, Map insertion,
+    ; _WS_ApplyPatch iteration, and gWS_FieldClass lookups for no-change events.
+    ; LOCATIONCHANGE fires ~100+/sec during normal desktop use; most produce no field changes.
+    if (title == row.title && isCloaked = row.isCloaked && isMin = row.isMinimized && isVisible = row.isVisible) {
+        if (!hasLocationChange) {
+            Profiler.Leave() ; @profile
+            return 0  ; No change
+        }
+        ; Location change: check if monitor actually changed
+        hMon := Win_GetMonitorHandle(hwnd)
+        if (hMon = row.monitorHandle) {
+            Profiler.Leave() ; @profile
+            return 0  ; No change
+        }
+        ; Monitor changed — build minimal patch with only monitor fields
+        Profiler.Leave() ; @profile
+        return { monitorHandle: hMon, monitorLabel: Win_GetMonitorLabel(hMon) }
     }
 
     ; PERF: Only probe monitor on LOCATIONCHANGE — NAMECHANGE can't move a window.

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -370,7 +370,7 @@ WL_UpsertWindow(records, source := "") {
         _WS_MarkDirty()  ; Structural change (new windows or sort-affecting fields via upsert)
     }
     if (added || updated) {
-        _WS_BumpRev("UpsertWindow:" . source)
+        _WS_BumpRev("UpsertWindow", source)
     }
     ; RACE FIX: Update peak windows inside Critical - producers can interrupt after release
     if (added > 0)
@@ -493,7 +493,7 @@ WL_UpdateFields(hwnd, patch, source := "", returnRow := false) {
         _WS_MarkDirty(result.mruOnly, result.mruOnly ? hwnd : 0)
     }
     if (changed) {
-        _WS_BumpRev("UpdateFields:" . source)
+        _WS_BumpRev("UpdateFields", source)
     }
     ; Return row when requested to avoid redundant GetByHwnd lookups
     if (returnRow) {
@@ -547,7 +547,7 @@ WL_BatchUpdateFields(patches, source := "") {
         _WS_MarkDirty(batchMruOnly, batchMruOnly ? batchBumpedHwnd : 0)
     }
     if (changedCount > 0)
-        _WS_BumpRev("BatchUpdateFields:" . source)
+        _WS_BumpRev("BatchUpdateFields", source)
 
     Critical "Off"
     Profiler.Leave() ; @profile
@@ -777,13 +777,13 @@ WL_FlushChurnLog() {
 ; Atomic revision bump - prevents race conditions when multiple producers bump rev
 ; NOTE: No Critical "Off" — callers hold Critical and "Off" here would leak their state.
 ; Critical "On" is kept for the rare caller without Critical (e.g., EndScan).
-_WS_BumpRev(source) {
+_WS_BumpRev(prefix, detail := "") {
     Critical "On"
     global cfg, gWS_Rev
     gWS_Rev += 1
     Stats_BumpLifetimeStat("TotalWindowUpdates")
     if (cfg.DiagChurnLog)
-        _WS_DiagBump(source)
+        _WS_DiagBump(detail != "" ? prefix ":" detail : prefix)
 }
 
 WL_GetByHwnd(hwnd) {


### PR DESCRIPTION
## Summary

- Early-out in `_WEH_UpdateExisting` when title/vis/min/cloak match the store row — skips Object allocation, Map insertion, and `_WS_ApplyPatch` for the dominant no-change case
- LOCATIONCHANGE events with no actual field changes (~100+/sec during normal desktop use) no longer propagate through the store mutation path, while Z-order and icon enrichment still run
- Fix `_WS_BumpRev` caller-side log guard: defer `":"` concatenation into the `DiagChurnLog` guard (3 call sites)

Closes #379

## Test plan

- [x] Pre-gate: 86 static analysis checks pass
- [x] Unit tests: 564 pass (including 179 core/store)
- [x] GUI tests: 351 pass
- [x] Flight recorder tests: 32 pass
- [x] Live tests: 64 pass (core, features, execution, network, pump, watcher)
- [ ] Manual: Enable DiagChurnLog — verify fewer rev bumps during idle desktop
- [ ] Manual: Alt+Tab shows correct MRU order, titles, icons after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)