### PR TITLE
Eliminate 2 cross-file mutations from ownership manifest

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -21,11 +21,9 @@
 #   Discover full landscape: powershell -File tools/query_global_ownership.ps1 -Discover
 
 cfg: launcher_tray, config_loader, setup_utils
-gAnim_DeferredTimerStart: gui_animation, gui_paint
 gAnim_HidePending: gui_animation, gui_overlay
 gD2D_RT: gui_bgimage, gui_overlay, gui_paint
 gGUI_CurrentWSName: gui_activation, gui_state
-_gPaint_SubCache: gui_gdip, gui_paint
 gGUI_DisplayItems: gui_data, gui_state
 gGUI_EventBuffer: gui_activation, gui_state
 gGUI_FocusBeforeShow: gui_paint, gui_state

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -144,6 +144,20 @@ _Anim_UpdateTweens(now := 0) {
     return activeCount
 }
 
+; ========================= DEFERRED START =========================
+
+; Called by GUI_Repaint's finally block after the reentrancy guard drops.
+; If Anim_EnsureTimer() was called during paint (STA pump dispatched a show
+; sequence that started a tween), the start was deferred to avoid blocking
+; the paint. This consumes that deferral. (#175)
+Anim_ConsumeDeferredStart() {
+    global gAnim_DeferredTimerStart
+    if (gAnim_DeferredTimerStart) {
+        gAnim_DeferredTimerStart := false
+        Anim_EnsureTimer()
+    }
+}
+
 ; ========================= FRAME LOOP =========================
 
 Anim_EnsureTimer() {

--- a/src/gui/gui_gdip.ahk
+++ b/src/gui/gui_gdip.ahk
@@ -303,8 +303,6 @@ _D2D_SetEllipsisTrimming(tf) {
 ; Dispose all D2D resources. COM wrappers auto-release via __Delete.
 D2D_DisposeResources() {
     global gD2D_Res, gD2D_ResScale, gGdip_ResScale, gD2D_BrushCache, gGdip_IconCache
-    global _gPaint_SubCache
-
     ; Clear named resources — COM wrapper __Delete releases each object
     gD2D_Res := Map()
     gD2D_ResScale := 0.0
@@ -317,7 +315,7 @@ D2D_DisposeResources() {
     _D2D_ClearIconCache()
 
     ; Clear paint subtitle cache (hwnd → "Class: ..." strings)
-    _gPaint_SubCache := Map()
+    Paint_InvalidateSubCache()
 }
 
 ; ========================= ICON CACHE =========================

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -59,6 +59,13 @@ Paint_LogStartSession() {
 ;      overwrites gD2D_BackBuffer, nested BeginDraw fails D2DERR_WRONG_STATE)
 ;   2. Inner try/finally — prevents guard from getting stuck if any D2D call throws
 
+; Called by D2D_DisposeResources when D2D device is lost/recreated.
+; Invalidates the lazy subtitle cache so stale entries aren't reused.
+Paint_InvalidateSubCache() {
+    global _gPaint_SubCache
+    _gPaint_SubCache := Map()
+}
+
 Paint_ClearSurface() {
     global gD2D_RT, gPaint_RepaintInProgress
     if (!gD2D_RT || gPaint_RepaintInProgress)
@@ -322,15 +329,7 @@ GUI_Repaint() {
 
     } finally {
         gPaint_RepaintInProgress := false
-        ; If a tween was started during this paint's STA pump (e.g., GRACE_FIRE
-        ; dispatched ShowOverlayWithFrozen which called Anim_StartTween), the
-        ; frame loop launch was deferred to avoid blocking this paint. Start it
-        ; now that the guard is clear. (#175)
-        global gAnim_DeferredTimerStart
-        if (gAnim_DeferredTimerStart) {
-            gAnim_DeferredTimerStart := false
-            Anim_EnsureTimer()
-        }
+        Anim_ConsumeDeferredStart()
     }
 }
 


### PR DESCRIPTION
## Summary

- **`gAnim_DeferredTimerStart`**: Created `Anim_ConsumeDeferredStart()` in gui_animation — paint's `finally` block calls it instead of directly clearing animation's internal deferred-start flag
- **`_gPaint_SubCache`**: Created `Paint_InvalidateSubCache()` in gui_paint — gui_gdip calls it during `D2D_DisposeResources` instead of directly clearing paint's private cache
- Ownership manifest reduced from 16 → 14 entries; remaining 14 confirmed as inherent architectural coupling

## Test plan

- [x] `query_global_ownership.ps1 -Generate` confirms manifest is up to date (14 entries)
- [x] Full test suite passes: 86 static analysis checks, 564 unit, 355 GUI, 32 flight recorder, 64 live (1015 total)
- [x] Compilation succeeds

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)