### PR TITLE
Fix misleading STA pump comment in paint path

### DIFF
--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -278,8 +278,10 @@ GUI_Repaint() {
                 gAnim_FrameTimeDisplay := QPC() - tPaintWork
                 D2D_ReleaseBackBuffer()
 
-                ; DComp clip + Commit + Present: no STA pump between them,
-                ; guaranteed to land on the same compositor frame.
+                ; DComp clip + Commit + Present: kept adjacent so they land on
+                ; the same compositor frame.  Commit and Present ARE STA pump
+                ; points, but gPaint_RepaintInProgress blocks reentrant callbacks
+                ; from modifying DComp/DXGI state between them.
                 if (needsResize && phW > 0 && phH > 0) {
                     D2D_SetClipRect(phW, phH)
                     D2D_Commit()


### PR DESCRIPTION
## Summary
- Corrects a comment in `gui_paint.ahk` that claimed "no STA pump between" DComp Commit and DXGI Present
- Both are COM calls that **do** pump STA — the actual safety comes from `gPaint_RepaintInProgress` blocking reentrant callbacks from modifying DComp/DXGI state
- Found during a full STA reentrancy audit of the paint and frame loop paths (all 5 invariants verified, no violations)

## Test plan
- [ ] `.\tests\test.ps1 --live` — comment-only change, no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)