### PR TITLE
Use static DllCall buffers in monitor utility functions

### DIFF
--- a/src/gui/gui_win.ahk
+++ b/src/gui/gui_win.ahk
@@ -31,7 +31,7 @@ Win_GetWorkAreaFromHwnd(hWnd, &left, &top, &right, &bottom) {
     ; MONITORINFO (40 bytes): cbSize(4) + rcMonitor(16) + rcWork(16) + dwFlags(4)
     ; rcMonitor: left(4) top(8) right(12) bottom(16)
     ; rcWork:    left(20) top(24) right(28) bottom(32)
-    mi := Buffer(40, 0)
+    static mi := Buffer(40, 0)  ; static: reused per-call, repopulated before each DllCall
     NumPut("UInt", 40, mi, 0)
     if (!DllCall("user32\GetMonitorInfoW", "ptr", hMon, "ptr", mi.Ptr, "int")) {
         left := 0
@@ -58,7 +58,7 @@ Win_GetMonitorBoundsFromHwnd(hWnd, &left, &top, &right, &bottom) {
         return
     }
     ; MONITORINFO layout: see Win_GetWorkAreaFromHwnd above
-    mi := Buffer(40, 0)
+    static mi := Buffer(40, 0)  ; static: reused per-call, repopulated before each DllCall
     NumPut("UInt", 40, mi, 0)
     if (!DllCall("user32\GetMonitorInfoW", "ptr", hMon, "ptr", mi.Ptr, "int")) {
         left := 0
@@ -78,7 +78,7 @@ Win_GetMonitorBoundsFromHwnd(hWnd, &left, &top, &right, &bottom) {
 
 ; Get monitor scale from rect
 Win_GetMonitorScale(left, top, right, bottom) {
-    rc := Buffer(16, 0)
+    static rc := Buffer(16, 0)  ; static: reused per-call, repopulated before each DllCall
     NumPut("Int", left, rc, 0)
     NumPut("Int", top, rc, 4)
     NumPut("Int", right, rc, 8)


### PR DESCRIPTION
## Summary

- Align 3 monitor utility functions (`Win_GetWorkAreaFromHwnd`, `Win_GetMonitorBoundsFromHwnd`, `Win_GetMonitorScale`) with the existing `static` buffer pattern used by `Win_GetRectPhys` in the same file
- All functions fully overwrite buffer contents via `NumPut` before each `DllCall`, making static reuse safe (AHK is single-threaded within Critical sections)
- Consistency change — the performance difference is negligible

Closes #422

## Test plan

- [ ] `.\tests\test.ps1 --live` passes
- [ ] Verify overlay renders correctly on primary monitor
- [ ] Verify overlay renders correctly when `GUI_OverlayMonitor = "Active"` on a secondary monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)