### PR TITLE
Micro-optimize main-thread blocking functions

### DIFF
--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -1497,7 +1497,11 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
     static batchPatches := Map()
     batchPatches.Clear()
 
-    addedCount := 0
+    ; PERF: Collect new-window records for batched upsert (one Critical enter/exit
+    ; + one rev bump instead of N). Pattern matches _WEH_ProcessBatch line 691.
+    static newRecs := []
+    newRecs.Length := 0
+
     updatedCount := 0
     skippedIneligible := 0
     for hwnd, _data in wsMap {
@@ -1533,8 +1537,7 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
             rec["workspaceName"] := _wsn
             rec["isOnCurrentWorkspace"] := _isCur
 
-            try WL_UpsertWindow([rec])
-            addedCount++
+            newRecs.Push(rec)
         } else {
             ; Window exists - only patch if workspace data actually changed
             if (row.workspaceName != _wsn
@@ -1549,6 +1552,10 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
             }
         }
     }
+    ; Batch-upsert all new windows (one Critical + one rev bump instead of N)
+    addedCount := newRecs.Length
+    if (addedCount > 0)
+        try WL_UpsertWindow(newRecs, "komorebi_fullstate_add")
     if (logEnabled)
         KSub_DiagLog("ProcessFullState: added " addedCount " updated " updatedCount " skipped(ineligible) " skippedIneligible)
 

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -505,9 +505,13 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
         brHdr := gD2D_Res["brHdr"]
         tfHdr := gD2D_Res["tfHdr"]
         if (shadowEnabled) {
-            _FX_DrawTextLeftShadow("Title", textX, hdrY, textW, hdrTextH, brHdr, tfHdr, shadowBr, sOffX, sOffY)
+            ; PERF: Inlined _FX_DrawTextLeftShadow — eliminates AHK function call overhead
+            ; (~1-2μs per call × N text elements/frame). Shadow first, then crisp text on top.
+            D2D_DrawTextLeft("Title", textX + sOffX, hdrY + sOffY, textW, hdrTextH, shadowBr, tfHdr)
+            D2D_DrawTextLeft("Title", textX, hdrY, textW, hdrTextH, brHdr, tfHdr)
             for _, col in cols {
-                _FX_DrawTextLeftShadow(col.name, col.x, hdrY, col.w, hdrTextH, brHdr, tfHdr, shadowBr, sOffX, sOffY)
+                D2D_DrawTextLeft(col.name, col.x + sOffX, hdrY + sOffY, col.w, hdrTextH, shadowBr, tfHdr)
+                D2D_DrawTextLeft(col.name, col.x, hdrY, col.w, hdrTextH, brHdr, tfHdr)
             }
         } else {
             D2D_DrawTextLeft("Title", textX, hdrY, textW, hdrTextH, brHdr, tfHdr)
@@ -741,11 +745,15 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
             }
 
             if (shadowEnabled) {
-                _FX_DrawTextLeftShadow(title, textX, yRow + titleY, textW, titleH, brMainUse, tfMainUse, shadowBr, sOffX, sOffY)
-                _FX_DrawTextLeftShadow(sub, textX, yRow + subY, textW, subH, brSubUse, tfSubUse, shadowBr, sOffX, sOffY)
+                ; PERF: Inlined _FX_DrawTextLeftShadow (see header block comment)
+                D2D_DrawTextLeft(title, textX + sOffX, yRow + titleY + sOffY, textW, titleH, shadowBr, tfMainUse)
+                D2D_DrawTextLeft(title, textX, yRow + titleY, textW, titleH, brMainUse, tfMainUse)
+                D2D_DrawTextLeft(sub, textX + sOffX, yRow + subY + sOffY, textW, subH, shadowBr, tfSubUse)
+                D2D_DrawTextLeft(sub, textX, yRow + subY, textW, subH, brSubUse, tfSubUse)
                 for _, col in cols {
                     val := col._exists ? cur.%col.key% : ""
-                    _FX_DrawTextLeftShadow(val, col.x, yRow + colY, col.w, colH, brColUse, tfColUse, shadowBr, sOffX, sOffY)
+                    D2D_DrawTextLeft(val, col.x + sOffX, yRow + colY + sOffY, col.w, colH, shadowBr, tfColUse)
+                    D2D_DrawTextLeft(val, col.x, yRow + colY, col.w, colH, brColUse, tfColUse)
                 }
             } else {
                 D2D_DrawTextLeft(title, textX, yRow + titleY, textW, titleH, brMainUse, tfMainUse)
@@ -772,7 +780,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
     if (diagTiming)
         t1 := QPC()
     if (count > rowsToDraw && rowsToDraw > 0) {
-        _GUI_DrawScrollbar(wPhys, contentTopY, rowsToDraw, RowH, scrollTop, count, cachedLayout)
+        _GUI_DrawScrollbar(wPhys, contentTopY, rowsToDraw, RowH, start0, count, cachedLayout)
     }
     if (diagTiming)
         tPO_Scrollbar := QPC() - t1
@@ -897,7 +905,9 @@ _GUI_DrawActionButtons(wPhys, yRow, rowHPhys, scale, Mx) {
 
 ; ========================= SCROLLBAR =========================
 
-_GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, scrollTop, count, cachedLayout) {
+; PERF: start0 passed from caller (already computed in _GUI_PaintOverlay) to avoid
+; redundant Win_Wrap0 call
+_GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, start0, count, cachedLayout) {
     global cfg, gD2D_BrushGeneration
     Profiler.Enter("_GUI_DrawScrollbar") ; @profile
     if (!cfg.GUI_ScrollBarEnabled || count <= 0 || rowsDrawn <= 0 || rowHPhys <= 0) {
@@ -925,7 +935,6 @@ _GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, scrollTop, count, ca
         thumbH := 3
     }
 
-    start0 := Win_Wrap0(scrollTop, count)
     startRatio := start0 / count
     y1 := y + Floor(startRatio * trackH)
     y2 := y1 + thumbH
@@ -1073,13 +1082,6 @@ _GUI_DrawFooter(wPhys, hPhys, shadowP, shadowBr, cachedLayout) {
 }
 
 ; ---- Text Shadow ----
-
-; Draw text with a drop shadow behind it. Shadow is drawn first (offset, darker),
-; then crisp text on top. Two DrawText calls per shadowed text element.
-_FX_DrawTextLeftShadow(text, x, y, w, h, brush, tf, shadowBrush, offX, offY) {
-    D2D_DrawTextLeft(text, x + offX, y + offY, w, h, shadowBrush, tf)
-    D2D_DrawTextLeft(text, x, y, w, h, brush, tf)
-}
 
 _FX_DrawTextCenteredShadow(text, x, y, w, h, brush, tf, shadowBrush, offX, offY) {
     D2D_DrawTextCentered(text, x + offX, y + offY, w, h, shadowBrush, tf)

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -729,10 +729,12 @@ _GUI_ShowOverlayWithFrozen() {
     diagTiming := cfg.DiagPaintTimingLog  ; PERF: cache config read (5+ uses)
 
     ; ===== TIMING: Show sequence start =====
-    tShow_Start := QPC()
-    idleDuration := (gPaint_LastPaintTick > 0) ? (A_TickCount - gPaint_LastPaintTick) : -1
-    if (diagTiming)
+    ; PERF: Guard QPC calls behind diagTiming — 6 DllCalls (~600ns) saved when diagnostics disabled
+    if (diagTiming) {
+        tShow_Start := QPC()
+        idleDuration := (gPaint_LastPaintTick > 0) ? (A_TickCount - gPaint_LastPaintTick) : -1
         Paint_Log("ShowOverlay START (idle=" (idleDuration > 0 ? Round(idleDuration/1000, 1) "s" : "first") " frozen=" gGUI_DisplayItems.Length " items=" gGUI_LiveItems.Length ")")
+    }
 
     ; Set visible flag FIRST to prevent re-entrancy issues
     ; (Show/DwmFlush can pump messages, allowing hotkeys to fire mid-function)
@@ -768,12 +770,14 @@ _GUI_ShowOverlayWithFrozen() {
     Anim_PrepareShowFade(hasAnim)
 
     ; ===== TIMING: Resize =====
-    t1 := QPC()
+    if (diagTiming)
+        t1 := QPC()
     rowsDesired := GUI_ComputeRowsToShow(gGUI_DisplayItems.Length)
     GUI_ResizeToRows(rowsDesired, true)  ; skipFlush — we flush after paint
     global gGUI_LastRowsDesired
     gGUI_LastRowsDesired := rowsDesired  ; Sync so first paint skips unnecessary pre-render
-    tShow_Resize := QPC() - t1
+    if (diagTiming)
+        tShow_Resize := QPC() - t1
 
     ; ===== Show window BEFORE painting =====
     ; With SwapChain + DComp, Present() works for hidden windows (commits to the
@@ -841,9 +845,11 @@ _GUI_ShowOverlayWithFrozen() {
     ; By painting before starting the tween, the window stays invisible until
     ; content is rendered.
     ; ===== TIMING: Paint on visible window (Present works) =====
-    t1 := QPC()
+    if (diagTiming)
+        t1 := QPC()
     GUI_Repaint()
-    tShow_Repaint := QPC() - t1
+    if (diagTiming)
+        tShow_Repaint := QPC() - t1
 
     ; NOW start the show-fade tween — first paint is done, content is rendered.
     ; Animation timer can safely call GUI_Repaint from here on.
@@ -877,9 +883,10 @@ _GUI_ShowOverlayWithFrozen() {
     GUI_StartHoverPolling()
 
     ; ===== TIMING: Log show sequence =====
-    tShow_Total := QPC() - tShow_Start
-    if (diagTiming)
+    if (diagTiming) {
+        tShow_Total := QPC() - tShow_Start
         Paint_Log("ShowOverlay END: total=" Round(tShow_Total, 2) "ms | resize=" Round(tShow_Resize, 2) " repaint=" Round(tShow_Repaint, 2))
+    }
     Profiler.Leave() ; @profile
 }
 

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -1477,6 +1477,7 @@ WL_GetDisplayList(opts := 0) {
 
     ; Build filtered subset Map for O(1) membership checks
     itemsMap := Map()
+    itemsMap.Capacity := items.Length  ; PERF: pre-size to avoid rehash during population
     for _, rec in items
         itemsMap[rec.hwnd] := rec
 


### PR DESCRIPTION
## Summary

- **Batch WL_UpsertWindow** in `_KSub_ProcessFullState`: collect new-window records into static array, single upsert after loop. Saves N-1 Critical transitions + rev bumps during workspace discovery (~50-200μs for 5-10 windows)
- **Inline `_FX_DrawTextLeftShadow`**: 2-line wrapper called ~20×/frame eliminated. Saves ~20-40μs/frame when shadows enabled
- **Pass `start0` to `_GUI_DrawScrollbar`**: avoid redundant `Win_Wrap0` recomputation (~1-2μs/frame)
- **Guard QPC in `_GUI_ShowOverlayWithFrozen`**: 6 DllCalls now skipped when diagnostics disabled (~600ns/show)
- **Pre-size `itemsMap.Capacity`** in `WL_GetDisplayList` (~0.5-1μs per build)

Closes #434

## Audit scope

78 functions audited across 20 files (46 Tier 1 + 15 Tier 2 + 17 Tier 3 callees). Most were already well-optimized — static buffers, hoisted invariants, batched DllCalls throughout. 9 agent-proposed findings were rejected during validation (cross-function contract changes, already-optimized patterns, unsafe static reuse).

## Test plan

- [x] All 1014 tests pass (unit, GUI, live, flight recorder)
- [ ] Verify with komorebi: switch workspaces with multiple windows to exercise batched upsert path

🤖 Generated with [Claude Code](https://claude.com/claude-code)