### PR TITLE
Move gGUI_FocusBeforeShow ownership to gui_state

### DIFF
--- a/ownership.manifest
+++ b/ownership.manifest
@@ -25,7 +25,6 @@ gD2D_RT: gui_bgimage, gui_overlay, gui_paint
 gGUI_CurrentWSName: gui_activation, gui_state
 gGUI_DisplayItems: gui_data, gui_state
 gGUI_EventBuffer: gui_activation, gui_state
-gGUI_FocusBeforeShow: gui_paint, gui_state
 gGUI_LastRowsDesired: gui_paint, gui_state
 gGUI_LiveItems: gui_activation, gui_data
 gGUI_OverlayVisible: gui_overlay, gui_state

--- a/src/gui/gui_overlay.ahk
+++ b/src/gui/gui_overlay.ahk
@@ -13,7 +13,6 @@ global gGUI_OverlayH := 0      ; Alias → same as gGUI_BaseH (single-window com
 global GUI_LOG_TRIM_EVERY_N_HIDES := 10
 global gGUI_CachedVisibleRows := -1   ; Cached result of GUI_GetVisibleRows; -1 = stale
 global gGUI_StealFocus := false      ; Effective steal-focus (cfg OR Mica)
-global gGUI_FocusBeforeShow := 0     ; Hwnd of foreground window before overlay took focus
 
 ; D2D factories and device pipeline (process-global, survive render target recreation)
 global gD2D_Factory := 0       ; ID2D1Factory1

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -336,7 +336,7 @@ GUI_Repaint() {
 _GUI_RevealBoth() {
     global gGUI_Base, gGUI_BaseH, gGUI_Revealed, cfg
     global gGUI_State, gGUI_OverlayVisible  ; Need access to state for race fix
-    global gGUI_StealFocus, gGUI_FocusBeforeShow
+    global gGUI_StealFocus
 
     Profiler.Enter("_GUI_RevealBoth") ; @profile
 
@@ -364,7 +364,7 @@ _GUI_RevealBoth() {
 
     try {
         if (gGUI_StealFocus) {
-            gGUI_FocusBeforeShow := DllCall("user32\GetForegroundWindow", "ptr")
+            ; gGUI_FocusBeforeShow already captured by _GUI_ShowOverlayWithFrozen
             DllCall("user32\ShowWindow", "ptr", gGUI_BaseH, "int", 5)  ; SW_SHOW
             DllCall("user32\SetForegroundWindow", "ptr", gGUI_BaseH)
         } else {

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -11,6 +11,7 @@
 global gGUI_State := "IDLE"
 
 global gGUI_CurrentWSName := ""       ; Cached from gWS_Meta (updated by workspace flip callback)
+global gGUI_FocusBeforeShow := 0     ; Hwnd of foreground window before overlay took focus
 global gGUI_WSContextSwitch := false  ; True if workspace changed during this overlay session (sel=1 sticky)
 global gGUI_ToggleBase := []     ; Snapshot for workspace toggle (Ctrl key support)
 global gGUI_DisplayItems := []   ; Items being rendered (may be filtered by workspace mode)
@@ -736,6 +737,13 @@ _GUI_ShowOverlayWithFrozen() {
     ; (Show/DwmFlush can pump messages, allowing hotkeys to fire mid-function)
     gGUI_OverlayVisible := true
 
+    ; Capture foreground BEFORE resize — resize pumps the STA message loop,
+    ; which can dispatch _GUI_RevealBoth via reentrancy. If we captured after
+    ; resize (old location), the overlay could already be foreground, saving
+    ; its own hwnd as the restore target.
+    if (gGUI_StealFocus)
+        gGUI_FocusBeforeShow := DllCall("user32\GetForegroundWindow", "ptr")
+
     ; NOTE: Do NOT set gGUI_LiveItems := gGUI_DisplayItems here!
     ; gGUI_LiveItems must remain the unfiltered source of truth for cross-session consistency.
     ; Paint function correctly uses gGUI_DisplayItems when in ACTIVE state.
@@ -792,7 +800,7 @@ _GUI_ShowOverlayWithFrozen() {
 
     try {
         if (gGUI_StealFocus) {
-            gGUI_FocusBeforeShow := DllCall("user32\GetForegroundWindow", "ptr")
+            ; gGUI_FocusBeforeShow already captured above (before resize)
             ; Raw ShowWindow bypasses AHK's caption-aware size adjustment (WS_CAPTION grows the window)
             DllCall("user32\ShowWindow", "ptr", gGUI_BaseH, "int", 5)  ; SW_SHOW
             DllCall("user32\SetForegroundWindow", "ptr", gGUI_BaseH)


### PR DESCRIPTION
## Summary

- Moved `gGUI_FocusBeforeShow` declaration from `gui_overlay` (never used there) to `gui_state` (primary owner: 2 writes + sole reader)
- Moved focus capture earlier in `_GUI_ShowOverlayWithFrozen` — before resize where STA message pumps can trigger `_GUI_RevealBoth` via reentrancy
- Removed duplicate focus capture from `_GUI_RevealBoth` in `gui_paint`, fixing a subtle race where the overlay's own hwnd could overwrite the legitimate capture
- Eliminated `gGUI_FocusBeforeShow` manifest entry (13 → 12 lines)

Closes #393

## Test plan

- [x] Pre-gate static analysis (86 checks) — validates manifest + global declarations
- [x] Unit tests (564 tests)
- [x] GUI state machine tests (355 tests)
- [x] Flight recorder tests (32 tests)
- [x] Live integration tests (64 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)