### PR TITLE
Remove dead work from paint hot path and window upsert

### DIFF
--- a/src/gui/gui_paint.ahk
+++ b/src/gui/gui_paint.ahk
@@ -586,9 +586,9 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
         if (diagTiming) {
             tPO_RowsStart := QPC()
             tPO_IconsTotal := 0
+            iconCacheHits := 0
+            iconCacheMisses := 0
         }
-        iconCacheHits := 0
-        iconCacheMisses := 0
 
         start0 := Win_Wrap0(scrollTop, count)
         i := 0
@@ -727,7 +727,7 @@ _GUI_PaintOverlay(items, selIndex, wPhys, hPhys, scale, diagTiming := false) {
             ; destruction.  Try the bitmap cache regardless so frozen display items
             ; keep their last-known icon.
             iconDrawn := D2D_DrawCachedIcon(curHwnd, curIcon, ix, iy, ISize, &iconWasCacheHit)
-            if (iconDrawn) {
+            if (iconDrawn && diagTiming) {
                 if (iconWasCacheHit)
                     iconCacheHits += 1
                 else

--- a/src/gui/gui_state.ahk
+++ b/src/gui/gui_state.ahk
@@ -899,12 +899,11 @@ _GUI_MoveSelectionFrozen(delta) {
     global gGUI_Sel, gGUI_DisplayItems, gGUI_ScrollTop, cfg
     global gFX_GPUReady
 
-    if (gGUI_DisplayItems.Length = 0) {
+    count := gGUI_DisplayItems.Length
+    if (count = 0) {
         Profiler.Leave() ; @profile
         return
     }
-
-    count := gGUI_DisplayItems.Length
     prevSel := gGUI_Sel  ; Capture BEFORE changing selection (for animation)
 
     newSel := gGUI_Sel + delta

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -333,7 +333,7 @@ WL_UpsertWindow(records, source := "") {
                     ; Only update if value differs
                     if (!row.HasOwnProp(k) || row.%k% != v) {
                         ; Diagnostic: track which fields trigger changes (skip for new records)
-                        if (!isNew && diagChurn)
+                        if (diagChurn)
                             gWS_DiagChurn[k] := gWS_DiagChurn.Get(k, 0) + 1
                         row.%k% := v
                         rowChanged := true


### PR DESCRIPTION
## Summary

- Guard `iconCacheHits`/`iconCacheMisses` init and per-row increments behind `diagTiming` — these ran every row of every frame but were only read in diagnostic mode
- Remove always-true `!isNew` condition in `WL_UpsertWindow` else branch (dead code)
- Hoist `.Length` read in `_GUI_MoveSelectionFrozen` to avoid redundant property access

Closes #454

## Test plan

- [x] Full test suite passes (1014/1014 — static analysis, unit, GUI, live, flight recorder)
- [ ] Verify overlay renders correctly with `DiagPaintTimingLog` enabled (icon counters still reported)
- [ ] Verify overlay renders correctly with diagnostics disabled (normal path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)