### PR TITLE
Micro-optimize main-thread blocking functions (cherry-pick from #435)

### DIFF
--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -1497,7 +1497,11 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
     static batchPatches := Map()
     batchPatches.Clear()
 
-    addedCount := 0
+    ; PERF: Collect new-window records for batched upsert (one Critical enter/exit
+    ; + one rev bump instead of N). Pattern matches _WEH_ProcessBatch line 691.
+    static newRecs := []
+    newRecs.Length := 0
+
     updatedCount := 0
     skippedIneligible := 0
     for hwnd, _data in wsMap {
@@ -1533,8 +1537,7 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
             rec["workspaceName"] := _wsn
             rec["isOnCurrentWorkspace"] := _isCur
 
-            try WL_UpsertWindow([rec])
-            addedCount++
+            newRecs.Push(rec)
         } else {
             ; Window exists - only patch if workspace data actually changed
             if (row.workspaceName != _wsn
@@ -1549,6 +1552,10 @@ _KSub_ProcessFullState(stateObj, skipWorkspaceUpdate := false, lightMode := fals
             }
         }
     }
+    ; Batch-upsert all new windows (one Critical + one rev bump instead of N)
+    addedCount := newRecs.Length
+    if (addedCount > 0)
+        try WL_UpsertWindow(newRecs, "komorebi_fullstate_add")
     if (logEnabled)
         KSub_DiagLog("ProcessFullState: added " addedCount " updated " updatedCount " skipped(ineligible) " skippedIneligible)
 

--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -773,7 +773,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
     if (diagTiming)
         t1 := QPC()
     if (count > rowsToDraw && rowsToDraw > 0) {
-        _GUI_DrawScrollbar(wPhys, contentTopY, rowsToDraw, RowH, scrollTop, count, cachedLayout)
+        _GUI_DrawScrollbar(wPhys, contentTopY, rowsToDraw, RowH, start0, count, cachedLayout)
     }
     if (diagTiming)
         tPO_Scrollbar := QPC() - t1
@@ -898,7 +898,9 @@ _GUI_DrawActionButtons(wPhys, yRow, rowHPhys, scale, Mx) {
 
 ; ========================= SCROLLBAR =========================
 
-_GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, scrollTop, count, cachedLayout) {
+; PERF: start0 passed from caller (already computed in _GUI_PaintOverlay) to avoid
+; redundant Win_Wrap0 call
+_GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, start0, count, cachedLayout) {
     global cfg, gD2D_BrushGeneration
     Profiler.Enter("_GUI_DrawScrollbar") ; @profile
     if (!cfg.GUI_ScrollBarEnabled || count <= 0 || rowsDrawn <= 0 || rowHPhys <= 0) {
@@ -926,7 +928,6 @@ _GUI_DrawScrollbar(wPhys, contentTopY, rowsDrawn, rowHPhys, scrollTop, count, ca
         thumbH := 3
     }
 
-    start0 := Win_Wrap0(scrollTop, count)
     startRatio := start0 / count
     y1 := y + Floor(startRatio * trackH)
     y2 := y1 + thumbH

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -729,10 +729,12 @@ _GUI_ShowOverlayWithFrozen() {
     diagTiming := cfg.DiagPaintTimingLog  ; PERF: cache config read (5+ uses)
 
     ; ===== TIMING: Show sequence start =====
-    tShow_Start := QPC()
-    idleDuration := (gPaint_LastPaintTick > 0) ? (A_TickCount - gPaint_LastPaintTick) : -1
-    if (diagTiming)
+    ; PERF: Guard QPC calls behind diagTiming — 6 DllCalls (~600ns) saved when diagnostics disabled
+    if (diagTiming) {
+        tShow_Start := QPC()
+        idleDuration := (gPaint_LastPaintTick > 0) ? (A_TickCount - gPaint_LastPaintTick) : -1
         Paint_Log("ShowOverlay START (idle=" (idleDuration > 0 ? Round(idleDuration/1000, 1) "s" : "first") " frozen=" gGUI_DisplayItems.Length " items=" gGUI_LiveItems.Length ")")
+    }
 
     ; Set visible flag FIRST to prevent re-entrancy issues
     ; (Show/DwmFlush can pump messages, allowing hotkeys to fire mid-function)
@@ -768,12 +770,14 @@ _GUI_ShowOverlayWithFrozen() {
     Anim_PrepareShowFade(hasAnim)
 
     ; ===== TIMING: Resize =====
-    t1 := QPC()
+    if (diagTiming)
+        t1 := QPC()
     rowsDesired := GUI_ComputeRowsToShow(gGUI_DisplayItems.Length)
     GUI_ResizeToRows(rowsDesired, true)  ; skipFlush — we flush after paint
     global gGUI_LastRowsDesired
     gGUI_LastRowsDesired := rowsDesired  ; Sync so first paint skips unnecessary pre-render
-    tShow_Resize := QPC() - t1
+    if (diagTiming)
+        tShow_Resize := QPC() - t1
 
     ; ===== Show window BEFORE painting =====
     ; With SwapChain + DComp, Present() works for hidden windows (commits to the
@@ -841,9 +845,11 @@ _GUI_ShowOverlayWithFrozen() {
     ; By painting before starting the tween, the window stays invisible until
     ; content is rendered.
     ; ===== TIMING: Paint on visible window (Present works) =====
-    t1 := QPC()
+    if (diagTiming)
+        t1 := QPC()
     GUI_Repaint()
-    tShow_Repaint := QPC() - t1
+    if (diagTiming)
+        tShow_Repaint := QPC() - t1
 
     ; NOW start the show-fade tween — first paint is done, content is rendered.
     ; Animation timer can safely call GUI_Repaint from here on.
@@ -877,9 +883,10 @@ _GUI_ShowOverlayWithFrozen() {
     GUI_StartHoverPolling()
 
     ; ===== TIMING: Log show sequence =====
-    tShow_Total := QPC() - tShow_Start
-    if (diagTiming)
+    if (diagTiming) {
+        tShow_Total := QPC() - tShow_Start
         Paint_Log("ShowOverlay END: total=" Round(tShow_Total, 2) "ms | resize=" Round(tShow_Resize, 2) " repaint=" Round(tShow_Repaint, 2))
+    }
     Profiler.Leave() ; @profile
 }
 

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -1477,6 +1477,7 @@ WL_GetDisplayList(opts := 0) {
 
     ; Build filtered subset Map for O(1) membership checks
     itemsMap := Map()
+    itemsMap.Capacity := items.Length  ; PERF: pre-size to avoid rehash during population
     for _, rec in items
         itemsMap[rec.hwnd] := rec
 


### PR DESCRIPTION
## Summary
- Cherry-picks 4 of 5 optimizations from #435, dropping shadow-inlining that conflicted with #433's helper approach
- Batched komorebi upsert: N Critical sections → 1 per full-state process
- QPC diagnostic guards: 6 DllCalls saved per show when diagnostics disabled
- Scrollbar start0 passthrough: eliminates redundant Win_Wrap0 call
- Map pre-size: avoids rehash during display list population

## Test plan
- [x] Full test suite (1016/1016 pass)

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)