### PR TITLE
Micro-optimize blocking functions: double hash, field class, timer guard

### DIFF
--- a/src/core/icon_pump.ahk
+++ b/src/core/icon_pump.ahk
@@ -222,9 +222,8 @@ IconPump_CleanupWindow(hwnd) {
         rec.iconHicon := 0  ; Defensive: prevent use-after-free
     }
 
-    ; Clean up attempt tracking
-    if (_IP_Attempts.Has(hwnd))
-        _IP_Attempts.Delete(hwnd)
+    ; Clean up attempt tracking (Delete throws on missing key; try swallows harmlessly)
+    try _IP_Attempts.Delete(hwnd)
     Critical "Off"
 }
 
@@ -300,7 +299,7 @@ _IP_Tick() {
 
         isHidden := rec.isCloaked || rec.isMinimized || !rec.isVisible
         hasIcon := rec.iconHicon != 0
-        currentMethod := rec.HasOwnProp("iconMethod") ? rec.iconMethod : ""
+        currentMethod := rec.iconMethod  ; PERF: field always exists per _WS_NewRecord — skip HasOwnProp
 
         ; PERF: Hoist title computation before mode switch (used in multiple log branches)
         title := logEnabled ? _IP_TruncTitle(rec) : ""

--- a/src/core/proc_pump.ahk
+++ b/src/core/proc_pump.ahk
@@ -146,7 +146,8 @@ _PP_Tick() {
         ; (_PP_FailedPidCache, _PP_FailedPidCacheTTL declared at function top)
         ; RACE FIX: Protect cache read - ProcPump_PruneFailedPidCache runs from heartbeat timer
         Critical "On"
-        if (_PP_FailedPidCache.Has(pid) && (A_TickCount - _PP_FailedPidCache[pid]) < _PP_FailedPidCacheTTL) {
+        cachedTick := _PP_FailedPidCache.Get(pid, 0)  ; PERF: single lookup replaces Has+[] double hash
+        if (cachedTick && (A_TickCount - cachedTick) < _PP_FailedPidCacheTTL) {
             Critical "Off"
             if (logEnabled)
                 _PP_Log("SKIP pid=" pid " (failed cache)")

--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -332,7 +332,10 @@ _WEH_WinEventProc(hWinEventHook, event, hwnd, idObject, idChild, idEventThread, 
         SetTimer(_WEH_FastPathBatch, -1)
 
     ; Wake timer if it was paused due to idle
-    _WinEventHook_EnsureTimerRunning()
+    ; PERF: Skip EnsureTimerRunning when timer is already on (matching destroy/hide paths
+    ; at lines 249/263). Avoids entering Pump_EnsureRunning's Critical section.
+    if (!_WEH_TimerOn)
+        _WinEventHook_EnsureTimerRunning()
     } catch as e {
         Profiler.Leave() ; @profile
         Critical "Off"
@@ -583,15 +586,30 @@ _WEH_ProcessBatch() {
         if (_WEH_PendingLocChange.Has(hwnd))
             locSnapshot[hwnd] := true
     }
-    for _, arr in [destroyed, hidden, toProcess] {
-        for _, h in arr {
-            if (_WEH_PendingHwnds.Has(h))
-                _WEH_PendingHwnds.Delete(h)
-            if (_WEH_PendingZNeeded.Has(h))
-                _WEH_PendingZNeeded.Delete(h)
-            if (_WEH_PendingLocChange.Has(h))
-                _WEH_PendingLocChange.Delete(h)
-        }
+    ; PERF: Sequential loops avoid ephemeral [destroyed, hidden, toProcess] Array allocation
+    for _, h in destroyed {
+        if (_WEH_PendingHwnds.Has(h))
+            _WEH_PendingHwnds.Delete(h)
+        if (_WEH_PendingZNeeded.Has(h))
+            _WEH_PendingZNeeded.Delete(h)
+        if (_WEH_PendingLocChange.Has(h))
+            _WEH_PendingLocChange.Delete(h)
+    }
+    for _, h in hidden {
+        if (_WEH_PendingHwnds.Has(h))
+            _WEH_PendingHwnds.Delete(h)
+        if (_WEH_PendingZNeeded.Has(h))
+            _WEH_PendingZNeeded.Delete(h)
+        if (_WEH_PendingLocChange.Has(h))
+            _WEH_PendingLocChange.Delete(h)
+    }
+    for _, h in toProcess {
+        if (_WEH_PendingHwnds.Has(h))
+            _WEH_PendingHwnds.Delete(h)
+        if (_WEH_PendingZNeeded.Has(h))
+            _WEH_PendingZNeeded.Delete(h)
+        if (_WEH_PendingLocChange.Has(h))
+            _WEH_PendingLocChange.Delete(h)
     }
     Critical "Off"
 
@@ -638,9 +656,10 @@ _WEH_ProcessBatch() {
         updatedHwnds := []
         batchPatches := Map()
         for _, hwnd in toProcess {
-            if (gWS_Store.Has(hwnd + 0)) {
+            row := gWS_Store.Get(hwnd + 0, 0)  ; PERF: single lookup replaces Has+[] double hash
+            if (row) {
                 ; Lightweight path: window already in store — skip immutable fields
-                result := _WEH_UpdateExisting(hwnd, locSnapshot.Has(hwnd))
+                result := _WEH_UpdateExisting(hwnd, locSnapshot.Has(hwnd), row)
                 if (result = -1)
                     ineligibleHwnds.Push(hwnd)
                 else if (result = 0) {
@@ -823,7 +842,7 @@ _WEH_RetryFocusProbe(hwnd, originalTick, attempt) {
 ; Skips immutable fields (class, PID) - only fetches title + vis/min/cloak.
 ; Returns: Object patch (success), -1 (ineligible/destroyed), false (skipped/error)
 ; Caller batches patches and calls WL_BatchUpdateFields once for the whole batch.
-_WEH_UpdateExisting(hwnd, hasLocationChange := true) {
+_WEH_UpdateExisting(hwnd, hasLocationChange := true, row := 0) {
     Profiler.Enter("_WEH_UpdateExisting") ; @profile
     global gWS_Store
     ; Check window still exists
@@ -855,7 +874,9 @@ _WEH_UpdateExisting(hwnd, hasLocationChange := true) {
     }
 
     ; Re-check eligibility using stored class (immutable) + fresh title
-    row := gWS_Store[hwnd + 0]
+    ; PERF: Accept row from caller when available to avoid double hash lookup
+    if (!row)
+        row := gWS_Store[hwnd + 0]
     class := row.class
     isVisible := false
     isMin := false

--- a/src/gui/d2d_shader.ahk
+++ b/src/gui/d2d_shader.ahk
@@ -1111,12 +1111,12 @@ Shader_PreRender(name, w, h, timeSec, darken := 0.0, desaturate := 0.0, opacity 
     Profiler.Enter("Shader_PreRender") ; @profile
     cb := gShader_CBuffer
 
-    if (!gShader_Ready || !gShader_Registry.Has(name)) {
+    ; PERF: single .Get() replaces .Has() + [] double hash lookup
+    entry := gShader_Registry.Get(name, 0)
+    if (!gShader_Ready || !entry) {
         Profiler.Leave() ; @profile
         return false
     }
-
-    entry := gShader_Registry[name]
 
     ; One-time log per shader name (reuse entry from above)
     if (cfg.DiagShaderLog && !dbgRendered.Has(name)) {
@@ -1241,8 +1241,7 @@ Shader_PreRender(name, w, h, timeSec, darken := 0.0, desaturate := 0.0, opacity 
     vpChanged := (vpW != w || vpH != h)
     if (vpChanged) {
         vpW := w, vpH := h
-        NumPut("float", Float(w), vp, 8)
-        NumPut("float", Float(h), vp, 12)
+        NumPut("float", Float(w), "float", Float(h), vp, 8)  ; PERF: combined NumPut
     }
     if (gShader_StateDirty || vpChanged)
         ComCall(44, ctx, "uint", 1, "ptr", vp, "int")

--- a/src/gui/gui_data.ahk
+++ b/src/gui/gui_data.ahk
@@ -182,9 +182,10 @@ GUI_ReconcileDestroys() {
 
     Critical "On"
     removed := 0
-    i := gGUI_DisplayItems.Length
+    items := gGUI_DisplayItems  ; PERF: cache global ref, avoid repeated global dereference in loop
+    i := items.Length
     while (i >= 1) {
-        if (!gWS_Store.Has(gGUI_DisplayItems[i].hwnd + 0)) {
+        if (!gWS_Store.Has(items[i].hwnd + 0)) {
             GUI_EvictDisplayItem(i)
             removed++
         }

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -564,11 +564,13 @@ FX_PreRenderSelectionEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, b
     ; Single .Get() lookup + guarded mutation (config-stable values)
     if (!se.isBGShader && (entry := gShader_Registry.Get(se.key, 0))) {
         static _selLastGlow := -1, _selLastInt := -1.0
-        if (cfg.GUI_SelectionGlow != _selLastGlow || cfg.GUI_SelectionIntensity != _selLastInt) {
-            entry.selGlow := cfg.GUI_SelectionGlow
-            entry.selIntensity := cfg.GUI_SelectionIntensity
-            _selLastGlow := cfg.GUI_SelectionGlow
-            _selLastInt := cfg.GUI_SelectionIntensity
+        glow := cfg.GUI_SelectionGlow  ; PERF: cache locals, avoid double cfg read
+        intensity := cfg.GUI_SelectionIntensity
+        if (glow != _selLastGlow || intensity != _selLastInt) {
+            entry.selGlow := glow
+            entry.selIntensity := intensity
+            _selLastGlow := glow
+            _selLastInt := intensity
         }
     }
 
@@ -1189,10 +1191,11 @@ FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borde
     entry := gShader_Registry.Get(he.key, 0)
     if (entry) {
         static _hovLastGlow := -1, _hovLastInt := -1.0
-        if (cfg.GUI_HoverSelectionGlow != _hovLastGlow || hovIntensity != _hovLastInt) {
-            entry.selGlow := cfg.GUI_HoverSelectionGlow
+        hovGlow := cfg.GUI_HoverSelectionGlow  ; PERF: cache local, avoid double cfg read
+        if (hovGlow != _hovLastGlow || hovIntensity != _hovLastInt) {
+            entry.selGlow := hovGlow
             entry.selIntensity := hovIntensity
-            _hovLastGlow := cfg.GUI_HoverSelectionGlow
+            _hovLastGlow := hovGlow
             _hovLastInt := hovIntensity
         }
     }
@@ -1225,8 +1228,12 @@ FX_PreRenderHoverEffect(w, h, selX, selY, selW, selH, selARGB, borderARGB, borde
     bdrR := _hovBdrR, bdrG := _hovBdrG, bdrB := _hovBdrB, bdrA := _hovBdrA
 
     ; BG-as-hover Resize mode: render at hover rect size
+    ; PERF: cache Resize mode in static (matching FX_DrawHoverEffect pattern)
+    static _hovPreRenderResizeMode := -1
+    if (_hovPreRenderResizeMode = -1)
+        _hovPreRenderResizeMode := cfg.GUI_HoverBGShaderAsSelectionSize = "Resize"
     renderW := w, renderH := h
-    if (he.isBGShader && cfg.GUI_HoverBGShaderAsSelectionSize = "Resize") {
+    if (he.isBGShader && _hovPreRenderResizeMode) {
         renderW := Max(Round(selW), 1)
         renderH := Max(Round(selH), 1)
     }

--- a/src/gui/gui_interceptor.ahk
+++ b/src/gui/gui_interceptor.ahk
@@ -411,8 +411,9 @@ INT_SetBypassMode(shouldBypass) {
     global gINT_BypassMode, cfg
 
     global FR_EV_BYPASS, gFR_Enabled
-    diagLog := cfg.DiagEventLog
+    ; PERF: diagLog read deferred inside branches — skip on no-change fast path
     if (shouldBypass && !gINT_BypassMode) {
+        diagLog := cfg.DiagEventLog
         ; Entering bypass mode - disable Tab hooks
         if (gFR_Enabled)
             FR_Record(FR_EV_BYPASS, 1)
@@ -427,6 +428,7 @@ INT_SetBypassMode(shouldBypass) {
                 GUI_LogEvent("INT: BYPASS Hotkey Off FAILED: " e.Message)
         }
     } else if (!shouldBypass && gINT_BypassMode) {
+        diagLog := cfg.DiagEventLog
         ; Leaving bypass mode - re-enable Tab hooks
         if (gFR_Enabled)
             FR_Record(FR_EV_BYPASS, 0)

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -762,7 +762,8 @@ _GUI_ShowOverlayWithFrozen() {
     ; resized.  That nested paint either renders at the old RT size (stretched)
     ; or blocks on shader compilation and holds the reentrancy guard (blank).
     ; The tween starts after resize + show + reveal, right before the first paint.
-    Anim_PrepareShowFade(cfg.PerfAnimationType != "None")
+    hasAnim := cfg.PerfAnimationType != "None"  ; PERF: cache, read twice (here + line ~847)
+    Anim_PrepareShowFade(hasAnim)
 
     ; ===== TIMING: Resize =====
     t1 := QPC()
@@ -844,7 +845,7 @@ _GUI_ShowOverlayWithFrozen() {
 
     ; NOW start the show-fade tween — first paint is done, content is rendered.
     ; Animation timer can safely call GUI_Repaint from here on.
-    if (cfg.PerfAnimationType != "None")
+    if (hasAnim)
         Anim_StartTween("showFade", 0.0, 1.0, 90, Anim_EaseOutQuad)
 
     ; RACE FIX: If Alt was released during paint, hide and abort.

--- a/src/shared/blacklist.ahk
+++ b/src/shared/blacklist.ahk
@@ -265,15 +265,16 @@ Blacklist_IsWindowEligible(hwnd, title := "", class := "") {
                 return false
             }
         }
+        ahkWin := "ahk_id " hwnd  ; PERF: cache once, used by both WinGetTitle and WinGetClass
         try {
             if (title = "")
-                title := WinGetTitle("ahk_id " hwnd)
+                title := WinGetTitle(ahkWin)
             if (title = "") {
                 Profiler.Leave() ; @profile
                 return false
             }
             if (class = "")
-                class := WinGetClass("ahk_id " hwnd)
+                class := WinGetClass(ahkWin)
         } catch {
             Profiler.Leave() ; @profile
             return false

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -267,7 +267,7 @@ WL_UpsertWindow(records, source := "") {
     Profiler.Enter("WL_UpsertWindow") ; @profile
     global cfg, gWS_Store, gWS_Rev, gWS_ScanId, gWS_DiagChurn, gWS_SortOrderDirty
     global gWS_SortAffectingFields, gWS_ContentOnlyFields, gWS_InternalFields, gWS_MRUBumpOnly, FR_EV_WINDOW_ADD, gFR_Enabled
-    global gWS_DirtyHwnds
+    global gWS_DirtyHwnds, gWS_FieldClass
     if (!IsObject(records) || !(records is Array)) {
         Profiler.Leave() ; @profile
         return { added: 0, updated: 0, rev: gWS_Rev }
@@ -336,13 +336,15 @@ WL_UpsertWindow(records, source := "") {
                             gWS_DiagChurn[k] := gWS_DiagChurn.Get(k, 0) + 1
                         row.%k% := v
                         rowChanged := true
-                        ; Mark dirty for delta tracking (new records or non-internal field changes)
-                        if (gWS_SortAffectingFields.Has(k))
+                        ; PERF: Single gWS_FieldClass.Get() replaces 3 separate Map.Has() lookups
+                        ; (matches _WS_ApplyPatch pattern at line ~419)
+                        cls := gWS_FieldClass.Get(k, "")
+                        if (cls = "sort" || cls = "mruSort")
                             sortDirty := true
-                        else if (gWS_ContentOnlyFields.Has(k))
+                        else if (cls = "content")
                             contentDirty := true
                         ; Mark hwnd dirty for cosmetic patch during ACTIVE state
-                        if (!gWS_InternalFields.Has(k))
+                        if (cls != "internal")
                             gWS_DirtyHwnds[hwnd] := true
                     }
                 }
@@ -525,9 +527,9 @@ WL_BatchUpdateFields(patches, source := "") {
 
     for hwnd, patch in patches {
         hwnd := hwnd + 0
-        if (!gWS_Store.Has(hwnd))
+        row := gWS_Store.Get(hwnd, 0)  ; PERF: single lookup replaces Has+[] double hash
+        if (!row)
             continue
-        row := gWS_Store[hwnd]
 
         ; Apply patch using shared helper
         result := _WS_ApplyPatch(row, patch, hwnd)


### PR DESCRIPTION
## Summary

- Eliminate 7 `.Has()`+`[]` double hash lookups with single `.Get()` calls across shader pipeline, WinEvent batch processing, window store, proc pump, and icon pump
- Consolidate `WL_UpsertWindow` triple field classification (3× `Map.Has()` per changed field) into single `gWS_FieldClass.Get()` + string comparison, matching existing `_WS_ApplyPatch` pattern
- Guard `_WEH_WinEventProc`'s unconditional `EnsureTimerRunning()` with `if (!_WEH_TimerOn)`, matching destroy/hide paths — avoids entering Critical section hundreds of times per second
- Eliminate ephemeral `[destroyed, hidden, toProcess]` meta-array allocation in `_WEH_ProcessBatch` cleanup loop
- Pass store row from `_WEH_ProcessBatch` to `_WEH_UpdateExisting` as parameter to avoid re-fetching
- Cache config reads, string concatenations, and global references to locals in 7 hot-path functions

Closes #408

## Test plan

- [x] All 86 static analysis checks pass
- [x] All 564 unit tests pass (including 179 store tests exercising UpsertWindow/BatchUpdateFields)
- [x] All 355 GUI state machine tests pass
- [x] All 32 flight recorder tests pass
- [x] All 84 live integration tests pass (core, network, features, execution, pump, watcher)
- [ ] Manual smoke test: Alt-Tab overlay shows, cycles, activates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)