### PR TITLE
Hoist EnsureRunning out of per-row loop + dead code cleanup

### DIFF
--- a/src/core/komorebi_sub.ahk
+++ b/src/core/komorebi_sub.ahk
@@ -1083,7 +1083,6 @@ _KSub_OnNotification(jsonLine) {
         }
         if (wsName != "") {
             Critical "On"
-            global _KSub_LastWorkspaceName
             ; Capture old workspace BEFORE updating (needed for move events)
             previousWsName := _KSub_LastWorkspaceName
             ; Track whether to fire WL_SetCurrentWorkspace after Critical release

--- a/src/gui/gui_effects.ahk
+++ b/src/gui/gui_effects.ahk
@@ -1314,16 +1314,16 @@ FX_DrawHoverEffect(wPhys, hPhys, selX, selY, selW, selH, rad) { ; lint-ignore: d
         if (_hovResizeMode = -1)
             _hovResizeMode := (cfg.GUI_HoverBGShaderAsSelectionSize = "Resize")
         if (_hovResizeMode) {
-            NumPut("float", Float(selX), "float", Float(selY),
-                   "float", Float(selX + selW), "float", Float(selY + selH), hov_dstRect)
+            NumPut("float", selX, "float", selY,
+                   "float", selX + selW, "float", selY + selH, hov_dstRect)
             NumPut("float", 0.0, "float", 0.0,
-                   "float", Float(selW), "float", Float(selH), hov_srcRect)
+                   "float", selW, "float", selH, hov_srcRect)
             hovBmpWrap.ptr := pBitmap
             gD2D_RT.DrawBitmap(hovBmpWrap, hov_dstRect, 1.0, 1, hov_srcRect)
         } else {
-            NumPut("float", Float(selX), "float", Float(selY),
-                   "float", Float(selX + selW), "float", Float(selY + selH), hov_srcRect)
-            NumPut("float", Float(selX), "float", Float(selY), hov_tgtPt)
+            NumPut("float", selX, "float", selY,
+                   "float", selX + selW, "float", selY + selH, hov_srcRect)
+            NumPut("float", selX, "float", selY, hov_tgtPt)
             gD2D_RT.DrawImage(pBitmap, hov_tgtPt, hov_srcRect)
         }
         if (clipped)

--- a/src/gui/gui_pump.ahk
+++ b/src/gui/gui_pump.ahk
@@ -307,7 +307,8 @@ _GUIPump_CollectTick() {
 
         ; Flag hwnds that have no icon — pump must skip nochange cache for these
         ; (stale cache from removed-then-readded HWND would return "unchanged")
-        needsIcon := []
+        static needsIcon := [] ; lint-ignore: static-in-timer
+        needsIcon.Length := 0
         for _, h in hwnds {
             row := WL_GetByHwnd(h)
             if (row && !row.iconHicon)

--- a/src/shared/window_list.ahk
+++ b/src/shared/window_list.ahk
@@ -194,7 +194,7 @@ WL_EndScan(graceMs := "") {
             continue  ; May have been removed by another producer
         if (rec.lastSeenScanId != gWS_ScanId) {
             ; Komorebi-managed windows are "present" even if winenum doesn't see them
-            if (rec.HasOwnProp("workspaceName") && rec.workspaceName != "") {
+            if (rec.workspaceName != "") {
                 komorebiKeep.Push(hwnd)
                 continue
             }
@@ -389,6 +389,11 @@ WL_UpsertWindow(records, source := "") {
     ; Enqueue for enrichment OUTSIDE Critical (queue operations have their own Critical)
     for _, row in rowsToEnqueue
         _WS_EnqueueIfNeeded(row)
+
+    ; PERF: Hoisted from _WS_EnqueueIfNeeded — call once per batch instead of per-row.
+    ; These are idempotent flag checks; calling once after the loop is sufficient.
+    try MRU_Lite_EnsureRunning()
+    try KomorebiLite_EnsureRunning()
 
     Profiler.Leave() ; @profile
     return { added: added, updated: updated, rev: gWS_Rev }
@@ -1001,8 +1006,6 @@ _WS_EnqueueIfNeeded(row) {
         if (!wakeIcon)
             try GUIPump_EnsureRunning()
     }
-    try MRU_Lite_EnsureRunning()
-    try KomorebiLite_EnsureRunning()
 }
 
 ; Enqueue hwnd for icon enrichment without row-level checks.


### PR DESCRIPTION
## Summary

- Hoist `MRU_Lite_EnsureRunning()` + `KomorebiLite_EnsureRunning()` from `_WS_EnqueueIfNeeded` (per-row) to `WL_UpsertWindow` (once after loop) — saves ~120-180μs per 30-window batch
- Remove 6 redundant `Float()` wrappers in `FX_DrawHoverEffect` (`NumPut("float")` already coerces)
- Remove dead `HasOwnProp("workspaceName")` guard in `WL_EndScan` (field always exists)
- Remove duplicate `global _KSub_LastWorkspaceName` in `_KSub_OnNotification`
- Make `needsIcon` static in `_GUIPump_CollectTick` to match adjacent `pidSet`/`hwndSet` pattern

Closes #458

## Test plan

- [x] Pre-gate static analysis passes (86 checks)
- [x] All 1039 tests pass (unit, GUI, live, flight recorder)
- [x] Verified `_WS_EnqueueIfNeeded` has no other production callers
- [x] Verified `_WS_NewRecord` always creates `workspaceName: ""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)