### PR TITLE
Skip redundant CSSetConstantBuffers ComCall in compute dispatch

### DIFF
--- a/src/gui/d2d_shader.ahk
+++ b/src/gui/d2d_shader.ahk
@@ -1164,8 +1164,8 @@ Shader_PreRender(name, w, h, timeSec, darken := 0.0, desaturate := 0.0, opacity 
         if (cb != csLastCb) {
             NumPut("ptr", cb, csCbBuf)
             csLastCb := cb
+            ComCall(71, ctx, "uint", 0, "uint", 1, "ptr", csCbBuf, "int")
         }
-        ComCall(71, ctx, "uint", 0, "uint", 1, "ptr", csCbBuf, "int")
 
         ; CSSetUnorderedAccessViews (vtable 68): UAV at slot 0
         static csUavBuf := Buffer(A_PtrSize, 0)


### PR DESCRIPTION
## Summary

- Move `CSSetConstantBuffers` (ComCall 71) inside the existing `csLastCb` cache guard so it only fires when the cbuffer pointer actually changes
- The cbuffer pointer never changes during a session, so every call after the first was a no-op rebinding the same pointer to the same slot
- Aligns with the caching pattern already used by `PSSetConstantBuffers` and `CSSetShader` in the same function

Closes #398

## Test plan

- [x] All 1015 tests pass (`.\tests\test.ps1 --live`)
- [ ] Manual: verify compute-based mouse effects (ember_trail, campfire_embers, etc.) render correctly
- [ ] Manual: verify shader hot-reload still binds the cbuffer on first dispatch after reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)