### PR TITLE
Deduplicate patterns, fix concurrency gap, harden errors

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -240,15 +240,9 @@ if (g_AltTabbyMode = "blacklist") {
     ExitApp()
 }
 
-; Parse --launcher-hwnd=<N> from command-line args.
-; Shared by config and blacklist editor mode handlers.
+; Parse --launcher-hwnd=<N> — delegates to shared ParseLauncherHwnd() in ipc_constants.ahk
 _ParseLauncherHwnd() {
-    global ARG_LAUNCHER_HWND, ARG_LAUNCHER_HWND_LEN
-    for _, arg in A_Args {
-        if (SubStr(arg, 1, ARG_LAUNCHER_HWND_LEN) = ARG_LAUNCHER_HWND)
-            return Integer(SubStr(arg, ARG_LAUNCHER_HWND_LEN + 1))
-    }
-    return 0
+    return ParseLauncherHwnd()
 }
 
 ; Notify launcher that an editor process is closing (for dashboard refresh).

--- a/src/core/winevent_hook.ahk
+++ b/src/core/winevent_hook.ahk
@@ -69,7 +69,7 @@ _WEH_DiagLog(msg) {
     global cfg, LOG_PATH_WINEVENT
     if (!cfg.DiagWinEventLog)
         return
-    LogAppend(LOG_PATH_WINEVENT, msg)
+    try LogAppend(LOG_PATH_WINEVENT, msg)
 }
 
 

--- a/src/editors/config_editor_native.ahk
+++ b/src/editors/config_editor_native.ahk
@@ -1117,55 +1117,10 @@ _CEN_MakeFileClearHandler(globalName) {
 
 _CEN_OnFileBrowse(globalName) {
     global gCEN, gConfigIniPath
-    ctrlInfo := gCEN["Controls"][globalName]
-
-    filter := "Images (*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.tiff;*.webp)"
-    selected := FileSelect(1, , "Select Background Image", filter)
-    if (selected = "")
+    destPath := ConfigEditor_BrowseBackgroundImage(gConfigIniPath)
+    if (destPath = "")
         return
-
-    ; Determine resources directory (next to config.ini)
-    configDir := ""
-    if (gConfigIniPath != "")
-        SplitPath(gConfigIniPath, , &configDir)
-    else if (A_IsCompiled)
-        configDir := A_ScriptDir
-    else
-        configDir := A_ScriptDir "\.."
-
-    resDir := configDir "\resources"
-    if (!DirExist(resDir))
-        DirCreate(resDir)
-
-    ; Determine destination filename
-    SplitPath(selected, , , &ext)
-    ext := StrLower(ext)
-    destExt := ext
-
-    ; WebP → PNG conversion (via libwebp — GDI+ WebP support varies by Windows version)
-    if (ext = "webp") {
-        converted := _CEN_ConvertWebPToPNG(selected, resDir)
-        if (converted = "") {
-            ThemeMsgBox("Failed to convert WebP image. Please select a PNG or JPG instead.", "Conversion Error", "OK Icon!")
-            return
-        }
-        destExt := "png"
-        destPath := resDir "\alttabby-background." destExt
-        ; Remove old background files only AFTER successful conversion
-        loop files resDir "\alttabby-background.*"
-            if (A_LoopFileFullPath != converted)
-                FileDelete(A_LoopFileFullPath)
-        if (converted != destPath)
-            FileMove(converted, destPath, true)
-    } else {
-        destPath := resDir "\alttabby-background." destExt
-        FileCopy(selected, destPath, true)
-        ; Remove stale background files with different extensions
-        loop files resDir "\alttabby-background.*"
-            if (A_LoopFileFullPath != destPath)
-                FileDelete(A_LoopFileFullPath)
-    }
-
+    ctrlInfo := gCEN["Controls"][globalName]
     ctrlInfo.ctrl.Value := destPath
 }
 
@@ -1173,10 +1128,6 @@ _CEN_OnFileClear(globalName) {
     global gCEN
     ctrlInfo := gCEN["Controls"][globalName]
     ctrlInfo.ctrl.Value := ""
-}
-
-_CEN_ConvertWebPToPNG(webpPath, outputDir) {
-    return WebP_ConvertToPNG(webpPath, outputDir)
 }
 
 ; Create a handler that syncs slider value -> edit control

--- a/src/editors/config_editor_webview.ahk
+++ b/src/editors/config_editor_webview.ahk
@@ -402,60 +402,12 @@ _CEW_ForceReveal() {
 
 _CEW_OnFileBrowse(globalName) {
     global gCEW_WebView, gConfigIniPath
-
-    filter := "Images (*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.tiff;*.webp)"
-    selected := FileSelect(1, , "Select Background Image", filter)
-    if (selected = "")
+    destPath := ConfigEditor_BrowseBackgroundImage(gConfigIniPath)
+    if (destPath = "")
         return
-
-    ; Determine resources directory (next to config.ini)
-    configDir := ""
-    if (gConfigIniPath != "")
-        SplitPath(gConfigIniPath, , &configDir)
-    else if (A_IsCompiled)
-        configDir := A_ScriptDir
-    else
-        configDir := A_ScriptDir "\.."
-
-    resDir := configDir "\resources"
-    if (!DirExist(resDir))
-        DirCreate(resDir)
-
-    SplitPath(selected, , , &ext)
-    ext := StrLower(ext)
-    destExt := ext
-
-    ; WebP → PNG conversion (via libwebp — GDI+ WebP support varies by Windows version)
-    if (ext = "webp") {
-        converted := _CEW_ConvertWebPToPNG(selected, resDir)
-        if (converted = "") {
-            ThemeMsgBox("Failed to convert WebP image. Please select a PNG or JPG instead.", "Conversion Error", "OK Icon!")
-            return
-        }
-        destExt := "png"
-        destPath := resDir "\alttabby-background." destExt
-        ; Remove old background files only AFTER successful conversion
-        loop files resDir "\alttabby-background.*"
-            if (A_LoopFileFullPath != converted)
-                FileDelete(A_LoopFileFullPath)
-        if (converted != destPath)
-            FileMove(converted, destPath, true)
-    } else {
-        destPath := resDir "\alttabby-background." destExt
-        FileCopy(selected, destPath, true)
-        ; Remove stale background files with different extensions
-        loop files resDir "\alttabby-background.*"
-            if (A_LoopFileFullPath != destPath)
-                FileDelete(A_LoopFileFullPath)
-    }
-
     ; Send path back to JS
     escaped := StrReplace(StrReplace(destPath, "\", "\\"), "'", "\'")
     try gCEW_WebView.ExecuteScript("setFilePath('" globalName "','" escaped "')")
-}
-
-_CEW_ConvertWebPToPNG(webpPath, outputDir) {
-    return WebP_ConvertToPNG(webpPath, outputDir)
 }
 
 ; Trigger JS save (which posts "save" message back, applying changes and destroying GUI)

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -25,9 +25,19 @@ global gFX_ShaderTime := Map()       ; layerIndex → {offset, carry, accumulate
 global gFX_MouseEffect      ; Mouse effect state: {key, name, opacity}
 global gFX_SelectionEffect  ; Selection effect state: {key, name, opacity, darkness, desat, speed, isBGShader}
 global gFX_HoverEffect      ; Hover effect state: {key, name, opacity, darkness, desat, speed, isBGShader}
-gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0, _bitmap: 0}
-gFX_SelectionEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
-gFX_HoverEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
+gFX_MouseEffect := _FX_DefaultMouseEffect()
+gFX_SelectionEffect := _FX_DefaultSelectionEffect()
+gFX_HoverEffect := _FX_DefaultHoverEffect()
+
+_FX_DefaultMouseEffect() {
+    return {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0, _bitmap: 0}
+}
+_FX_DefaultSelectionEffect() {
+    return {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
+}
+_FX_DefaultHoverEffect() {
+    return {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
+}
 global gFX_MousePrevX := 0.0        ; Previous frame mouse X
 global gFX_MousePrevY := 0.0        ; Previous frame mouse Y
 global gFX_MouseVelX := 0.0         ; Smoothed velocity X (px/sec)
@@ -198,9 +208,9 @@ FX_GPU_Dispose() {
     ; Release shader resources
     gFX_ShaderTime := Map()
     gFX_ShaderLayers := []
-    gFX_MouseEffect := {key: "", name: "", opacity: 0.0, darkness: 0.0, desat: 0.0, speed: 1.0, reactivity: 1.0, _bitmap: 0}
-    gFX_SelectionEffect := {key: "", name: "", opacity: 1.0, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
-    gFX_HoverEffect := {key: "", name: "", opacity: 0.8, darkness: 0.0, desat: 0.0, speed: 1.0, isBGShader: false, _bitmap: 0}
+    gFX_MouseEffect := _FX_DefaultMouseEffect()
+    gFX_SelectionEffect := _FX_DefaultSelectionEffect()
+    gFX_HoverEffect := _FX_DefaultHoverEffect()
     Shader_Cleanup()
 }
 

--- a/src/pump/enrichment_pump.ahk
+++ b/src/pump/enrichment_pump.ahk
@@ -53,13 +53,7 @@ _Pump_Init() {
     _Pump_DiagEnabled := cfg.DiagPumpLog
 
     ; Parse --launcher-hwnd from command line (for PUMP_READY self-announce)
-    global ARG_LAUNCHER_HWND, ARG_LAUNCHER_HWND_LEN
-    for _, arg in A_Args {
-        if (SubStr(arg, 1, ARG_LAUNCHER_HWND_LEN) = ARG_LAUNCHER_HWND) {
-            _Pump_LauncherHwnd := Integer(SubStr(arg, ARG_LAUNCHER_HWND_LEN + 1))
-            break
-        }
-    }
+    _Pump_LauncherHwnd := ParseLauncherHwnd()
 
     ; Initialize blacklist (for title-based re-check on enrichment)
     Blacklist_Init()
@@ -268,12 +262,8 @@ _Pump_HandleStatsFlush(parsed) {
         ; Backup existing file (crash safety)
         if (FileExist(statsPath))
             try FileCopy(statsPath, statsPath ".bak", true)
-        ; Atomic write: temp + rename
-        ; UTF-8-RAW = no BOM (BOM breaks IniRead/GetPrivateProfileString)
-        tmpPath := statsPath ".tmp"
-        try FileDelete(tmpPath)
-        FileAppend(content, tmpPath, "UTF-8-RAW")
-        FileMove(tmpPath, statsPath, true)
+        ; Atomic write: UTF-8-RAW = no BOM (BOM breaks IniRead/GetPrivateProfileString)
+        WriteFileAtomic(statsPath, content, "UTF-8-RAW")
         ; Success — remove backup
         try FileDelete(statsPath ".bak")
     } catch as e {
@@ -344,10 +334,13 @@ _Pump_ResolveIcon(hwnd, pid, exePath) {
     }
 
     if (h) {
+        ; RACE FIX: Protect map mutation — _Pump_PruneAllCaches iterates this map on a separate timer
+        Critical "On"
         ; Track ownership — destroy old HICON if re-enriching same hwnd
         if (oldIcon := _Pump_OwnedIcons.Get(hwnd, 0))
             try DllCall("user32\DestroyIcon", "ptr", oldIcon)
         _Pump_OwnedIcons[hwnd] := h
+        Critical "Off"
     }
 
     return {h: h, method: method}

--- a/src/shared/blacklist.ahk
+++ b/src/shared/blacklist.ahk
@@ -216,10 +216,7 @@ _BL_AddToSection(sectionName, entry) {
         newContent := _BL_InsertInSection(content, sectionName, entry)
         if (newContent = content)
             return false  ; Failed to insert (section not found)
-        tmpPath := gBlacklist_FilePath ".tmp"
-        try FileDelete(tmpPath)  ; Clean stale tmp from prior crash
-        FileAppend(newContent, tmpPath, "UTF-8")
-        FileMove(tmpPath, gBlacklist_FilePath, 1)  ; 1 = overwrite
+        WriteFileAtomic(gBlacklist_FilePath, newContent)
         return true
     } catch as e {
         LogAppend(LOG_PATH_STORE, "blacklist write error in _BL_AddToSection: " e.Message)

--- a/src/shared/config_loader.ahk
+++ b/src/shared/config_loader.ahk
@@ -314,7 +314,7 @@ _CL_SupplementIni(path) {
         content .= (i > 1 ? "`n" : "") . line
     }
 
-    _CL_WriteFileAtomic(path, content)
+    WriteFileAtomic(path, content)
 }
 
 ; Migrate renamed/combined config keys from older versions.
@@ -439,17 +439,18 @@ _CL_CleanupOrphanedKeys(path) {
         newContent .= (i > 1 ? "`n" : "") . line
     }
 
-    _CL_WriteFileAtomic(path, newContent)
+    WriteFileAtomic(path, newContent)
 }
 
 ; Write content atomically: write to temp file first, then replace original.
 ; On failure, cleans up temp and re-throws.
-_CL_WriteFileAtomic(path, content) {
+; encoding: file encoding (default "UTF-8", use "UTF-8-RAW" for no BOM)
+WriteFileAtomic(path, content, encoding := "UTF-8") {
     tempPath := path ".tmp"
     try {
         if (FileExist(tempPath))
             FileDelete(tempPath)
-        FileAppend(content, tempPath, "UTF-8")
+        FileAppend(content, tempPath, encoding)
         FileMove(tempPath, path, true)
     } catch as e {
         try FileDelete(tempPath)
@@ -603,14 +604,9 @@ _CL_EnsureArraySections(path, changes) {
     }
 
     ; Write back
-    tempPath := path ".tmp"
     try {
-        if (FileExist(tempPath))
-            FileDelete(tempPath)
-        FileAppend(content, tempPath, "UTF-8")
-        FileMove(tempPath, path, true)
+        WriteFileAtomic(path, content)
     } catch as e {
-        try FileDelete(tempPath)
         try LogAppend(LOG_PATH_STORE, "config merge write error: " e.Message " path=" path)
     }
 }
@@ -711,15 +707,9 @@ CL_WriteIniPreserveFormat(path, section, key, value, defaultVal := "", valType :
     }
 
     ; Atomic write: temp file then move, so a crash mid-write can't lose the config
-    tempPath := path ".tmp"
     try {
-        if (FileExist(tempPath))
-            FileDelete(tempPath)
-        FileAppend(newContent, tempPath, "UTF-8")
-        ; Atomic overwrite: MoveFileEx with MOVEFILE_REPLACE_EXISTING on NTFS
-        FileMove(tempPath, path, true)
+        WriteFileAtomic(path, newContent)
     } catch as e {
-        try FileDelete(tempPath)
         global LOG_PATH_STORE
         LogAppend(LOG_PATH_STORE, "config write error: " e.Message " path=" path)
         return false
@@ -899,7 +889,7 @@ _CL_NormalizeArraySections(arraySections) {
             }
             content .= sectionText
         }
-        _CL_WriteFileAtomic(gConfigIniPath, content)
+        WriteFileAtomic(gConfigIniPath, content)
     }
 }
 
@@ -949,14 +939,9 @@ CL_DeleteSections(sectionNames) {
             newContent .= "`n"
     }
 
-    tempPath := gConfigIniPath ".tmp"
     try {
-        if (FileExist(tempPath))
-            FileDelete(tempPath)
-        FileAppend(newContent, tempPath, "UTF-8")
-        FileMove(tempPath, gConfigIniPath, true)
+        WriteFileAtomic(gConfigIniPath, newContent)
     } catch as e {
-        try FileDelete(tempPath)
         try LogAppend(LOG_PATH_STORE, "config cleanup write error: " e.Message)
     }
 }

--- a/src/shared/ipc_constants.ahk
+++ b/src/shared/ipc_constants.ahk
@@ -54,3 +54,14 @@ global IPC_WM_STATS_REQUEST := 0x8002   ; WM_APP+2: PostMessage from launcher to
 ; Command-line argument constants
 global ARG_LAUNCHER_HWND := "--launcher-hwnd="
 global ARG_LAUNCHER_HWND_LEN := StrLen(ARG_LAUNCHER_HWND)
+
+; Parse --launcher-hwnd=<N> from command-line args.
+; Returns the launcher hwnd as an integer, or 0 if not found.
+ParseLauncherHwnd() {
+    global ARG_LAUNCHER_HWND, ARG_LAUNCHER_HWND_LEN
+    for _, arg in A_Args {
+        if (SubStr(arg, 1, ARG_LAUNCHER_HWND_LEN) = ARG_LAUNCHER_HWND)
+            return Integer(SubStr(arg, ARG_LAUNCHER_HWND_LEN + 1))
+    }
+    return 0
+}

--- a/src/shared/resource_utils.ahk
+++ b/src/shared/resource_utils.ahk
@@ -19,25 +19,36 @@ global RES_ID_EDITOR_HTML := 25    ; config_editor.txt (HTML content)
 ; WebView2 Evergreen runtime GUID (shared by all editors)
 global WEBVIEW2_EVERGREEN_GUID := "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
 
-; Extract an embedded resource to a file
+; Load an embedded resource into memory: FindResource → LoadResource → LockResource.
 ; resourceId: Resource ID from @Ahk2Exe-AddResource directive
-; destPath: Full path to write the extracted file
-; Returns: true on success, throws on failure
-ResourceExtract(resourceId, destPath) {
+; outSize: receives the resource size in bytes
+; Returns: pointer to locked resource data, throws on failure
+_ResourceLoad(resourceId, &outSize) {
     global RT_RCDATA
 
     hRes := DllCall("FindResource", "ptr", 0, "int", resourceId, "int", RT_RCDATA, "ptr")
     if (!hRes)
         throw Error("Resource " resourceId " not found")
 
-    resSize := DllCall("SizeofResource", "ptr", 0, "ptr", hRes, "uint")
+    outSize := DllCall("SizeofResource", "ptr", 0, "ptr", hRes, "uint")
     hMem := DllCall("LoadResource", "ptr", 0, "ptr", hRes, "ptr")
-    if (!hMem || !resSize)
+    if (!hMem || !outSize)
         throw Error("Failed to load resource " resourceId)
 
     pData := DllCall("LockResource", "ptr", hMem, "ptr")
     if (!pData)
         throw Error("Failed to lock resource " resourceId)
+
+    return pData
+}
+
+; Extract an embedded resource to a file
+; resourceId: Resource ID from @Ahk2Exe-AddResource directive
+; destPath: Full path to write the extracted file
+; Returns: true on success, throws on failure
+ResourceExtract(resourceId, destPath) {
+    resSize := 0
+    pData := _ResourceLoad(resourceId, &resSize)
 
     buf := Buffer(resSize, 0)
     DllCall("RtlMoveMemory", "ptr", buf.Ptr, "ptr", pData, "uptr", resSize)
@@ -74,20 +85,8 @@ ResourceExtractToTemp(resourceId, fileName, destDir := "") {
 ; resourceId: Resource ID from @Ahk2Exe-AddResource directive
 ; Returns: Buffer with resource data, or throws on failure.
 ResourceLoadToBuffer(resourceId) {
-    global RT_RCDATA
-
-    hRes := DllCall("FindResource", "ptr", 0, "int", resourceId, "int", RT_RCDATA, "ptr")
-    if (!hRes)
-        throw Error("Resource " resourceId " not found")
-
-    resSize := DllCall("SizeofResource", "ptr", 0, "ptr", hRes, "uint")
-    hMem := DllCall("LoadResource", "ptr", 0, "ptr", hRes, "ptr")
-    if (!hMem || !resSize)
-        throw Error("Failed to load resource " resourceId)
-
-    pData := DllCall("LockResource", "ptr", hMem, "ptr")
-    if (!pData)
-        throw Error("Failed to lock resource " resourceId)
+    resSize := 0
+    pData := _ResourceLoad(resourceId, &resSize)
 
     buf := Buffer(resSize)
     DllCall("RtlMoveMemory", "ptr", buf, "ptr", pData, "uptr", resSize)

--- a/src/shared/stats.ahk
+++ b/src/shared/stats.ahk
@@ -255,12 +255,8 @@ _Stats_DirectWrite(statsPath, content) {
         ; Backup existing file (crash safety)
         if (FileExist(statsPath))
             try FileCopy(statsPath, statsPath ".bak", true)
-        ; Atomic write: write to temp, then rename
-        ; UTF-8-RAW = no BOM (BOM breaks IniRead/GetPrivateProfileString)
-        tmpPath := statsPath ".tmp"
-        try FileDelete(tmpPath)
-        FileAppend(content, tmpPath, "UTF-8-RAW")
-        FileMove(tmpPath, statsPath, true)
+        ; Atomic write: UTF-8-RAW = no BOM (BOM breaks IniRead/GetPrivateProfileString)
+        WriteFileAtomic(statsPath, content, "UTF-8-RAW")
         ; Success — remove backup
         try FileDelete(statsPath ".bak")
         return true

--- a/src/shared/webp_utils.ahk
+++ b/src/shared/webp_utils.ahk
@@ -91,3 +91,57 @@ WebP_ConvertToPNG(webpPath, outputDir) {
         return ""
     }
 }
+
+; Browse for a background image file, handle WebP conversion, and copy to resources/.
+; Shared by native and WebView2 config editors.
+; configIniPath: path to config.ini (used to locate resources/ directory)
+; Returns: destination file path, or "" if cancelled/failed
+ConfigEditor_BrowseBackgroundImage(configIniPath) {
+    filter := "Images (*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.tiff;*.webp)"
+    selected := FileSelect(1, , "Select Background Image", filter)
+    if (selected = "")
+        return ""
+
+    ; Determine resources directory (next to config.ini)
+    configDir := ""
+    if (configIniPath != "")
+        SplitPath(configIniPath, , &configDir)
+    else if (A_IsCompiled)
+        configDir := A_ScriptDir
+    else
+        configDir := A_ScriptDir "\.."
+
+    resDir := configDir "\resources"
+    if (!DirExist(resDir))
+        DirCreate(resDir)
+
+    SplitPath(selected, , , &ext)
+    ext := StrLower(ext)
+    destExt := ext
+
+    ; WebP → PNG conversion (via libwebp — GDI+ WebP support varies by Windows version)
+    if (ext = "webp") {
+        converted := WebP_ConvertToPNG(selected, resDir)
+        if (converted = "") {
+            ThemeMsgBox("Failed to convert WebP image. Please select a PNG or JPG instead.", "Conversion Error", "OK Icon!")
+            return ""
+        }
+        destExt := "png"
+        destPath := resDir "\alttabby-background." destExt
+        ; Remove old background files only AFTER successful conversion
+        loop files resDir "\alttabby-background.*"
+            if (A_LoopFileFullPath != converted)
+                FileDelete(A_LoopFileFullPath)
+        if (converted != destPath)
+            FileMove(converted, destPath, true)
+    } else {
+        destPath := resDir "\alttabby-background." destExt
+        FileCopy(selected, destPath, true)
+        ; Remove stale background files with different extensions
+        loop files resDir "\alttabby-background.*"
+            if (A_LoopFileFullPath != destPath)
+                FileDelete(A_LoopFileFullPath)
+    }
+
+    return destPath
+}


### PR DESCRIPTION
## Summary

- **WriteFileAtomic**: Promoted private `_CL_WriteFileAtomic` to public `WriteFileAtomic(path, content, encoding)` — replaces 8 inline atomic-write sites across config_loader, stats, enrichment_pump, and blacklist
- **Editor file browse**: Extracted `ConfigEditor_BrowseBackgroundImage()` to webp_utils.ahk — both editors reduced from ~45 lines to ~5, deleted trivial `_ConvertWebPToPNG` wrappers
- **Pump icon concurrency**: Added `Critical "On"`/`"Off"` around `_Pump_OwnedIcons` mutation in `_Pump_ResolveIcon` (matching existing RACE FIX in `_Pump_PruneAllCaches`)
- **Resource loading**: Extracted `_ResourceLoad` helper for shared FindResource→LoadResource→LockResource chain
- **Launcher hwnd parsing**: Added public `ParseLauncherHwnd()` to ipc_constants.ahk, replacing inline copies in pump
- **WinEventHook error handling**: Added `try` before `LogAppend` in `_WEH_DiagLog` (3 of 4 diagnostic loggers already had it)
- **Effect state factories**: Extracted `_FX_Default{Mouse,Selection,Hover}Effect()` for init + dispose consistency

Net: **-58 lines** (126 added, 184 removed) across 12 files.

Closes #413

## Test plan

- [x] Static analysis: all 86 checks pass
- [x] Unit tests: 564/564 pass
- [x] GUI tests: 355/355 pass
- [x] Flight recorder tests: 32/32 pass
- [x] Live tests: 64/64 pass (core, network, execution, features, pump, watcher)
- [ ] Manual smoke test: launch Alt-Tabby, trigger Alt+Tab overlay, verify shaders render

🤖 Generated with [Claude Code](https://claude.com/claude-code)