### PR TITLE
Fix Update_ApplyCore silent failure propagation

### DIFF
--- a/src/alt_tabby.ahk
+++ b/src/alt_tabby.ahk
@@ -424,7 +424,12 @@ if (g_AltTabbyMode = "update-installed") {
             ExitApp()
         }
 
-        Launcher_DoUpdateInstalled(sourcePath, targetPath)
+        updateOk := Launcher_DoUpdateInstalled(sourcePath, targetPath)
+        if (!updateOk) {
+            ; Update failed — relaunch source so user isn't left with no running instance
+            if (FileExist(sourcePath))
+                try Run('"' sourcePath '"')
+        }
     } catch as e {
         ThemeMsgBox("The update could not be completed.`n`n"
             "Possible causes:`n"
@@ -433,6 +438,9 @@ if (g_AltTabbyMode = "update-installed") {
             "The previous version is still intact. Try closing all Alt-Tabby`n"
             "processes and running the update again.`n`n"
             "Details: " e.Message, APP_NAME, "Iconx")
+        ; Relaunch source so user isn't left with no running instance
+        if (FileExist(sourcePath))
+            try Run('"' sourcePath '"')
     }
     ExitApp()
 }
@@ -466,7 +474,7 @@ if (g_AltTabbyMode = "install-to-pf") {
             overwriteUserData := (configResult = "Yes")
         }
 
-        Update_ApplyCore({
+        result := Update_ApplyCore({
             sourcePath: state.source,
             targetPath: state.target,
             useLockFile: true,
@@ -477,6 +485,11 @@ if (g_AltTabbyMode = "install-to-pf") {
             ensureShortcuts: true,
             successMessage: "Alt-Tabby has been installed to:`n" state.target
         })
+        if (!result) {
+            ; ApplyCore failed (relaunchAfter=true but returned instead of ExitApp) — relaunch source
+            if (IsSet(state) && state.HasOwnProp("source") && FileExist(state.source))
+                try Run('"' state.source '"')
+        }
     } catch as e {
         ThemeMsgBox("The installation could not be completed.`n`n"
             "Possible causes:`n"

--- a/src/launcher/launcher_install.ahk
+++ b/src/launcher/launcher_install.ahk
@@ -262,7 +262,7 @@ Launcher_DoUpdateInstalled(sourcePath, targetPath) {
     global cfg, g_GuiPID, g_PumpPID
     if (cfg.DiagLauncherLog)
         Launcher_Log("UPDATE_INSTALLED source=" sourcePath " target=" targetPath)
-    Update_ApplyCore({
+    return Update_ApplyCore({
         sourcePath: sourcePath,
         targetPath: targetPath,
         useLockFile: true,

--- a/src/launcher/launcher_main.ahk
+++ b/src/launcher/launcher_main.ahk
@@ -336,8 +336,9 @@ Launcher_ReleaseMutexes() {
 ; Re-acquire both mutexes after a failed restart attempt.
 ; Called from launcher_tray admin toggle fallback path.
 Launcher_ReacquireMutexes() {
-    Launcher_AcquireMutex()
-    _Launcher_AcquireActiveMutex()
+    if (!Launcher_AcquireMutex() || !_Launcher_AcquireActiveMutex())
+        return false
+    return true
 }
 
 ; Handle WM_COPYDATA control signals from child processes

--- a/src/launcher/launcher_tray.ahk
+++ b/src/launcher/launcher_tray.ahk
@@ -603,7 +603,10 @@ _AdminToggle_CheckComplete() {
             } else {
                 ; Task failed - re-acquire mutexes before relaunching subprocesses,
                 ; otherwise another instance could start in the unprotected window
-                Launcher_ReacquireMutexes()
+                if (!Launcher_ReacquireMutexes()) {
+                    ThemeMsgBox("Another Alt-Tabby instance started while restarting. This instance will exit.", APP_NAME, "Iconi")
+                    ExitApp()
+                }
                 LaunchPump()
                 LaunchGui()
                 ThemeMsgBox("The scheduled task could not start Alt-Tabby.`nPlease restart Alt-Tabby manually.", APP_NAME, "Iconx")

--- a/src/launcher/launcher_wizard.ahk
+++ b/src/launcher/launcher_wizard.ahk
@@ -239,22 +239,15 @@ _WizardApplyChoices(startMenu, startup, install, admin, autoUpdate) {
             ; Already in Program Files
             installSucceeded := true
         } else {
-            installOk := false
-            try {
-                Update_ApplyCore({
-                    sourcePath: A_ScriptFullPath,
-                    targetPath: targetPath,
-                    useLockFile: false,
-                    validatePE: false,
-                    copyMode: true,
-                    cleanupSourceOnFailure: false,
-                    relaunchAfter: false
-                })
-                installOk := true
-            } catch as e {
-                if (cfg.DiagLauncherLog)
-                    Launcher_Log("WIZARD PF install failed: " e.Message)
-            }
+            installOk := Update_ApplyCore({
+                sourcePath: A_ScriptFullPath,
+                targetPath: targetPath,
+                useLockFile: false,
+                validatePE: false,
+                copyMode: true,
+                cleanupSourceOnFailure: false,
+                relaunchAfter: false
+            })
             if (installOk && FileExist(targetPath)) {
                 exePath := targetPath
                 installedElsewhere := targetPath

--- a/src/shared/setup_utils.ahk
+++ b/src/shared/setup_utils.ahk
@@ -976,7 +976,7 @@ Update_ApplyCore(opts) {
                 modTime := FileGetTime(lockFile, "M")
                 if (DateDiff(A_Now, modTime, "Minutes") < 5) {
                     ThemeMsgBox("Another update is in progress. Please wait.", APP_NAME, "Icon!")
-                    return
+                    return false
                 }
                 FileDelete(lockFile)
             }
@@ -1015,7 +1015,7 @@ Update_ApplyCore(opts) {
                 if (lockFile != "")
                     try FileDelete(lockFile)
                 ThemeMsgBox("Could not rename existing version:`n" renameErr.Message "`n`nUpdate aborted. The file may be locked by antivirus or another process.", "Update Error", "Iconx")
-                return
+                return false
             }
         }
 
@@ -1026,7 +1026,7 @@ Update_ApplyCore(opts) {
             if (lockFile != "")
                 try FileDelete(lockFile)
             ThemeMsgBox("Downloaded file appears to be corrupted (invalid PE header).`nUpdate aborted.", "Update Error", "Iconx")
-            return
+            return false
         }
 
         ; Copy or move new exe to target location
@@ -1146,6 +1146,8 @@ Update_ApplyCore(opts) {
         if (lockFile != "")
             try FileDelete(lockFile)
 
+        return true
+
     } catch as e {
         ; Rollback - handle partial/corrupted targetPath from failed copy/move
         rollbackSuccess := false
@@ -1178,6 +1180,7 @@ Update_ApplyCore(opts) {
                 "Try renaming this file back to the original name.`n"
                 "If that fails, please reinstall Alt-Tabby.`n`n"
                 "Details: " e.Message, "Alt-Tabby Critical", "Iconx")
+        return false
     }
 }
 
@@ -1583,7 +1586,7 @@ Update_ContinueFromElevation() {
         }
 
         _Update_ApplyAndRelaunch(newExePath, targetExePath)
-        return true  ; Won't reach here if successful (ExitApp called)
+        return false  ; Only reached if Update_ApplyCore failed (success calls ExitApp)
     } catch {
         return false
     }


### PR DESCRIPTION
## Summary

- `Update_ApplyCore` now returns `bool` (`false` at all 4 failure paths, `true` at success) instead of returning normally on failure — callers previously inferred success from lack of exception
- All 5 callers updated: wizard uses return value directly (drops misleading try-catch), install/update modes relaunch source exe on failure to prevent "no running instance" state
- `Update_ContinueFromElevation` returns `false` instead of `true` when `_Update_ApplyAndRelaunch` returns (success calls `ExitApp`), unblocking previously dead relaunch fallback code
- `Launcher_ReacquireMutexes` checks mutex acquisition results and returns `false` on failure; admin toggle fallback exits cleanly if another instance took over

## Test plan

- [x] Full test suite passes (`test.ps1 --live` — all suites green, pump failures pre-existing)
- [ ] Lock PF exe externally → wizard install should detect failure and NOT proceed with admin task/config redirect
- [ ] Install-to-PF with locked exe → should relaunch source exe on failure
- [ ] Enable admin → stop task service beforehand → should handle gracefully

Closes #427

Generated with [Claude Code](https://claude.com/claude-code)