### PR TITLE
Extract Anim_BeginHideFade to eliminate cross-file gAnim_HidePending mutation

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -21,7 +21,6 @@
 #   Discover full landscape: powershell -File tools/query_global_ownership.ps1 -Discover
 
 cfg: launcher_tray, config_loader, setup_utils
-gAnim_HidePending: gui_animation, gui_overlay
 gD2D_RT: gui_bgimage, gui_overlay, gui_paint
 gGUI_CurrentWSName: gui_activation, gui_state
 gGUI_DisplayItems: gui_data, gui_state

--- a/src/gui/gui_animation.ahk
+++ b/src/gui/gui_animation.ahk
@@ -111,6 +111,14 @@ _Anim_CancelTween(name) {
         gAnim_Tweens.Delete(name)
 }
 
+Anim_BeginHideFade(hWnd) {
+    global gAnim_HidePending
+    gAnim_HidePending := true
+    Anim_AddLayered()
+    DllCall("SetLayeredWindowAttributes", "ptr", hWnd, "uint", 0, "uchar", 255, "uint", 2)
+    Anim_StartTween("hideFade", 1.0, 0.0, 60, Anim_EaseOutQuad)
+}
+
 Anim_CancelAll() {
     global gAnim_Tweens, gAnim_HidePending
     gAnim_Tweens := Map()

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -130,12 +130,7 @@ GUI_HideOverlay() {
     ; Animated hide-fade: start opacity tween, defer actual hide
     ; _Anim_OnHideFadeComplete() will call _Anim_DoActualHide() when done
     if (cfg.PerfAnimationType != "None" && gGUI_Revealed) {
-        gAnim_HidePending := true
-        ; Add WS_EX_LAYERED so SetLayeredWindowAttributes can fade the entire
-        ; DWM composition (content + acrylic + shadow) as one unit.
-        Anim_AddLayered()
-        DllCall("SetLayeredWindowAttributes", "ptr", gGUI_BaseH, "uint", 0, "uchar", 255, "uint", 2)
-        Anim_StartTween("hideFade", 1.0, 0.0, 60, Anim_EaseOutQuad)
+        Anim_BeginHideFade(gGUI_BaseH)
         Profiler.Leave() ; @profile
         return
     }


### PR DESCRIPTION
## Summary

- Extract 4-line hide-fade initiation sequence from `GUI_HideOverlay` (gui_overlay) into new public `Anim_BeginHideFade(hWnd)` in gui_animation
- Remove `gAnim_HidePending: gui_animation, gui_overlay` from ownership manifest — now single-file owned
- gui_overlay still reads `gAnim_HidePending` for re-entrancy guard; only the write moved

Closes #389

## Test plan

- [x] `query_global_ownership.ps1 gAnim_HidePending` confirms single-file ownership
- [x] `query_global_ownership.ps1 -Generate` confirms manifest up to date (no diff)
- [x] Full test suite: 1015/1015 tests pass
- [x] Static analysis: 86/86 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)